### PR TITLE
Hotkeys now display cooldown timer over them when used.

### DIFF
--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -1307,14 +1307,14 @@ void CMagicSkillMng::SetSkillCooldown(__TABLE_UPC_SKILL* pSkill)
 	// Convert iReCastTime (stored in tenths of seconds) to seconds
 	const float fCooldown = static_cast<float>(pSkill->iReCastTime) / 10.0f;
 
-	//if (pSkill->iSelfAnimID1 > 0)
-	//{
+	if (pSkill->iSelfAnimID1 > 0)
+	{
 		m_RecastTimes[pSkill->dwID] = fCooldown;
-	//}
-	//else
-	//{
-	//	m_NonActionRecastTimes[pSkill->dwID] = fCooldown;
-	//}
+	}
+	else
+	{
+		m_NonActionRecastTimes[pSkill->dwID] = fCooldown;
+	}
 }
 
 bool CMagicSkillMng::CheckValidDistance(__TABLE_UPC_SKILL* pSkill, __Vector3 vTargetPos, float fTargetRadius)
@@ -1644,28 +1644,7 @@ void CMagicSkillMng::Tick()
 		}
 #endif
 		it->second -= CN3Base::s_fSecPerFrm;
-		int k;
-		for (k = 0; k < MAX_SKILL_HOTKEY_PAGE; ++k)
-		{
-			int j;
-			for (j = 0; j < MAX_SKILL_IN_HOTKEY; ++j)
-			{
-				__IconItemSkill* icon = m_pGameProcMain->m_pUIHotKeyDlg->m_pMyHotkey[k][j];
-				if (!icon) continue;
-
-				if (icon->pSkill->dwID == it->first)
-				{
-					if (icon->fCurrentCooldDown < icon->pSkill->iReCastTime)
-						icon->fCurrentCooldDown += CN3Base::s_fSecPerFrm;
-
-					if (it->second < 0)
-					{
-						icon->fCurrentCooldDown = 0.0f;
-					}
-				}
-			}			
-		}
-
+		
 		if (it->second < 0)
 		{
 			it = m_RecastTimes.erase(it);			
@@ -1673,7 +1652,7 @@ void CMagicSkillMng::Tick()
 		else
 			++it;
 	}
-	/*for (auto it = m_NonActionRecastTimes.begin(); it != m_NonActionRecastTimes.end(); )
+	for (auto it = m_NonActionRecastTimes.begin(); it != m_NonActionRecastTimes.end(); )
 	{
 #ifdef _DEBUG
 		if (m_fMsgUpdateTimer >= 0.2f)
@@ -1686,10 +1665,10 @@ void CMagicSkillMng::Tick()
 #endif
 		it->second -= CN3Base::s_fSecPerFrm;
 		if (it->second < 0)
-			it = m_RecastTimes.erase(it);
+			it = m_NonActionRecastTimes.erase(it);
 		else
 			++it;
-	}*/
+	}
 	// Legacy Existing code for delay and casting
 	m_fDelay -= CN3Base::s_fSecPerFrm;
 	if (m_fDelay < 0.0f) m_fDelay = 0.0f;
@@ -3074,5 +3053,24 @@ void CMagicSkillMng::StunMySelf(__TABLE_UPC_SKILL_TYPE_3* pType3)
 	{
 		m_pGameProcMain->CommandSitDown(false, false); // 일으켜 세운다.
 		s_pPlayer->Stun(STUN_TIME);
+	}
+}
+
+
+float CMagicSkillMng::GetSkillCooldown(__TABLE_UPC_SKILL* pSkill)
+{
+	if (pSkill->iSelfAnimID1 > 0)
+	{
+		auto it = m_RecastTimes.find(pSkill->dwID);
+		if (it == m_RecastTimes.end())
+			return -1;
+		return it->second;
+	}
+	else
+	{
+		auto it = m_NonActionRecastTimes.find(pSkill->dwID);
+		if (it == m_NonActionRecastTimes.end())
+			return -1;
+		return it->second;
 	}
 }

--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -1632,6 +1632,7 @@ void CMagicSkillMng::Tick()
 #ifdef _DEBUG
 	m_fMsgUpdateTimer += CN3Base::s_fSecPerFrm;
 #endif
+
 	for (auto it = m_RecastTimes.begin(); it != m_RecastTimes.end(); )
 	{
 #ifdef _DEBUG
@@ -1644,14 +1645,13 @@ void CMagicSkillMng::Tick()
 		}
 #endif
 		it->second -= CN3Base::s_fSecPerFrm;
-		
+
 		if (it->second < 0)
-		{
-			it = m_RecastTimes.erase(it);			
-		}
+			it = m_RecastTimes.erase(it);
 		else
 			++it;
 	}
+
 	for (auto it = m_NonActionRecastTimes.begin(); it != m_NonActionRecastTimes.end(); )
 	{
 #ifdef _DEBUG
@@ -1663,12 +1663,14 @@ void CMagicSkillMng::Tick()
 			m_fMsgUpdateTimer = 0.0f;
 		}
 #endif
+
 		it->second -= CN3Base::s_fSecPerFrm;
 		if (it->second < 0)
 			it = m_NonActionRecastTimes.erase(it);
 		else
 			++it;
 	}
+
 	// Legacy Existing code for delay and casting
 	m_fDelay -= CN3Base::s_fSecPerFrm;
 	if (m_fDelay < 0.0f) m_fDelay = 0.0f;
@@ -3056,14 +3058,14 @@ void CMagicSkillMng::StunMySelf(__TABLE_UPC_SKILL_TYPE_3* pType3)
 	}
 }
 
-
-float CMagicSkillMng::GetSkillCooldown(__TABLE_UPC_SKILL* pSkill)
+float CMagicSkillMng::GetCooldown(const __TABLE_UPC_SKILL* pSkill) const
 {
 	if (pSkill->iSelfAnimID1 > 0)
 	{
 		auto it = m_RecastTimes.find(pSkill->dwID);
 		if (it == m_RecastTimes.end())
 			return -1;
+
 		return it->second;
 	}
 	else
@@ -3071,6 +3073,7 @@ float CMagicSkillMng::GetSkillCooldown(__TABLE_UPC_SKILL* pSkill)
 		auto it = m_NonActionRecastTimes.find(pSkill->dwID);
 		if (it == m_NonActionRecastTimes.end())
 			return -1;
+
 		return it->second;
 	}
 }

--- a/Client/WarFare/MagicSkillMng.h
+++ b/Client/WarFare/MagicSkillMng.h
@@ -132,6 +132,7 @@ public:
 	void	Tick();
 	void	UpdateZonePointerPositions();
 	void	CancelZonePointer();
+	float   GetSkillCooldown(__TABLE_UPC_SKILL* pSkill);
 
 	CMagicSkillMng();
 	CMagicSkillMng(CGameProcMain* pGameProcMain);

--- a/Client/WarFare/MagicSkillMng.h
+++ b/Client/WarFare/MagicSkillMng.h
@@ -132,7 +132,7 @@ public:
 	void	Tick();
 	void	UpdateZonePointerPositions();
 	void	CancelZonePointer();
-	float   GetSkillCooldown(__TABLE_UPC_SKILL* pSkill);
+	float   GetCooldown(const __TABLE_UPC_SKILL* pSkill) const;
 
 	CMagicSkillMng();
 	CMagicSkillMng(CGameProcMain* pGameProcMain);

--- a/Client/WarFare/N3UIWndBase.h
+++ b/Client/WarFare/N3UIWndBase.h
@@ -73,6 +73,7 @@ struct	__IconItemSkill		{
 //								e_UIIconType			eIconType;
 								CN3UIIcon*				pUIIcon;
 								std::string				szIconFN;
+								float					fCurrentCooldDown;
 
 								union {
 									struct {

--- a/Client/WarFare/N3UIWndBase.h
+++ b/Client/WarFare/N3UIWndBase.h
@@ -73,7 +73,6 @@ struct	__IconItemSkill		{
 //								e_UIIconType			eIconType;
 								CN3UIIcon*				pUIIcon;
 								std::string				szIconFN;
-								float					fCurrentCooldDown;
 
 								union {
 									struct {

--- a/Client/WarFare/UIHotKeyDlg.cpp
+++ b/Client/WarFare/UIHotKeyDlg.cpp
@@ -326,14 +326,23 @@ void CUIHotKeyDlg::Render()
 	{
 		if (m_pMyHotkey[m_iCurPage][k] != NULL)
 		{
-			if (m_pMyHotkey[m_iCurPage][k]->fCurrentCooldDown > 0 && m_pMyHotkey[m_iCurPage][k]->fCurrentCooldDown < m_pMyHotkey[m_iCurPage][k]->pSkill->iReCastTime)
-				RenderCooldown(m_pMyHotkey[m_iCurPage][k]);
-			else
+			float skillCd = CGameProcedure::s_pProcMain->m_pMagicSkillMng->GetSkillCooldown(m_pMyHotkey[m_iCurPage][k]->pSkill);
+			
+			//not on cd
+			if (skillCd == -1)
 			{
 				CN3UIIcon* pUIIcon = m_pMyHotkey[m_iCurPage][k]->pUIIcon;
 				if (pUIIcon)
 					pUIIcon->Render();
 			}
+			else
+			{
+				RenderCooldown(m_pMyHotkey[m_iCurPage][k], skillCd);
+			}
+
+			//	CN3UIIcon* pUIIcon = m_pMyHotkey[m_iCurPage][k]->pUIIcon;
+			//	if (pUIIcon)
+			//		pUIIcon->Render();
 
 			DisplayCountStr(m_pMyHotkey[m_iCurPage][k]);
 		}
@@ -719,9 +728,7 @@ void CUIHotKeyDlg::DoOperate(__IconItemSkill*	pSkill)
 	//char szBuf[512];
 	// 메시지 박스 출력..	
 	//wsprintf(szBuf, "%s 스킬이 사용되었습니다.", pSkill->pSkill->szName.c_str() );
-	//CGameProcedure::s_pProcMain->MsgOutput(szBuf, 0xffffff00);
-
-	PlayRepairSound();					
+	//CGameProcedure::s_pProcMain->MsgOutput(szBuf, 0xffffff00);			
 	
 	int iIDTarget = CGameBase::s_pPlayer->m_iIDTarget;
 	CGameProcedure::s_pProcMain->m_pMagicSkillMng->MsgSend_MagicProcess(iIDTarget, pSkill->pSkill);
@@ -999,7 +1006,7 @@ T clamp(T value, T min, T max)
 	return (value < min) ? min : (value > max) ? max : value;
 }
 
-void CUIHotKeyDlg::RenderCooldown(__IconItemSkill * pSkill)
+void CUIHotKeyDlg::RenderCooldown(__IconItemSkill * pSkill, float fSkillCdTime)
 {
 	if (!pSkill)
 		return;
@@ -1011,7 +1018,7 @@ void CUIHotKeyDlg::RenderCooldown(__IconItemSkill * pSkill)
 	float centerX = (rc.left + rc.right) / 2;
 	float radius = std::sqrt(std::pow(centerX - rc.left, 2) + std::pow(centerY - rc.top, 2));
 
-	float progress = 1.0f - (pSkill->fCurrentCooldDown / (static_cast<float>(pSkill->pSkill->iReCastTime) / 10.0f));
+	float progress = (fSkillCdTime / (static_cast<float>(pSkill->pSkill->iReCastTime) / 10.0f));
 
 	progress = clamp(progress, 0.0f, 1.0f);
 

--- a/Client/WarFare/UIHotKeyDlg.h
+++ b/Client/WarFare/UIHotKeyDlg.h
@@ -85,7 +85,7 @@ public:
 	void				UpdateDisableCheck();
 
 	bool				ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur);
-	void				RenderCooldown(__IconItemSkill* pSkill, float fSkillCdTime);
+	void				RenderCooldown(const __IconItemSkill* pSkill, float fCooldown);
 };
 
 #endif // !defined(AFX_UIHOTKEYDLG_H__9B85201C_0294_4023_8658_923A6A2174BF__INCLUDED_)

--- a/Client/WarFare/UIHotKeyDlg.h
+++ b/Client/WarFare/UIHotKeyDlg.h
@@ -85,6 +85,7 @@ public:
 	void				UpdateDisableCheck();
 
 	bool				ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur);
+	void				CUIHotKeyDlg::RenderCooldown(__IconItemSkill* pSkill);
 };
 
 #endif // !defined(AFX_UIHOTKEYDLG_H__9B85201C_0294_4023_8658_923A6A2174BF__INCLUDED_)

--- a/Client/WarFare/UIHotKeyDlg.h
+++ b/Client/WarFare/UIHotKeyDlg.h
@@ -85,7 +85,7 @@ public:
 	void				UpdateDisableCheck();
 
 	bool				ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur);
-	void				CUIHotKeyDlg::RenderCooldown(__IconItemSkill* pSkill);
+	void				RenderCooldown(__IconItemSkill* pSkill, float fSkillCdTime);
 };
 
 #endif // !defined(AFX_UIHOTKEYDLG_H__9B85201C_0294_4023_8658_923A6A2174BF__INCLUDED_)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
No cooldown visual displayed on top of skills/items in hotkey bar

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Cooldown now renders for skills/items

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
Fix for issue #43 
-Added rendering logic in UIHotKeyDlg.
- UIHotKeyDlg will check the cooldowns in MagicSkillManager maps and render the cd for the current skillbar. 


## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
