### PR TITLE
fix user cannot close npctalk menu with close button

### DIFF
--- a/Client/WarFare/UIQuestTalk.cpp
+++ b/Client/WarFare/UIQuestTalk.cpp
@@ -26,7 +26,7 @@ CUIQuestTalk::CUIQuestTalk()
 {
 	m_pTextTalk	= NULL;
 	m_pBtnOk	= NULL;
-
+	m_pBtnClose = NULL;
 	m_iNumTalk	= 0;
 	m_iCurTalk	= 0;
 }
@@ -78,6 +78,10 @@ bool CUIQuestTalk::ReceiveMessage(CN3UIBase *pSender, uint32_t dwMsg)
 				m_pTextTalk->SetString(m_szTalk[m_iCurTalk]);
 			}
 		}
+		else if (pSender == m_pBtnClose)
+		{
+			SetVisible(false);
+		}
 	}
 
 	return true;
@@ -92,10 +96,9 @@ bool CUIQuestTalk::Load(HANDLE hFile)
 	m_pBtnOk	= (CN3UIButton*)(this->GetChildByID("btn_Ok_center"));		__ASSERT(m_pBtnOk, "NULL UI Component!!!");
 
 	// NOTE(srmeier): new stuff
-	CN3UIButton* m_pBtnClose = (CN3UIButton*)(this->GetChildByID("btn_close"));
-	if (m_pBtnClose) {
-		m_pBtnClose->SetVisible(false);
-	}
+	m_pBtnClose = (CN3UIButton*)(this->GetChildByID("btn_close"));
+	__ASSERT(m_pBtnClose, "NULL UI Component!!!");
+	//m_pBtnClose->SetVisible(false);
 
 	CN3UIButton* m_pBtnUpperEvent = (CN3UIButton*)(this->GetChildByID("btn_UpperEvent"));
 	if (m_pBtnUpperEvent) {

--- a/Client/WarFare/UIQuestTalk.cpp
+++ b/Client/WarFare/UIQuestTalk.cpp
@@ -24,11 +24,15 @@ static char THIS_FILE[]=__FILE__;
 
 CUIQuestTalk::CUIQuestTalk()
 {
-	m_pTextTalk	= NULL;
-	m_pBtnOk	= NULL;
-	m_pBtnClose = NULL;
-	m_iNumTalk	= 0;
-	m_iCurTalk	= 0;
+	m_pTextTalk			= nullptr;
+	m_pBtnOk			= nullptr;
+	m_pBtnClose			= nullptr;
+	m_pBtnUpperEvent	= nullptr;
+	m_pBtnNext			= nullptr;
+	m_pBtnOkRight		= nullptr;
+	m_pBtnPre			= nullptr;
+	m_iNumTalk			= 0;
+	m_iCurTalk			= 0;
 }
 
 CUIQuestTalk::~CUIQuestTalk()
@@ -89,36 +93,30 @@ bool CUIQuestTalk::ReceiveMessage(CN3UIBase *pSender, uint32_t dwMsg)
 
 bool CUIQuestTalk::Load(HANDLE hFile)
 {
-	if(CN3UIBase::Load(hFile)==false) return false;
+	if (!CN3UIBase::Load(hFile))
+		return false;
 
-	m_pTextTalk	= (CN3UIString*)(this->GetChildByID("Text_Talk"));	__ASSERT(m_pTextTalk, "NULL UI Component!!!");
-//	m_pBtnOk	= (CN3UIButton*)(this->GetChildByID("Btn_Ok"));		__ASSERT(m_pBtnOk, "NULL UI Component!!!");
-	m_pBtnOk	= (CN3UIButton*)(this->GetChildByID("btn_Ok_center"));		__ASSERT(m_pBtnOk, "NULL UI Component!!!");
+	N3_VERIFY_UI_COMPONENT(m_pTextTalk,			(CN3UIString*) GetChildByID("Text_Talk"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnOk,			(CN3UIButton*) GetChildByID("btn_Ok_center"));
 
-	// NOTE(srmeier): new stuff
-	m_pBtnClose = (CN3UIButton*)(this->GetChildByID("btn_close"));
-	__ASSERT(m_pBtnClose, "NULL UI Component!!!");
-	//m_pBtnClose->SetVisible(false);
+	// NOTE(srmeier): new stuff:
+	N3_VERIFY_UI_COMPONENT(m_pBtnClose,			(CN3UIButton*) GetChildByID("btn_close"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnUpperEvent,	(CN3UIButton*) GetChildByID("btn_UpperEvent"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnNext,			(CN3UIButton*) GetChildByID("btn_Next"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnOkRight,		(CN3UIButton*) GetChildByID("btn_Ok_right"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnPre,			(CN3UIButton*) GetChildByID("btn_Pre"));
 
-	CN3UIButton* m_pBtnUpperEvent = (CN3UIButton*)(this->GetChildByID("btn_UpperEvent"));
-	if (m_pBtnUpperEvent) {
+	if (m_pBtnUpperEvent != nullptr)
 		m_pBtnUpperEvent->SetVisible(false);
-	}
 
-	CN3UIButton* m_pBtnNext = (CN3UIButton*)(this->GetChildByID("btn_Next"));
-	if (m_pBtnNext) {
+	if (m_pBtnNext != nullptr)
 		m_pBtnNext->SetVisible(false);
-	}
 
-	CN3UIButton* m_pBtnOkRight = (CN3UIButton*)(this->GetChildByID("btn_Ok_right"));
-	if (m_pBtnOkRight) {
+	if (m_pBtnOkRight != nullptr)
 		m_pBtnOkRight->SetVisible(false);
-	}
 
-	CN3UIButton* m_pBtnPre = (CN3UIButton*)(this->GetChildByID("btn_Pre"));
-	if (m_pBtnPre) {
+	if (m_pBtnPre != nullptr)
 		m_pBtnPre->SetVisible(false);
-	}
 
 	return true;
 }
@@ -145,4 +143,19 @@ void CUIQuestTalk::SetVisible(bool bVisible)
 		CGameProcedure::s_pUIMgr->SetVisibleFocusedUI(this);
 	else
 		CGameProcedure::s_pUIMgr->ReFocusUI();//this_ui
+}
+
+void CUIQuestTalk::Release()
+{
+	CN3UIBase::Release();
+
+	m_pTextTalk			= nullptr;
+	m_pBtnOk			= nullptr;
+	m_pBtnClose			= nullptr;
+	m_pBtnUpperEvent	= nullptr;
+	m_pBtnNext			= nullptr;
+	m_pBtnOkRight		= nullptr;
+	m_pBtnPre			= nullptr;
+	m_iNumTalk			= 0;
+	m_iCurTalk			= 0;
 }

--- a/Client/WarFare/UIQuestTalk.h
+++ b/Client/WarFare/UIQuestTalk.h
@@ -19,7 +19,7 @@ class CUIQuestTalk   : public CN3UIBase
 protected:
 	class CN3UIString*		m_pTextTalk;
 	class CN3UIButton*		m_pBtnOk;
-
+	class CN3UIButton*		m_pBtnClose;
 	std::string				m_szTalk[MAX_STRING_TALK];
 	int						m_iNumTalk;
 	int						m_iCurTalk;

--- a/Client/WarFare/UIQuestTalk.h
+++ b/Client/WarFare/UIQuestTalk.h
@@ -17,22 +17,27 @@
 class CUIQuestTalk   : public CN3UIBase
 {
 protected:
-	class CN3UIString*		m_pTextTalk;
-	class CN3UIButton*		m_pBtnOk;
-	class CN3UIButton*		m_pBtnClose;
-	std::string				m_szTalk[MAX_STRING_TALK];
-	int						m_iNumTalk;
-	int						m_iCurTalk;
+	CN3UIString*	m_pTextTalk;
+	CN3UIButton*	m_pBtnOk;
+	CN3UIButton*	m_pBtnClose;
+	CN3UIButton*	m_pBtnUpperEvent;
+	CN3UIButton*	m_pBtnNext;
+	CN3UIButton*	m_pBtnOkRight;
+	CN3UIButton*	m_pBtnPre;
+
+	std::string		m_szTalk[MAX_STRING_TALK];
+	int				m_iNumTalk;
+	int				m_iCurTalk;
 
 public:
-	void SetVisible(bool bVisible);
-	bool OnKeyPress(int iKey);
-	bool Load(HANDLE hFile);
-	bool ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg);
+	void Release() override;
+	void SetVisible(bool bVisible) override;
+	bool OnKeyPress(int iKey) override;
+	bool Load(HANDLE hFile) override;
+	bool ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg) override;
 	void Open(Packet& pkt);
 	CUIQuestTalk();
-	virtual ~CUIQuestTalk();
-
+	~CUIQuestTalk() override;
 };
 
 #endif // !defined(AFX_UIQUESTTALK_H__DB9A4C59_4BE8_4698_9462_CF036C8D834D__INCLUDED_)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Current state : user cannot close NpcTalk menu with close button because close button visibility set as false inside UIQuestTalk.cpp, also it is not initialized and does not define as member.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
m_pBtnClose initialized in constructor, defined in header file and its visibility set as default ( visible ). By this way, button is visible now and user can close NpcTalk menu by clicking the button.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
This change improves user experience, close button should be working, otherwise user is forced to display all of the messages of selected npc.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
