### PR TITLE
kasar hood ID written wrong, causes it not to be closed

### DIFF
--- a/Client/N3Base/N3UIBase.cpp
+++ b/Client/N3Base/N3UIBase.cpp
@@ -449,15 +449,16 @@ void CN3UIBase::PrintChildIDs(void) {
 
 CN3UIBase* CN3UIBase::GetChildByID(const std::string& szID)
 {
-	if(szID.empty()) return NULL;
+	if (szID.empty())
+		return nullptr;
 
-	for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
+	for (CN3UIBase* pChild : m_Children)
 	{
-		CN3UIBase* pChild = (*itor);
-//		if(pChild->m_szID == szID) return pChild;
-		if(lstrcmpi(pChild->m_szID.c_str(), szID.c_str()) == 0) return pChild; // 대소문자 안가리고 검색..
+		if (lstrcmpiA(szID.c_str(), pChild->m_szID.c_str()) == 0)
+			return pChild;
 	}
-	return NULL;
+
+	return nullptr;
 }
 
 void CN3UIBase::SetVisible(bool bVisible)

--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -1677,7 +1677,7 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 			AllClearImageByName("mage", false);
 			AllClearImageByName("cleric", false);
 			AllClearImageByName("Blade Master", false);
-			AllClearImageByName("Kasar Hood", false);
+			AllClearImageByName("kasar hood", false);
 			AllClearImageByName("Arc Mage", false);
 			AllClearImageByName("Paladin", false);
 
@@ -1696,6 +1696,7 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 					break;
 
 				case CLASS_EL_BLADE:
+					TRACE("worked\n");
 					AllClearImageByName("blade", true);
 					break;
 

--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -1687,7 +1687,7 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 			AllClearImageByName("mage", false);
 			AllClearImageByName("cleric", false);
 			AllClearImageByName("Blade Master", false);
-			AllClearImageByName("kasar hood", false);
+			AllClearImageByName("Kasar Hood", false);
 			AllClearImageByName("Arc Mage", false);
 			AllClearImageByName("Paladin", false);
 

--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -1598,12 +1598,12 @@ void CUISkillTreeDlg::AllClearImageByName(const std::string& szFN, bool bTrueOrN
 	for ( int i = 0; i < 4; i++ )
 	{
 		str = "img_";	str += szFN;	sprintf(cstr, "_%d", i);	str+= cstr;
-		pBase = GetChildBaseByName(str);
+		pBase = GetChildByID(str);
 		if (pBase) pBase->SetVisible(bTrueOrNot);	
 	}
 
 	str = "img_";	str += szFN;
-	pBase = GetChildBaseByName(str);
+	pBase = GetChildByID(str);
 	if (pBase) pBase->SetVisible(bTrueOrNot);
 
 	for (int i = 0; i < 4; i++ )
@@ -1743,40 +1743,28 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 	
 }
 
-CN3UIImage*	CUISkillTreeDlg::GetChildImageByName(const std::string& szFN)
+CN3UIImage*	CUISkillTreeDlg::GetChildImageByName(const std::string& szID)
 {
-	for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
+	for (CN3UIBase* pChild : m_Children)
 	{
-		CN3UIBase* pChild = (CN3UIBase* )(*itor);
-		if ( (pChild->UIType() == UI_TYPE_IMAGE) && (szFN.compare(pChild->m_szID) == 0) )
-			return (CN3UIImage*)pChild;
+		if (pChild->UIType() == UI_TYPE_IMAGE
+			&& lstrcmpiA(szID.c_str(), pChild->m_szID.c_str()) == 0)
+			return static_cast<CN3UIImage*>(pChild);
 	}
 
-	return NULL;
+	return nullptr;
 }
 
-CN3UIBase* CUISkillTreeDlg::GetChildBaseByName(const std::string &szFN)
+CN3UIButton* CUISkillTreeDlg::GetChildButtonByName(const std::string& szID)
 {
-	for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
+	for (CN3UIBase* pChild : m_Children)
 	{
-		CN3UIBase* pChild = (CN3UIBase*) (*itor);
-		if ( szFN.compare(pChild->m_szID) == 0 )
-			return pChild;
+		if (pChild->UIType() == UI_TYPE_BUTTON
+			&& lstrcmpiA(szID.c_str(), pChild->m_szID.c_str()) == 0)
+			return static_cast<CN3UIButton*>(pChild);
 	}
 
-	return NULL;
-}
-
-CN3UIButton* CUISkillTreeDlg::GetChildButtonByName(const std::string& szFN)
-{
-	for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
-	{
-		CN3UIBase* pChild = (CN3UIBase* )(*itor);
-		if ( (pChild->UIType() == UI_TYPE_BUTTON) && (szFN.compare(pChild->m_szID) == 0) )
-			return (CN3UIButton*)pChild;
-	}
-
-	return NULL;
+	return nullptr;
 }
 
 //this_ui_add_start

--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -24,6 +24,9 @@
 #include "N3UIString.h"
 #include "N3SndObj.h"
 
+#include <algorithm> // std::transform
+#include <cctype>    // std::tolower
+
 #ifdef _DEBUG
 #undef THIS_FILE
 static char THIS_FILE[]=__FILE__;
@@ -1275,13 +1278,13 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 	switch ( CGameBase::s_pPlayer->m_InfoBase.eClass )
 	{
 		case CLASS_KA_BERSERKER:
+		case CLASS_KA_GUARDIAN:
 			pButton = (CN3UIButton* )GetChildByID("btn_berserker0");	ASSET_1
 			pButton = (CN3UIButton* )GetChildByID("btn_berserker1");	ASSET_2
 			pButton = (CN3UIButton* )GetChildByID("btn_berserker2");	ASSET_3
 			//pButton = (CN3UIButton* )GetChildByID("btn_berserker3");	ASSET_4
 			break;
 
-		// TODO: will need to add the "mastered" class to these as well...
 		case CLASS_KA_PENETRATOR:
 		case CLASS_KA_HUNTER:
 			pButton = (CN3UIButton* )GetChildByID("btn_hunter0");		ASSET_1
@@ -1291,6 +1294,7 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 			break;
 
 		case CLASS_KA_SHAMAN:
+		case CLASS_KA_DARKPRIEST:
 			pButton = (CN3UIButton* )GetChildByID("btn_shaman0");		ASSET_1
 			pButton = (CN3UIButton* )GetChildByID("btn_shaman1");		ASSET_2
 			pButton = (CN3UIButton* )GetChildByID("btn_shaman2");		ASSET_3
@@ -1298,6 +1302,7 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 			break;
 
 		case CLASS_KA_SORCERER:
+		case CLASS_KA_NECROMANCER:
 			pButton = (CN3UIButton* )GetChildByID("btn_sorcerer0");		ASSET_1
 			pButton = (CN3UIButton* )GetChildByID("btn_sorcerer1");		ASSET_2
 			pButton = (CN3UIButton* )GetChildByID("btn_sorcerer2");		ASSET_3
@@ -1305,6 +1310,7 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 			break;
 
 		case CLASS_EL_BLADE:
+		case CLASS_EL_PROTECTOR:
 			pButton = (CN3UIButton* )GetChildByID("btn_blade0");	ASSET_1
 			pButton = (CN3UIButton* )GetChildByID("btn_blade1");	ASSET_2
 			pButton = (CN3UIButton* )GetChildByID("btn_blade2");	ASSET_3
@@ -1312,6 +1318,7 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 			break;
 
 		case CLASS_EL_RANGER:
+		case CLASS_EL_ASSASIN:
 			pButton = (CN3UIButton* )GetChildByID("btn_ranger0");	ASSET_1
 			pButton = (CN3UIButton* )GetChildByID("btn_ranger1");	ASSET_2
 			pButton = (CN3UIButton* )GetChildByID("btn_ranger2");	ASSET_3
@@ -1319,6 +1326,7 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 			break;
 
 		case CLASS_EL_CLERIC:
+		case CLASS_EL_DRUID:
 			pButton = (CN3UIButton* )GetChildByID("btn_cleric0");	ASSET_1
 			pButton = (CN3UIButton* )GetChildByID("btn_cleric1");	ASSET_2
 			pButton = (CN3UIButton* )GetChildByID("btn_cleric2");	ASSET_3
@@ -1326,6 +1334,7 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 			break;
 
 		case CLASS_EL_MAGE:
+		case CLASS_EL_ENCHANTER:
 			pButton = (CN3UIButton* )GetChildByID("btn_mage0");		ASSET_1
 			pButton = (CN3UIButton* )GetChildByID("btn_mage1");		ASSET_2
 			pButton = (CN3UIButton* )GetChildByID("btn_mage2");		ASSET_3
@@ -1621,10 +1630,10 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 			AllClearImageByName("berserker", false);
 			AllClearImageByName("sorcerer", false);
 			AllClearImageByName("shaman", false);
-			AllClearImageByName("Shadow Knight",false);
-			AllClearImageByName("Berserker Hero", false);
-			AllClearImageByName("Elemental Lord", false);
-			AllClearImageByName("Shadow Bane", false);
+			AllClearImageByName("shadow_knight",false);
+			AllClearImageByName("berserker_hero", false);
+			AllClearImageByName("elemental_lord", false);
+			AllClearImageByName("shadow_bane", false);
 			
 
 			// 직업.. 
@@ -1654,18 +1663,22 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 					break;
 
 				case CLASS_KA_GUARDIAN:
+					AllClearImageByName("berserker", true);
 					AllClearImageByName("Berserker Hero", true);
 					break;
 
 				case CLASS_KA_PENETRATOR:
+					AllClearImageByName("hunter", true);
 					AllClearImageByName("Shadow Bane", true);
 					break;
 
 				case CLASS_KA_NECROMANCER:
+					AllClearImageByName("sorcerer", true);
 					AllClearImageByName("Elemental Lord", true);
 					break;
 
 				case CLASS_KA_DARKPRIEST:
+					AllClearImageByName("shaman", true);
 					AllClearImageByName("Shadow Knight", true);
 					break;
 			}
@@ -1676,10 +1689,10 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 			AllClearImageByName("blade", false);
 			AllClearImageByName("mage", false);
 			AllClearImageByName("cleric", false);
-			AllClearImageByName("Blade Master", false);
-			AllClearImageByName("kasar hood", false);
-			AllClearImageByName("Arc Mage", false);
-			AllClearImageByName("Paladin", false);
+			AllClearImageByName("blade_master", false);
+			AllClearImageByName("kasar_hood", false);
+			AllClearImageByName("arc_mage", false);
+			AllClearImageByName("paladin", false);
 
 			// 직업.. 
 			switch ( CGameBase::s_pPlayer->m_InfoBase.eClass )
@@ -1708,19 +1721,23 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 					break;
 
 				case CLASS_EL_PROTECTOR:
-					AllClearImageByName("Blade Master", true);
+					AllClearImageByName("blade", true);
+					AllClearImageByName("blade_master", true);
 					break;
 
 				case CLASS_EL_ASSASIN:
-					AllClearImageByName("Kasar Hood", true);
+					AllClearImageByName("ranger", true);
+					AllClearImageByName("kasar_hood", true);
 					break;
 					
 				case CLASS_EL_ENCHANTER:
-					AllClearImageByName("Arc Mage", true);
+					AllClearImageByName("mage", true);
+					AllClearImageByName("arc_mage", true);
 					break;
 
 				case CLASS_EL_DRUID:
-					AllClearImageByName("Paladin", true);
+					AllClearImageByName("cleric", true);
+					AllClearImageByName("paladin", true);
 					break;
 
 			}
@@ -1729,13 +1746,42 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 	
 }
 
+void CUISkillTreeDlg::NormalizeString(std::string& strInput)
+{
+	std::string result = strInput;
+
+	// convert to lower case
+	std::transform(strInput.begin(), strInput.end(), strInput.begin(), ::tolower);
+
+	// remove empty spaces (' ') & underscore ('_')
+	strInput.erase(std::remove_if(strInput.begin(), strInput.end(),
+		[](char c)
+		{
+			return c == ' ' || c == '_';
+		}), strInput.end());
+
+}
+
 CN3UIImage*	CUISkillTreeDlg::GetChildImageByName(const std::string& szFN)
 {
+
+	std::string strInputNorm = szFN;
+	NormalizeString(strInputNorm);
+
 	for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
 	{
-		CN3UIBase* pChild = (CN3UIBase* )(*itor);
-		if ( (pChild->UIType() == UI_TYPE_IMAGE) && (szFN.compare(pChild->m_szID) == 0) )
-			return (CN3UIImage*)pChild;
+		
+		CN3UIBase* pChild = (CN3UIBase*) (*itor);
+
+		if (pChild->UIType() != UI_TYPE_IMAGE)
+			continue;
+
+		std::string strIDNorm = pChild->m_szID;
+		NormalizeString(strIDNorm);
+
+		if (strIDNorm == strInputNorm)
+			return (CN3UIImage*) pChild;
+
 	}
 
 	return NULL;
@@ -1743,10 +1789,17 @@ CN3UIImage*	CUISkillTreeDlg::GetChildImageByName(const std::string& szFN)
 
 CN3UIBase* CUISkillTreeDlg::GetChildBaseByName(const std::string &szFN)
 {
-	for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
+
+	std::string strInputNorm = szFN;
+	NormalizeString(strInputNorm);
+
+	for (UIListItor itor = m_Children.begin(); itor != m_Children.end(); ++itor)
 	{
-		CN3UIBase* pChild = (CN3UIBase* )(*itor);
-		if ( szFN.compare(pChild->m_szID) == 0 )
+		CN3UIBase* pChild = (CN3UIBase*) (*itor);
+		std::string strIDNorm = pChild->m_szID;
+		NormalizeString(strIDNorm);
+
+		if (strIDNorm == strInputNorm)
 			return pChild;
 	}
 
@@ -1755,11 +1808,23 @@ CN3UIBase* CUISkillTreeDlg::GetChildBaseByName(const std::string &szFN)
 
 CN3UIButton* CUISkillTreeDlg::GetChildButtonByName(const std::string& szFN)
 {
+
+	std::string strInputNorm = szFN;
+	NormalizeString(strInputNorm);
+
 	for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
 	{
 		CN3UIBase* pChild = (CN3UIBase* )(*itor);
-		if ( (pChild->UIType() == UI_TYPE_BUTTON) && (szFN.compare(pChild->m_szID) == 0) )
-			return (CN3UIButton*)pChild;
+
+		if (pChild->UIType() != UI_TYPE_BUTTON)
+			continue;
+
+		std::string strIDNorm = pChild->m_szID;
+		NormalizeString(strIDNorm);
+
+		if (strIDNorm == strInputNorm)
+			return (CN3UIButton*) pChild;
+
 	}
 
 	return NULL;

--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -24,9 +24,6 @@
 #include "N3UIString.h"
 #include "N3SndObj.h"
 
-#include <algorithm> // std::transform
-#include <cctype>    // std::tolower
-
 #ifdef _DEBUG
 #undef THIS_FILE
 static char THIS_FILE[]=__FILE__;
@@ -1630,10 +1627,10 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 			AllClearImageByName("berserker", false);
 			AllClearImageByName("sorcerer", false);
 			AllClearImageByName("shaman", false);
-			AllClearImageByName("shadow_knight",false);
-			AllClearImageByName("berserker_hero", false);
-			AllClearImageByName("elemental_lord", false);
-			AllClearImageByName("shadow_bane", false);
+			AllClearImageByName("Shadow Knight",false);
+			AllClearImageByName("Berserker Hero", false);
+			AllClearImageByName("Elemental Lord", false);
+			AllClearImageByName("Shadow Bane", false);
 			
 
 			// 직업.. 
@@ -1689,10 +1686,10 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 			AllClearImageByName("blade", false);
 			AllClearImageByName("mage", false);
 			AllClearImageByName("cleric", false);
-			AllClearImageByName("blade_master", false);
-			AllClearImageByName("kasar_hood", false);
-			AllClearImageByName("arc_mage", false);
-			AllClearImageByName("paladin", false);
+			AllClearImageByName("Blade Master", false);
+			AllClearImageByName("kasar hood", false);
+			AllClearImageByName("Arc Mage", false);
+			AllClearImageByName("Paladin", false);
 
 			// 직업.. 
 			switch ( CGameBase::s_pPlayer->m_InfoBase.eClass )
@@ -1722,22 +1719,22 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 
 				case CLASS_EL_PROTECTOR:
 					AllClearImageByName("blade", true);
-					AllClearImageByName("blade_master", true);
+					AllClearImageByName("Blade Master", true);
 					break;
 
 				case CLASS_EL_ASSASIN:
 					AllClearImageByName("ranger", true);
-					AllClearImageByName("kasar_hood", true);
+					AllClearImageByName("Kasar Hood", true);
 					break;
 					
 				case CLASS_EL_ENCHANTER:
 					AllClearImageByName("mage", true);
-					AllClearImageByName("arc_mage", true);
+					AllClearImageByName("Arc Mage", true);
 					break;
 
 				case CLASS_EL_DRUID:
 					AllClearImageByName("cleric", true);
-					AllClearImageByName("paladin", true);
+					AllClearImageByName("Paladin", true);
 					break;
 
 			}
@@ -1746,42 +1743,13 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 	
 }
 
-void CUISkillTreeDlg::NormalizeString(std::string& strInput)
-{
-	std::string result = strInput;
-
-	// convert to lower case
-	std::transform(strInput.begin(), strInput.end(), strInput.begin(), ::tolower);
-
-	// remove empty spaces (' ') & underscore ('_')
-	strInput.erase(std::remove_if(strInput.begin(), strInput.end(),
-		[](char c)
-		{
-			return c == ' ' || c == '_';
-		}), strInput.end());
-
-}
-
 CN3UIImage*	CUISkillTreeDlg::GetChildImageByName(const std::string& szFN)
 {
-
-	std::string strInputNorm = szFN;
-	NormalizeString(strInputNorm);
-
 	for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
 	{
-		
-		CN3UIBase* pChild = (CN3UIBase*) (*itor);
-
-		if (pChild->UIType() != UI_TYPE_IMAGE)
-			continue;
-
-		std::string strIDNorm = pChild->m_szID;
-		NormalizeString(strIDNorm);
-
-		if (strIDNorm == strInputNorm)
-			return (CN3UIImage*) pChild;
-
+		CN3UIBase* pChild = (CN3UIBase* )(*itor);
+		if ( (pChild->UIType() == UI_TYPE_IMAGE) && (szFN.compare(pChild->m_szID) == 0) )
+			return (CN3UIImage*)pChild;
 	}
 
 	return NULL;
@@ -1789,17 +1757,10 @@ CN3UIImage*	CUISkillTreeDlg::GetChildImageByName(const std::string& szFN)
 
 CN3UIBase* CUISkillTreeDlg::GetChildBaseByName(const std::string &szFN)
 {
-
-	std::string strInputNorm = szFN;
-	NormalizeString(strInputNorm);
-
-	for (UIListItor itor = m_Children.begin(); itor != m_Children.end(); ++itor)
+	for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
 	{
 		CN3UIBase* pChild = (CN3UIBase*) (*itor);
-		std::string strIDNorm = pChild->m_szID;
-		NormalizeString(strIDNorm);
-
-		if (strIDNorm == strInputNorm)
+		if ( szFN.compare(pChild->m_szID) == 0 )
 			return pChild;
 	}
 
@@ -1808,23 +1769,11 @@ CN3UIBase* CUISkillTreeDlg::GetChildBaseByName(const std::string &szFN)
 
 CN3UIButton* CUISkillTreeDlg::GetChildButtonByName(const std::string& szFN)
 {
-
-	std::string strInputNorm = szFN;
-	NormalizeString(strInputNorm);
-
 	for(UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor)
 	{
 		CN3UIBase* pChild = (CN3UIBase* )(*itor);
-
-		if (pChild->UIType() != UI_TYPE_BUTTON)
-			continue;
-
-		std::string strIDNorm = pChild->m_szID;
-		NormalizeString(strIDNorm);
-
-		if (strIDNorm == strInputNorm)
-			return (CN3UIButton*) pChild;
-
+		if ( (pChild->UIType() == UI_TYPE_BUTTON) && (szFN.compare(pChild->m_szID) == 0) )
+			return (CN3UIButton*)pChild;
 	}
 
 	return NULL;

--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -1696,7 +1696,6 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 					break;
 
 				case CLASS_EL_BLADE:
-					TRACE("worked\n");
 					AllClearImageByName("blade", true);
 					break;
 

--- a/Client/WarFare/UISkillTreeDlg.h
+++ b/Client/WarFare/UISkillTreeDlg.h
@@ -57,6 +57,7 @@ protected:
 	RECT				GetSampleRect();
 	void				PageButtonInitialize();
 	bool				CheckSkillCanBeUse(__TABLE_UPC_SKILL* pUSkill);
+	void				NormalizeString(std::string& strInput);
 public:
 	void SetVisible(bool bVisible);
 	CUISkillTreeDlg();

--- a/Client/WarFare/UISkillTreeDlg.h
+++ b/Client/WarFare/UISkillTreeDlg.h
@@ -57,7 +57,6 @@ protected:
 	RECT				GetSampleRect();
 	void				PageButtonInitialize();
 	bool				CheckSkillCanBeUse(__TABLE_UPC_SKILL* pUSkill);
-	void				NormalizeString(std::string& strInput);
 public:
 	void SetVisible(bool bVisible);
 	CUISkillTreeDlg();

--- a/Client/WarFare/UISkillTreeDlg.h
+++ b/Client/WarFare/UISkillTreeDlg.h
@@ -84,9 +84,8 @@ public:
 	void				SetPageInIconRegion(int iKindOf, int iPageNum);		// 아이콘 역역에서 현재 페이지 설정..
 	void				SetPageInCharRegion();								// 문자 역역에서 현재 페이지 설정..
 
-	CN3UIImage*			GetChildImageByName(const std::string& szFN);
-	CN3UIBase*			GetChildBaseByName(const std::string& szFN);	
-	CN3UIButton*		GetChildButtonByName(const std::string& szFN);
+	CN3UIImage*			GetChildImageByName(const std::string& szID);
+	CN3UIButton*		GetChildButtonByName(const std::string& szID);
 
 	void				PageLeft();
 	void				PageRight();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
current class names on skill tree for el morad is not visible properly because kasar hood ( master rogue ) text is not closed correctly. Hence, for a warrior without master, class name seen as kasar hood, although it should be Blade.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Now, it is seen as Blade as it should be.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
ID written wrong in func SetPageInCharRegion(), in SkillTreeDlg.cpp. 

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
