### PR TITLE
to buy loyalty from npc knight clerk

### DIFF
--- a/Server/bin/QUESTS/1.lua
+++ b/Server/bin/QUESTS/1.lua
@@ -2018,49 +2018,36 @@ elseif nEventID == 15951 then
 	end
 	end
 elseif nEventID == 16951 then
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
-	pUser:NpcSay(15956, -1, -1, -1, -1, -1, -1, -1);
-	do return; end
-	end
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
 	pUser:SelectMsg(15957, 1003, 16956, 1004, 16957, 1005, 16958, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
-	end
-elseif nEventID == 16956 then
+	return
+elseif nEventID == 16956 then --user buys 500 NP
 	local coins = pUser:GetCoins();
-	if coins >= 0 and coins <= 1499999 then
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
-	pUser:NpcSay(15961, -1, -1, -1, -1, -1, -1, -1);
-	do return; end
+	if coins < 1500000 then --coin check
+		pUser:NpcSay(15961, -1, -1, -1, -1, -1, -1, -1);
+	return
 	end
+	if pUser:hasLoyalty(100) then -- loyalty check
+		pUser:NpcSay(15959, -1, -1, -1, -1, -1, -1, -1);
+	return
 	end
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
 	pUser:GoldLose(1500000);
-	pUser:SendDebugString("Unknown EXEC command 'CHANGE_LOYALTY'."); -- unknown execute command (CHANGE_LOYALTY)
-	do return; end
+	pUser:GiveLoyalty(500);
 	pUser:NpcSay(15958, -1, -1, -1, -1, -1, -1, -1);
-	do return; end
-	end
-elseif nEventID == 16957 then
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
+	return
+elseif nEventID == 16957 then --user buys 100 NP
 	local coins = pUser:GetCoins();
-	if coins >= 0 and coins <= 349999 then
+	if coins < 350000 then
 	pUser:NpcSay(15961, -1, -1, -1, -1, -1, -1, -1);
-	do return; end
+	return
 	end
+	if pUser:hasLoyalty(100) then -- loyalty check
+		pUser:NpcSay(15959, -1, -1, -1, -1, -1, -1, -1);
+	return
 	end
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
 	pUser:GoldLose(350000);
-	pUser:SendDebugString("Unknown EXEC command 'CHANGE_LOYALTY'."); -- unknown execute command (CHANGE_LOYALTY)
-	do return; end
+	pUser:GiveLoyalty(100);
 	pUser:NpcSay(15960, -1, -1, -1, -1, -1, -1, -1);
-	do return; end
-	end
+	return 
 elseif nEventID == 16958 then
 	pUser:NpcSay(15959, -1, -1, -1, -1, -1, -1, -1);
 	do return; end

--- a/Server/bin/QUESTS/2.lua
+++ b/Server/bin/QUESTS/2.lua
@@ -1349,49 +1349,36 @@ elseif nEventID == 15951 then
 	end
 	end
 elseif nEventID == 16951 then
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
-	pUser:NpcSay(15956, -1, -1, -1, -1, -1, -1, -1);
-	do return; end
-	end
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
 	pUser:SelectMsg(15957, 1003, 16956, 1004, 16957, 1005, 16958, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
-	end
+	return
 elseif nEventID == 16956 then
 	local coins = pUser:GetCoins();
-	if coins >= 0 and coins <= 1499999 then
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
-	pUser:NpcSay(15961, -1, -1, -1, -1, -1, -1, -1);
-	do return; end
+	if coins < 1500000 then --coin check
+		pUser:NpcSay(15961, -1, -1, -1, -1, -1, -1, -1);
+	return
 	end
+	if pUser:hasLoyalty(100) then -- loyalty check
+		pUser:NpcSay(15959, -1, -1, -1, -1, -1, -1, -1);
+	return
 	end
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
 	pUser:GoldLose(1500000);
-	pUser:SendDebugString("Unknown EXEC command 'CHANGE_LOYALTY'."); -- unknown execute command (CHANGE_LOYALTY)
-	do return; end
+	pUser:GiveLoyalty(500);
 	pUser:NpcSay(15958, -1, -1, -1, -1, -1, -1, -1);
-	do return; end
-	end
+	return
 elseif nEventID == 16957 then
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
 	local coins = pUser:GetCoins();
-	if coins >= 0 and coins <= 349999 then
+	if coins < 350000 then
 	pUser:NpcSay(15961, -1, -1, -1, -1, -1, -1, -1);
-	do return; end
+	return
 	end
+	if pUser:hasLoyalty(100) then -- loyalty check
+		pUser:NpcSay(15959, -1, -1, -1, -1, -1, -1, -1);
+	return
 	end
-	pUser:SendDebugString("Unknown LOGIC command 'CHECK_LOYALTY'.");
-	if false then -- unknown logic command (CHECK_LOYALTY)
 	pUser:GoldLose(350000);
-	pUser:SendDebugString("Unknown EXEC command 'CHANGE_LOYALTY'."); -- unknown execute command (CHANGE_LOYALTY)
-	do return; end
+	pUser:GiveLoyalty(100);
 	pUser:NpcSay(15960, -1, -1, -1, -1, -1, -1, -1);
-	do return; end
-	end
+	return 
 elseif nEventID == 16958 then
 	pUser:NpcSay(15959, -1, -1, -1, -1, -1, -1, -1);
 	do return; end


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
feature to buy national points from NPC is not working at the moment.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
It is working now for both nations. User can buy 100 or 500 np by paying 350000 or 1500000 coins from NPC Knight Clerk located in main cities.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
This is an important feature of the game and it should be working.

Note: this addition gives user national points but it is also affected by premium bonuses and it also gives right side national points. Current function under User.cpp works in that way. I don't remember what is official feature, does it really give right side national points ? does it really give bonusses from premium. If so, additional lua method can be added to directly add left side NP.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
