### PR TITLE
inventory is full message of exchange items

### DIFF
--- a/Server/GameServer/ItemHandler.cpp
+++ b/Server/GameServer/ItemHandler.cpp
@@ -770,9 +770,16 @@ bool CUser::RunExchange(int nExchangeID, uint32_t count)
 		|| isMerchanting())
 		return false;
 
+	// no empty space in inventory
+	if (!CheckExchange(nExchangeID)) 
+	{
+		Packet result(WIZ_ITEM_GET);
+		result << uint8_t(0); //error code : loot no room = 0
+		Send(&result);
+		return false;
+	}
+
 	if (pExchange == nullptr
-		// Is it a valid exchange (do we have room?)
-			|| !CheckExchange(nExchangeID)
 			// We handle flags from 0-101 only. Anything else is broken.
 			|| pExchange->bRandomFlag > 101)
 			return false;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Currently, user is not warned when tries to exchange abbys gems and chests while the inventory is full.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
User now warned with message when he/she tries to exchange item while having no space.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
Because this is original behavior and it improves user experience. Packet which we already have is used. Does not involve new logic or feature. Related packet name is WIZ_ITEM_GET.

This PR can solve issue #192 

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] For client changes, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
