### PR TITLE
fix for missing clan error texts

### DIFF
--- a/Client/WarFare/UIInn.cpp
+++ b/Client/WarFare/UIInn.cpp
@@ -92,6 +92,8 @@ void CUIInn::Message(int iMessageID)
 
 	if (iMessageID == IDS_CLAN_DENY_LOWGOLD)
 		CGameBase::GetTextF(iMessageID, &szMsg, CLAN_COST);
+	else
+		CGameBase::GetText(iMessageID, &szMsg);
 
 	CGameProcedure::MessageBoxPost(szMsg, "", MB_OK, BEHAVIOR_NOTHING);	
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Currently, if an user has clan, create clan feature does not show the message "you cannot create a clan because you have one"
It shows empty message because related line removed.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Now, it shows related error messages.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
UIInn - Message function is edited, because not formated texts are forgotten there.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
