### PR TITLE
Master quests for all classes & nations

### DIFF
--- a/Server/GameServer/QuestHandler.cpp
+++ b/Server/GameServer/QuestHandler.cpp
@@ -185,6 +185,65 @@ bool CUser::PromoteUser()
 	return true;
 }
 
+uint8_t CUser::CheckPromotionEligible()
+{
+	//level check
+	if (GetLevel() < 60)
+		return 2;
+
+	//beginner
+	if (isBeginner())
+		return 3;
+
+	//already master
+	if (isMastered())
+		return 4;
+
+	return 1;
+}
+
+bool CUser::GivePromotionQuest()
+{
+	if (isBeginner())
+	{
+		return false;
+	}
+	
+	uint16_t iQuestID = 0;
+	if (isNoviceWarrior())
+	{
+		iQuestID = QUEST_ID_MASTERY_WARRIOR;
+	}else if(isNoviceRogue())
+	{
+		iQuestID = QUEST_ID_MASTERY_ROGUE;
+	}
+	else if (isNoviceMage())
+	{
+		iQuestID = QUEST_ID_MASTERY_MAGE;
+	}
+	else if (isNovicePriest())
+	{
+		iQuestID = QUEST_ID_MASTERY_PRIEST;
+	}
+
+	//dont give quest if user already have it
+	if (CheckExistEvent(iQuestID, 1))
+	{
+		return false;
+	}
+
+	//return if quest already finished 
+	if (CheckExistEvent(iQuestID, 2))
+	{
+		return false;
+	}
+
+	//give quest
+	SaveEvent(iQuestID, 1);
+
+	return true;
+}
+
 bool CUser::RunZoneQuestScript(
 	int32_t iEventID)
 {

--- a/Server/GameServer/User.cpp
+++ b/Server/GameServer/User.cpp
@@ -204,7 +204,7 @@ bool CUser::HandlePacket(Packet & pkt)
 	uint8_t command;
 	pkt >> command;
 
-	//TRACE("[SID=%d] Packet: %X (len=%d)\n", GetSocketID(), command, pkt.wpos());
+	TRACE("[SID=%d] Packet: %X (len=%d)\n", GetSocketID(), command, pkt.wpos());
 
 	// If crypto's not been enabled yet, force the version packet to be sent.
 	//if (!isCryptoEnabled())

--- a/Server/GameServer/User.cpp
+++ b/Server/GameServer/User.cpp
@@ -204,7 +204,7 @@ bool CUser::HandlePacket(Packet & pkt)
 	uint8_t command;
 	pkt >> command;
 
-	TRACE("[SID=%d] Packet: %X (len=%d)\n", GetSocketID(), command, pkt.wpos());
+	//TRACE("[SID=%d] Packet: %X (len=%d)\n", GetSocketID(), command, pkt.wpos());
 
 	// If crypto's not been enabled yet, force the version packet to be sent.
 	//if (!isCryptoEnabled())

--- a/Server/GameServer/User.h
+++ b/Server/GameServer/User.h
@@ -542,6 +542,9 @@ public:
 	void SendDebugString(const char* pString);
 	int NumEmptySlots(void);
 
+	uint8_t CheckPromotionEligible();
+	bool GivePromotionQuest();
+	bool PromoteUser();
 	bool CheckClass(int16_t class1, int16_t class2 = -1, int16_t class3 = -1, int16_t class4 = -1, int16_t class5 = -1, int16_t class6 = -1);
 	bool GiveItem(uint32_t nItemID, uint16_t sCount = 1, bool send_packet = true, uint32_t Time = 0);
 	bool RobItem(uint32_t nItemID, uint32_t sCount = 1);
@@ -888,7 +891,6 @@ public:
 	bool RunZoneQuestScript(int32_t iEventID);
 
 	bool PromoteUserNovice();
-	bool PromoteUser();
 	void PromoteClan(ClanTypeFlag byFlag);
 
 	// Attack/zone checks
@@ -1300,4 +1302,17 @@ public:
 	DECLARE_LUA_FUNCTION(CheckMonsterChallengeUserCount) {
 		LUA_RETURN(LUA_GET_INSTANCE()->GetMonsterChallengeUserCount());
 	}
+
+	DECLARE_LUA_FUNCTION(CheckPromotionEligible)
+	{	
+		
+		LUA_RETURN(LUA_GET_INSTANCE()->CheckPromotionEligible());
+	}
+
+	DECLARE_LUA_FUNCTION(GivePromotionQuest)
+	{
+
+		LUA_RETURN(LUA_GET_INSTANCE()->GivePromotionQuest());
+	}
+
 };

--- a/Server/GameServer/lua_bindings.cpp
+++ b/Server/GameServer/lua_bindings.cpp
@@ -145,6 +145,10 @@ DEFINE_LUA_CLASS
 	MAKE_LUA_METHOD(CheckMonsterChallengeTime)
 	MAKE_LUA_METHOD(CheckMonsterChallengeUserCount)
 	MAKE_LUA_METHOD(GetPVPMonumentNation)
+	MAKE_LUA_METHOD(CheckPromotionEligible)
+	MAKE_LUA_METHOD(GivePromotionQuest)
+	MAKE_LUA_METHOD(PromoteUser)
+
 	);
 #undef LUA_CLASS
 

--- a/Server/bin/QUESTS/1.lua
+++ b/Server/bin/QUESTS/1.lua
@@ -234,11 +234,17 @@ elseif nEventID == 3002 then
 	end
 	end
 	end
-elseif nEventID == 6010 then
-	pUser:SendDebugString("Unhandled LOGIC command 'CHECK_PROMOTION_ELIGIBLE'."); -- unhandled logic command (CHECK_PROMOTION_ELIGIBLE)
-	if false then
-	pUser:SelectMsg(6000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+elseif nEventID == 6010 then --priest master check eligible 
+	if pUser:CheckPromotionEligible() == 1 then
+	pUser:SelectMsg(9000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif pUser:CheckPromotionEligible() == 2 then
+	pUser:NpcSay(9001, -1, -1, -1, -1, -1, -1, -1);
+	elseif pUser:CheckPromotionEligible() == 3 then 
+	pUser:NpcSay(9007, -1, -1, -1, -1, -1, -1, -1);
+	elseif pUser:CheckPromotionEligible() == 4 then 
+	pUser:NpcSay(9006, -1, -1, -1, -1, -1, -1, -1);
 	end
+	do return; end
 elseif nEventID == 6011 then
 	pUser:SendDebugString("Unhandled LOGIC command 'CHECK_PROMOTION_ELIGIBLE'."); -- unhandled logic command (CHECK_PROMOTION_ELIGIBLE)
 	if false then
@@ -249,12 +255,18 @@ elseif nEventID == 6013 then
 	if false then
 	pUser:SelectMsg(8000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
 	end
-elseif nEventID == 6030 then
-	pUser:SendDebugString("Unknown EXEC command 'GIVE_PROMOTION_QUEST'."); -- unknown execute command (GIVE_PROMOTION_QUEST)
+elseif nEventID == 6030 then -- priest master give quest yes no dlg
+	pUser:SelectMsg(9002, 1, 6031, 2, 6032, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	do return; end
+elseif nEventID == 6031 then -- accept priest master quest 
+	pUser:NpcSay(9003, -1, -1, -1, -1, -1, -1, -1);
+	do return; end	
+elseif nEventID == 6032 then -- dont accept priest master quest 
+	pUser:NpcSay(9003, -1, -1, -1, -1, -1, -1, -1);
 	do return; end
 elseif nEventID == 6040 then
-	pUser:SendDebugString("Unknown EXEC command 'PROMOTE_USER'."); -- unknown execute command (PROMOTE_USER)
-	do return; end
+	--pUser:SendDebugString("Unknown EXEC command 'PROMOTE_USER'."); -- unknown execute command (PROMOTE_USER)
+	pUser:PromoteUser();
 	do return; end
 elseif nEventID == 7281 then
 	local count = pUser:HowMuchItem(379049000);

--- a/Server/bin/QUESTS/1.lua
+++ b/Server/bin/QUESTS/1.lua
@@ -235,38 +235,113 @@ elseif nEventID == 3002 then
 	end
 	end
 elseif nEventID == 6010 then --priest master check eligible 
-	if pUser:CheckPromotionEligible() == 1 then
+	local result = pUser:CheckPromotionEligible();
+	if result == 1 then
 	pUser:SelectMsg(9000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
-	elseif pUser:CheckPromotionEligible() == 2 then
+	elseif result == 2 then
 	pUser:NpcSay(9001, -1, -1, -1, -1, -1, -1, -1);
-	elseif pUser:CheckPromotionEligible() == 3 then 
-	pUser:NpcSay(9007, -1, -1, -1, -1, -1, -1, -1);
-	elseif pUser:CheckPromotionEligible() == 4 then 
+	elseif result == 3 then 
 	pUser:NpcSay(9006, -1, -1, -1, -1, -1, -1, -1);
 	end
 	do return; end
-elseif nEventID == 6011 then
-	pUser:SendDebugString("Unhandled LOGIC command 'CHECK_PROMOTION_ELIGIBLE'."); -- unhandled logic command (CHECK_PROMOTION_ELIGIBLE)
-	if false then
+elseif nEventID == 6011 then --rogue master check eligible
+	local result = pUser:CheckPromotionEligible();
+	if result == 1 then
 	pUser:SelectMsg(7000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 2 then
+	pUser:NpcSay(7001, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 3 then 
+	pUser:NpcSay(7006, -1, -1, -1, -1, -1, -1, -1);
 	end
-elseif nEventID == 6013 then
-	pUser:SendDebugString("Unhandled LOGIC command 'CHECK_PROMOTION_ELIGIBLE'."); -- unhandled logic command (CHECK_PROMOTION_ELIGIBLE)
-	if false then
-	pUser:SelectMsg(8000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
-	end
-elseif nEventID == 6030 then -- priest master give quest yes no dlg
-	pUser:SelectMsg(9002, 1, 6031, 2, 6032, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
 	do return; end
-elseif nEventID == 6031 then -- accept priest master quest 
-	pUser:NpcSay(9003, -1, -1, -1, -1, -1, -1, -1);
+elseif nEventID == 6012 then --warrior master check eligible
+	local result = pUser:CheckPromotionEligible();
+	if result == 1 then
+	pUser:SelectMsg(6000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 2 then
+	pUser:NpcSay(6001, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 3 then 
+	pUser:NpcSay(6006, -1, -1, -1, -1, -1, -1, -1);
+	end
+	do return; end
+elseif nEventID == 6013 then --mage master check eligible
+	local result = pUser:CheckPromotionEligible();
+	if result == 1 then
+	pUser:SelectMsg(8000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 2 then
+	pUser:NpcSay(8001, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 3 then 
+	pUser:NpcSay(8006, -1, -1, -1, -1, -1, -1, -1);
+	end
+	do return; end
+elseif nEventID == 6030 then -- master give quest yes no dlg
+	if pUser:isNovicePriest() == true then
+	pUser:SelectMsg(9002, 1, 6031, 2, 6032, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    elseif 	pUser:isNoviceMage() == true then
+	pUser:SelectMsg(8002, 1, 6031, 2, 6032, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceRogue() == true then
+	pUser:SelectMsg(7002, 1, 6031, 2, 6032, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceWarrior() == true then
+	pUser:SelectMsg(6002, 1, 6031, 2, 6032, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	end
+	do return; end
+elseif nEventID == 6031 then -- accept master quest
+	pUser:GivePromotionQuest();
+	if pUser:isNovicePriest() == true then
+	pUser:NpcSay(9011, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceMage() == true then
+	pUser:NpcSay(8011, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceRogue() == true then
+	pUser:NpcSay(7011, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceWarrior() == true then
+	pUser:NpcSay(6011, -1, -1, -1, -1, -1, -1, -1);
+	end
 	do return; end	
 elseif nEventID == 6032 then -- dont accept priest master quest 
+	if pUser:isNovicePriest() == true then
 	pUser:NpcSay(9003, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceMage() == true then
+	pUser:NpcSay(8003, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceRogue() == true then
+	pUser:NpcSay(7003, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceWarrior() == true then
+	pUser:NpcSay(6003, -1, -1, -1, -1, -1, -1, -1);
+	end
 	do return; end
 elseif nEventID == 6040 then
-	--pUser:SendDebugString("Unknown EXEC command 'PROMOTE_USER'."); -- unknown execute command (PROMOTE_USER)
-	pUser:PromoteUser();
+	if pUser:isNovicePriest() == true then
+	pUser:SelectMsg(9004, 1, 6041, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceMage() == true then
+	pUser:SelectMsg(8004, 1, 6041, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceRogue() == true then
+	pUser:SelectMsg(7004, 1, 6041, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceWarrior() == true then
+	pUser:SelectMsg(6004, 1, 6041, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	end
+	do return; end
+elseif nEventID == 6041 then
+	local result = pUser:PromoteUser();
+	if result == true then --master success
+		if pUser:isNovicePriest() == true then
+		pUser:NpcSay(9005, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceMage() == true then
+		pUser:NpcSay(8005, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceRogue() == true then
+		pUser:NpcSay(7005, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceWarrior() == true then
+		pUser:NpcSay(6005, -1, -1, -1, -1, -1, -1, -1);
+		end
+	elseif result == false then -- fail
+		if pUser:isNovicePriest() == true then
+		pUser:NpcSay(9007, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceMage() == true then
+		pUser:NpcSay(8007, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceRogue() == true then
+		pUser:NpcSay(7007, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceWarrior() == true then
+		pUser:NpcSay(6007, -1, -1, -1, -1, -1, -1, -1);
+		end
+	end 
 	do return; end
 elseif nEventID == 7281 then
 	local count = pUser:HowMuchItem(379049000);
@@ -1384,7 +1459,7 @@ elseif nEventID == 10587 then
 	end
 elseif nEventID == 11001 then
 	if pUser:CheckClass(101, 105, 106, -1, -1, -1) then
-	pUser:SelectMsg(11008, 11001, 6010, 10000, 11050, 17010, 17027, 17070, 17070, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	pUser:SelectMsg(11008, 11001, 6012, 10000, 11050, 17010, 17027, 17070, 17070, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
 	end
 	if not pUser:CheckClass(101, 105, 106, -1, -1, -1) then
 	pUser:SelectMsg(17073, 17070, 17070, 35664, 35664, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);

--- a/Server/bin/QUESTS/2.lua
+++ b/Server/bin/QUESTS/2.lua
@@ -237,26 +237,113 @@ elseif nEventID == 3002 then
 	end
 	end
 elseif nEventID == 6010 then
-	pUser:SendDebugString("Unhandled LOGIC command 'CHECK_PROMOTION_ELIGIBLE'."); -- unhandled logic command (CHECK_PROMOTION_ELIGIBLE)
-	if false then
-	pUser:SelectMsg(6000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	local result = pUser:CheckPromotionEligible();
+	if result == 1 then
+	pUser:SelectMsg(9000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 2 then
+	pUser:NpcSay(9001, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 3 then 
+	pUser:NpcSay(9006, -1, -1, -1, -1, -1, -1, -1);
 	end
+	do return; end
 elseif nEventID == 6011 then
-	pUser:SendDebugString("Unhandled LOGIC command 'CHECK_PROMOTION_ELIGIBLE'."); -- unhandled logic command (CHECK_PROMOTION_ELIGIBLE)
-	if false then
+	local result = pUser:CheckPromotionEligible();
+	if result == 1 then
 	pUser:SelectMsg(7000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 2 then
+	pUser:NpcSay(7001, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 3 then 
+	pUser:NpcSay(7006, -1, -1, -1, -1, -1, -1, -1);
 	end
-elseif nEventID == 6013 then
-	pUser:SendDebugString("Unhandled LOGIC command 'CHECK_PROMOTION_ELIGIBLE'."); -- unhandled logic command (CHECK_PROMOTION_ELIGIBLE)
-	if false then
+	do return; end
+elseif nEventID == 6012 then --warrior master check eligible
+	local result = pUser:CheckPromotionEligible();
+	if result == 1 then
+	pUser:SelectMsg(6000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 2 then
+	pUser:NpcSay(6001, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 3 then 
+	pUser:NpcSay(6006, -1, -1, -1, -1, -1, -1, -1);
+	end
+	do return; end
+elseif nEventID == 6013 then --mage master check eligible
+	local result = pUser:CheckPromotionEligible();
+	if result == 1 then
 	pUser:SelectMsg(8000, 501, 6030, 502, 6040, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 2 then
+	pUser:NpcSay(8001, -1, -1, -1, -1, -1, -1, -1);
+	elseif result == 3 then 
+	pUser:NpcSay(8006, -1, -1, -1, -1, -1, -1, -1);
 	end
+	do return; end
 elseif nEventID == 6030 then
-	pUser:SendDebugString("Unknown EXEC command 'GIVE_PROMOTION_QUEST'."); -- unknown execute command (GIVE_PROMOTION_QUEST)
+	if pUser:isNovicePriest() == true then
+	pUser:SelectMsg(9002, 1, 6031, 2, 6032, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+    elseif 	pUser:isNoviceMage() == true then
+	pUser:SelectMsg(8002, 1, 6031, 2, 6032, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceRogue() == true then
+	pUser:SelectMsg(7002, 1, 6031, 2, 6032, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceWarrior() == true then
+	pUser:SelectMsg(6002, 1, 6031, 2, 6032, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	end
+	do return; end
+elseif nEventID == 6031 then -- accept master quest
+	pUser:GivePromotionQuest();
+	if pUser:isNovicePriest() == true then
+	pUser:NpcSay(9011, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceMage() == true then
+	pUser:NpcSay(8011, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceRogue() == true then
+	pUser:NpcSay(7011, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceWarrior() == true then
+	pUser:NpcSay(6011, -1, -1, -1, -1, -1, -1, -1);
+	end
+	do return; end
+elseif nEventID == 6032 then -- dont accept priest master quest 
+	if pUser:isNovicePriest() == true then
+	pUser:NpcSay(9003, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceMage() == true then
+	pUser:NpcSay(8003, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceRogue() == true then
+	pUser:NpcSay(7003, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceWarrior() == true then
+	pUser:NpcSay(6003, -1, -1, -1, -1, -1, -1, -1);
+	end
 	do return; end
 elseif nEventID == 6040 then
-	pUser:SendDebugString("Unknown EXEC command 'PROMOTE_USER'."); -- unknown execute command (PROMOTE_USER)
+	if pUser:isNovicePriest() == true then
+	pUser:SelectMsg(9004, 1, 6041, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceMage() == true then
+	pUser:SelectMsg(8004, 1, 6041, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceRogue() == true then
+	pUser:SelectMsg(7004, 1, 6041, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	elseif 	pUser:isNoviceWarrior() == true then
+	pUser:SelectMsg(6004, 1, 6041, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	end
 	do return; end
+elseif nEventID == 6041 then
+	local result = pUser:PromoteUser();
+	if result == true then --master success
+		if pUser:isNovicePriest() == true then
+		pUser:NpcSay(9005, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceMage() == true then
+		pUser:NpcSay(8005, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceRogue() == true then
+		pUser:NpcSay(7005, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceWarrior() == true then
+		pUser:NpcSay(6005, -1, -1, -1, -1, -1, -1, -1);
+		end
+	elseif result == false then -- fail
+		if pUser:isNovicePriest() == true then
+		pUser:NpcSay(9007, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceMage() == true then
+		pUser:NpcSay(8007, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceRogue() == true then
+		pUser:NpcSay(7007, -1, -1, -1, -1, -1, -1, -1);
+		elseif 	pUser:isNoviceWarrior() == true then
+		pUser:NpcSay(6007, -1, -1, -1, -1, -1, -1, -1);
+		end
+	end 
 	do return; end
 elseif nEventID == 8001 then
 	pUser:SendDebugString("Unknown LOGIC command 'CHECK_NOEXIST_ITEM'.");
@@ -704,7 +791,7 @@ elseif nEventID == 10587 then
 	end
 elseif nEventID == 11001 then
 	if pUser:CheckClass(201, 205, 206, -1, -1, -1) then
-	pUser:SelectMsg(11008, 11001, 6010, 10000, 11050, 17010, 17027, 17070, 17070, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+	pUser:SelectMsg(11008, 11001, 6012, 10000, 11050, 17010, 17027, 17070, 17070, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
 	end
 	if not pUser:CheckClass(201, 205, 206, -1, -1, -1) then
 	pUser:SelectMsg(17073, 17070, 17070, 35664, 35664, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
At current state, some required functions for master quests to work is not added on server side ( lua and cpp files ). Those functions are : CheckPromotionEligible, GivePromotionQuest. Therefore, master quests are not working at all. User cannot get any quest from NPC also user cannot return and promote his/her character to master.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Mentioned functions declared and filled. They are now working fine. User can get master quests ( all classes, warrior, rogue, priest, mage & all nations ), can return quests to be promoted to master. Required items from user has been robbed from his/her inventory.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
This is one of main features of the game and it should be working fine. Required additions done to unfinished parts of QuestHandler and lua scripts.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->
Tested with all classes and nations. Both under 60 and above levels and with items in inventory or without items in inventory.
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
