### PR TITLE
Magic skill mng fix

### DIFF
--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -223,6 +223,11 @@ bool CMagicSkillMng::CheckValidSkillMagic(__TABLE_UPC_SKILL* pSkill)
 
 		case 0: //dwNeedItem = 0 , all priest & warrior skills
 		{
+			//break if Bright Dew, Sleep Carpet, Sleep Wing (mage, priest) skills
+			if (pSkill->dw1stTableType == 0 || pSkill->dw1stTableType == 7)
+			{
+				break;
+			}
 
 			if (bNotEquipedItem || bHasDagger || bHasStaff || bHasBow)
 			{
@@ -710,8 +715,14 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 	switch (pSkill->dwNeedItem)
 	{
 
-		case 0: //dwNeedItem = 0 , all priest & warrior skills
+		case 0: //dwNeedItem = 0 , all priest & warrior attack skills
 		{
+
+			//break if Bright Dew, Sleep Carpet, Sleep Wing (mage, priest) skills
+			if (pSkill->dw1stTableType == 0 || pSkill->dw1stTableType == 7)
+			{
+				break;
+			}
 
 			if (bNotEquipedItem || bHasDagger || bHasStaff || bHasBow)
 			{

--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -726,6 +726,9 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 
 			if (bNotEquipedItem || bHasDagger || bHasStaff || bHasBow)
 			{
+				std::string buff;
+				GetText(IDS_SKILL_FAIL_INVALID_ITEM, &buff);
+				m_pGameProcMain->MsgOutput(buff, 0xffffff00);
 				return false;
 			}
 
@@ -733,6 +736,9 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 				!bHasMace && !bHas2HMace &&
 				!bHasSpear && !bHasPolearm )
 			{
+				std::string buff;
+				GetText(IDS_SKILL_FAIL_LACK_ITEM, &buff);
+				m_pGameProcMain->MsgOutput(buff, 0xffffff00);
 				return false;
 			}
 
@@ -744,11 +750,17 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 			if (bNotEquipedItem || bHasSword || bHas2HSword || bHasAxe || bHas2HAxe ||
 				bHasMace || bHas2HMace || bHasSpear || bHasPolearm || bHasBow || bHasStaff)
 			{
+				std::string buff;
+				GetText(IDS_SKILL_FAIL_INVALID_ITEM, &buff);
+				m_pGameProcMain->MsgOutput(buff, 0xffffff00);
 				return false;
 			}
 
 			if (!bHasDagger)
 			{
+				std::string buff;
+				GetText(IDS_SKILL_FAIL_LACK_ITEM, &buff);
+				m_pGameProcMain->MsgOutput(buff, 0xffffff00);
 				return false;
 			}
 
@@ -760,11 +772,17 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 			if (bNotEquipedItem || bHasSword || bHas2HSword || bHasAxe || bHas2HAxe ||
 				bHasMace || bHas2HMace || bHasSpear || bHasPolearm || bHasDagger || bHasStaff)
 			{
+				std::string buff;
+				GetText(IDS_SKILL_FAIL_INVALID_ITEM, &buff);
+				m_pGameProcMain->MsgOutput(buff, 0xffffff00);
 				return false;
 			}
 
 			if (!bHasBow)
 			{
+				std::string buff;
+				GetText(IDS_SKILL_FAIL_LACK_ITEM, &buff);
+				m_pGameProcMain->MsgOutput(buff, 0xffffff00);
 				return false;
 			}
 
@@ -780,11 +798,17 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 			if (bNotEquipedItem || bHasSword || bHas2HSword || bHasAxe || bHas2HAxe ||
 				bHasMace || bHas2HMace || bHasSpear || bHasPolearm || bHasDagger || bHasBow)
 			{
+				std::string buff;
+				GetText(IDS_SKILL_FAIL_INVALID_ITEM, &buff);
+				m_pGameProcMain->MsgOutput(buff, 0xffffff00);
 				return false;
 			}
 
 			if (!bHasStaff)
 			{
+				std::string buff;
+				GetText(IDS_SKILL_FAIL_LACK_ITEM, &buff);
+				m_pGameProcMain->MsgOutput(buff, 0xffffff00);
 				return false;
 			}
 			
@@ -799,6 +823,9 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 
 			if (iNum <= 0)
 			{
+				std::string buff;
+				GetText(IDS_SKILL_FAIL_LACK_ITEM, &buff);
+				m_pGameProcMain->MsgOutput(buff, 0xffffff00);
 				return false;
 			}
 

--- a/Server/GameServer/MagicInstance.cpp
+++ b/Server/GameServer/MagicInstance.cpp
@@ -380,6 +380,98 @@ SkillUseResult MagicInstance::CheckSkillPrerequisites()
 					pCaster->m_CoolDownList.erase(nSkillID);
 			}
 
+			_ITEM_TABLE* pLeftHand = TO_USER(pSkillCaster)->GetItemPrototype(LEFTHAND);
+			_ITEM_TABLE* pRightHand = TO_USER(pSkillCaster)->GetItemPrototype(RIGHTHAND);
+			
+
+			bool bNotEquipedItem = (pLeftHand == nullptr && pRightHand == nullptr);
+			bool bHasSword	= ((pLeftHand && pLeftHand->isSword()) || (pRightHand && pRightHand->isSword()));
+			bool bHas2HSword = ((pLeftHand && pLeftHand->is2HSword()) || (pRightHand && pRightHand->is2HSword()));
+			bool bHasAxe = ((pLeftHand && pLeftHand->isAxe()) || (pRightHand && pRightHand->isAxe()));
+			bool bHas2HAxe = ((pLeftHand && pLeftHand->is2HAxe()) || (pRightHand && pRightHand->is2HAxe()));
+			bool bHasMace = ((pLeftHand && pLeftHand->isMace()) || (pRightHand && pRightHand->isMace()));
+			bool bHas2HMace = ((pLeftHand && pLeftHand->is2HMace()) || (pRightHand && pRightHand->is2HMace()));
+			bool bHasSpear = ((pLeftHand && pLeftHand->isSpear()) || (pRightHand && pRightHand->isSpear()));
+			bool bHasPolearm = ((pLeftHand && pLeftHand->is2HSpear()) || (pRightHand && pRightHand->is2HSpear()));
+			bool bHasBow = ((pLeftHand && pLeftHand->isBow()) || (pRightHand && pRightHand->isBow()));
+			bool bHasStaff = ((pLeftHand && pLeftHand->isStaff()) || (pRightHand && pRightHand->isStaff()));
+			bool bHasDagger = ((pLeftHand && pLeftHand->isDagger()) || (pRightHand && pRightHand->isDagger()));
+			bool bHasPickAxe = ((pLeftHand && pLeftHand->isPickaxe()) || (pRightHand && pRightHand->isPickaxe()));
+
+			//implementation of pSkill->dwNeedItem
+			switch (pSkill->bItemGroup)
+			{
+				case 0: // all priest & warrior skills
+
+					if (bNotEquipedItem || bHasDagger || bHasStaff || bHasBow)
+					{
+						return SkillUseFail;
+					}
+
+					if (!bHasSword && !bHas2HSword && !bHasAxe && !bHas2HAxe &&
+						!bHasMace && !bHas2HMace &&
+						!bHasSpear && !bHasPolearm)
+					{
+						return SkillUseFail;
+					}
+
+					break;
+				case 1:	//dwNeedItem = 1 , only daggers
+					
+					if (bNotEquipedItem || bHasSword || bHas2HSword || bHasAxe || bHas2HAxe ||
+						bHasMace || bHas2HMace || bHasSpear || bHasPolearm || bHasBow || bHasStaff)
+					{
+						return SkillUseFail;
+					}
+
+					if (!bHasDagger)
+					{
+						return SkillUseFail;
+					}
+
+					break;
+				case 7: //dwNeedItem = 7 , only Bows - archery
+					
+					if (bNotEquipedItem || bHasSword || bHas2HSword || bHasAxe || bHas2HAxe ||
+						bHasMace || bHas2HMace || bHasSpear || bHasPolearm || bHasDagger || bHasStaff)
+					{
+						return SkillUseFail;
+					}
+
+					if (!bHasBow)
+					{
+						return SkillUseFail;
+					}
+
+					break;
+				case 9:
+					break;
+				case 11: //dwNeedItem = 11, only staves , mage 42 - 72 staff skills
+					
+					if (bNotEquipedItem || bHasSword || bHas2HSword || bHasAxe || bHas2HAxe ||
+						bHasMace || bHas2HMace || bHasSpear || bHasPolearm || bHasDagger || bHasBow)
+					{
+						return SkillUseFail;
+					}
+
+					if (!bHasStaff)
+					{
+						return SkillUseFail;
+					}
+
+					break;
+				default:
+					//other skills that requires items in inventory
+					//like guardian items, transformation totem, catapult
+					if (!pCaster->CheckExistItem(pSkill->bItemGroup))
+						return SkillUseFail;
+					break;
+
+			}
+			
+			/* can safely be removed 
+			* 370007000 --- not indatabase
+			* all archery skills processed on top already
 			if (pCaster->isRogue() && pSkill->bType[0] == 2 && pSkill -> iUseItem != 370007000)
 			{
 				_ITEM_TABLE * pLeftHand  = TO_USER(pSkillCaster)->GetItemPrototype(LEFTHAND);
@@ -393,7 +485,7 @@ SkillUseResult MagicInstance::CheckSkillPrerequisites()
 				if (bOpcode == MAGIC_EFFECTING)
 					return SkillUseOK;						
 			}
-
+			*/
 			// Same time skill checks...
 			MagicTypeCooldownList::iterator itr;
 			if ((pSkill->bType[0] == 1 

--- a/Server/GameServer/MagicInstance.cpp
+++ b/Server/GameServer/MagicInstance.cpp
@@ -401,7 +401,13 @@ SkillUseResult MagicInstance::CheckSkillPrerequisites()
 			//implementation of pSkill->dwNeedItem
 			switch (pSkill->bItemGroup)
 			{
-				case 0: // all priest & warrior skills
+				case 0: // all priest & warrior skills, (mage bright dew + priest sleep)
+
+					//mage master passive + priest sleep don't require any conditions
+					if (pSkill->bType[0] == 0 || pSkill->bType[0] == 7)
+					{
+						break;
+					}
 
 					if (bNotEquipedItem || bHasDagger || bHasStaff || bHasBow)
 					{


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
At current state, warriors cannot cast skills with 2h weapons
Priests can cast attack skills with daggers & staff
Rogues can cast attack skills with 1hswords / staves / 1haxes ...
Warriors can cast skills with daggers & staff ( basic ones)
Mage can cast staff skills 42/72 with any weapons
Skills requiring items ( like using transformation gems which requires totems ) handled wrong

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Now priest can cast attack skills with all kind of weapons except for staff & daggers,
Priest can use buff skills with any weapon
Warriors can cast attack skills with all kind of weapons except for staff & daggers
Rogue ( assasin ) is limited to using daggers, they cannot use swords or axes to cast skills
Rogue ( archer ) cannot use any other weapon than bows for attack skills
Mage cannot cast staff skills with any weapon, only staffs.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
dwNeedItem logic was wrong, it was just considering warrior skills ( 1055 & 1056 ). Also it was making impossible to use some
items like transformation gems, catapult etc.

dwNeedItem logic for casting skill used properly in switch block to have sustainable code for future additions ( like catapult items, transformation totem etc. ) 
## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] For client changes, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
