### PR TITLE
cstring conversion to compile uie

### DIFF
--- a/UIE/PropertyView.cpp
+++ b/UIE/PropertyView.cpp
@@ -427,7 +427,7 @@ BOOL CPropertyView::OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult)
 			if (IDOK == dlg.DoModal())
 			{
 				__ASSERT(dlg.GetSize()>0, "font height가 0보다 작습니다.");
-				std::string szFontName = std::string(CT2A(dlg.GetFaceName()));
+				std::string szFontName(CT2A(dlg.GetFaceName()));
 				pUIList->SetFont( szFontName, dlg.GetSize()/10, dlg.IsBold(), dlg.IsItalic());
 				UpdateUIListInfo();	// List 정보 다시 갱신하기
 			}

--- a/UIE/PropertyView.cpp
+++ b/UIE/PropertyView.cpp
@@ -427,7 +427,7 @@ BOOL CPropertyView::OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult)
 			if (IDOK == dlg.DoModal())
 			{
 				__ASSERT(dlg.GetSize()>0, "font height가 0보다 작습니다.");
-				std::string szFontName = dlg.GetFaceName();
+				std::string szFontName = std::string(CT2A(dlg.GetFaceName()));
 				pUIList->SetFont( szFontName, dlg.GetSize()/10, dlg.IsBold(), dlg.IsItalic());
 				UpdateUIListInfo();	// List 정보 다시 갱신하기
 			}

--- a/UIE/UIEDoc.cpp
+++ b/UIE/UIEDoc.cpp
@@ -1028,7 +1028,7 @@ void CUIEDoc::OnFileExport()
 	CFileDialog dlg(FALSE, "uif", NULL, dwFlags, "UI Files(*.uif)|*.uif;||", NULL);
 	if (IDCANCEL == dlg.DoModal()) return;
 
-	std::string szFN = dlg.GetPathName();
+	std::string szFN = std::string(CT2A(dlg.GetPathName()));
 	pUI->SaveToFile(szFN);
 }
 
@@ -1041,7 +1041,7 @@ void CUIEDoc::OnFileImport()
 	CFileDialog dlg(TRUE, "uif", NULL, dwFlags, "UI Files(*.uif)|*.uif;||", NULL);
 	if (IDCANCEL == dlg.DoModal()) return;
 
-	std::string szFN = dlg.GetPathName();
+	std::string szFN = std::string(CT2A(dlg.GetPathName()));
 	pUI->LoadFromFile(szFN);
 }
 
@@ -1094,8 +1094,8 @@ void CUIEDoc::OnBatchToolChangeImagePath()
 	CN3Texture Tex;
 	POSITION pos = dlg.GetStartPosition();
 	CString FileName;
-	std::string szFNOld = dlg2.m_szFN_Old;
-	std::string szFNNew = dlg2.m_szFN_New;
+	std::string szFNOld = std::string(CT2A(dlg2.m_szFN_Old));
+	std::string szFNNew = std::string(CT2A(dlg2.m_szFN_New));
 
 	while(pos != NULL)
 	{

--- a/UIE/UIEDoc.cpp
+++ b/UIE/UIEDoc.cpp
@@ -1028,7 +1028,7 @@ void CUIEDoc::OnFileExport()
 	CFileDialog dlg(FALSE, "uif", NULL, dwFlags, "UI Files(*.uif)|*.uif;||", NULL);
 	if (IDCANCEL == dlg.DoModal()) return;
 
-	std::string szFN = std::string(CT2A(dlg.GetPathName()));
+	std::string szFN(CT2A(dlg.GetPathName()));
 	pUI->SaveToFile(szFN);
 }
 
@@ -1041,7 +1041,7 @@ void CUIEDoc::OnFileImport()
 	CFileDialog dlg(TRUE, "uif", NULL, dwFlags, "UI Files(*.uif)|*.uif;||", NULL);
 	if (IDCANCEL == dlg.DoModal()) return;
 
-	std::string szFN = std::string(CT2A(dlg.GetPathName()));
+	std::string szFN(CT2A(dlg.GetPathName()));
 	pUI->LoadFromFile(szFN);
 }
 
@@ -1094,8 +1094,8 @@ void CUIEDoc::OnBatchToolChangeImagePath()
 	CN3Texture Tex;
 	POSITION pos = dlg.GetStartPosition();
 	CString FileName;
-	std::string szFNOld = std::string(CT2A(dlg2.m_szFN_Old));
-	std::string szFNNew = std::string(CT2A(dlg2.m_szFN_New));
+	std::string szFNOld(CT2A(dlg2.m_szFN_Old));
+	std::string szFNNew(CT2A(dlg2.m_szFN_New));
 
 	while(pos != NULL)
 	{


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
project is set multibyte at start (although it is not stated in project file). CString to std::string conversion is not done and so project does not compile.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Project compiles and opens.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
