### PR TITLE
max level limit in seeking party text changed to 80

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -4975,7 +4975,7 @@ void CGameProcMain::MsgRecv_UserState(Packet& pkt)
 			int iLMin = iLevel - 8;
 			if(iLMin < 0) iLMin = 0;
 			int iLMax = iLevel + 8;
-			if(iLMax > 60) iLMax = 60;
+			if(iLMax > 80) iLMax = 80;
 
 			std::string szMsg;
 			GetTextF(IDS_WANT_PARTY_MEMBER, &szMsg, iLMin, iLMax);

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -2603,7 +2603,7 @@ bool CGameProcMain::MsgRecv_UserIn(Packet& pkt, bool bWithFX)
 		int iLMin = iLevel - 8;
 		if(iLMin < 0) iLMin = 0;
 		int iLMax = iLevel + 8;
-		if(iLMax > 60) iLMax = 60;
+		if(iLMax > 80) iLMax = 80;
 
 		std::string szMsg;
 		GetTextF(IDS_WANT_PARTY_MEMBER, &szMsg, iLMin, iLMax);

--- a/Client/WarFare/UIPartyBBS.cpp
+++ b/Client/WarFare/UIPartyBBS.cpp
@@ -316,7 +316,7 @@ void CUIPartyBBS::PartyStringSet(uint8_t byType)
 		int iLMin = iLevel - 8;
 		if(iLMin < 0) iLMin = 0;
 		int iLMax = iLevel + 8;
-		if(iLMax > 60) iLMax = 60;
+		if(iLMax > 80) iLMax = 80;
 
 		char szBuff[128];
 		std::string szMsg;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Max level of seeking party text has been set as 60.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
It has been set as 80 which is the actual max level for 1299 version.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
This was causing misinformation for high level characters for example if a 79 level user opens seeking party feature, he/she sees level range as 71-60 and that is wrong.  

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
