### PR TITLE
n3tool save function rework

### DIFF
--- a/Client/N3Base/N3UIBase.cpp
+++ b/Client/N3Base/N3UIBase.cpp
@@ -676,7 +676,25 @@ bool CN3UIBase::Save(HANDLE hFile)
 
 	// child 정보
 	int iCC = m_Children.size();
-	WriteFile(hFile, &iCC, sizeof(iCC), &dwRWC, NULL); // Child 갯수 ㅆ고..고..
+
+	if (m_iFileFormatVersion >= N3FORMAT_VER_1264)
+	{
+		TRACE("version bigger or equal \n");
+		int16_t sCC = static_cast<int16_t>(iCC);
+		TRACE("sCC %d\n", sCC);
+		int16_t sIdk0 = 1; // unknown
+		TRACE("sIdk0 %d\n", sIdk0);
+
+		WriteFile(hFile, &sCC, sizeof(int16_t), &dwRWC, NULL); // children count
+		WriteFile(hFile, &sIdk0, sizeof(int16_t), &dwRWC, NULL); //unknown
+	}
+	else
+	{
+		WriteFile(hFile, &iCC, sizeof(iCC), &dwRWC, NULL);
+	}
+
+	//WriteFile(hFile, &iCC, sizeof(iCC), &dwRWC, NULL); // Child 갯수 ㅆ고..고..
+
 	for(UIListReverseItor itor = m_Children.rbegin(); m_Children.rend() != itor; ++itor)
 	// childadd할때 push_front이므로 저장할 때 거꾸로 저장해야 한다.
 	{
@@ -685,6 +703,13 @@ bool CN3UIBase::Save(HANDLE hFile)
 
 		WriteFile(hFile, &eUIType, sizeof(eUIType), &dwRWC, NULL); // UI Type 쓰고..
 		pChild->Save(hFile);
+
+		if (eUIType == UI_TYPE_STRING)
+		{
+			char padding[4] = { 0, 0, 0, 0 };
+			WriteFile(hFile, padding, 4, &dwRWC, NULL);
+		}
+
 	}
 
 	// base 정보


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
saved file with uie does not open by game because it does not support new versions. New version adds "00 00 00 00" padding after each string can be seen by checking current uif files of game with HxD editor. 

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Padding after each string also added so saved file can be opened by game.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
crucial to change UI bugs. ( for example scrollbar ID is forgotten to be set in ui file of CMDList ) 

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->
![ui_save_1](https://github.com/user-attachments/assets/dd53e60a-13c6-41e2-845d-f526aab65424)



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
