### PR TITLE
Add build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Build client and server
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  workflow_dispatch:
+    
+env:
+  # We use a debug build for slightly faster build times
+  BUILD_CONFIGURATION: Debug
+  BUILD_PLATFORM: Win32
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Build client
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Client.sln
+
+    - name: Build server
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" Server.sln

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
     - master
+  merge_group:
   workflow_dispatch:
     
 env:

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -1,0 +1,58 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Build tools
+
+on:
+  schedule:
+    - cron: "0 0 * * 0" # once a week every Sunday at midnight
+  workflow_dispatch:
+    
+env:
+  # We use a debug build for slightly faster build times
+  BUILD_CONFIGURATION: Debug
+  BUILD_PLATFORM: x86
+
+# These should really be moved into the one solution.
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Build N3CE
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" N3CE\N3CE.sln
+
+    - name: Build N3FXE
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" N3FXE\N3FXE.sln
+
+    - name: Build N3ME
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" N3ME\N3ME.sln
+
+    - name: Build N3TexViewer
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" N3TexViewer\N3TexViewer.sln
+
+    - name: Build N3Viewer
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" N3Viewer\N3Viewer.sln
+
+    - name: Build SkyViewer
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" SkyViewer\SkyViewer.sln
+
+    - name: Build TblEditor
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" TblEditor\TblEditor.sln
+
+    - name: Build UIE
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" UIE\UIE.sln

--- a/Client/N3Base/N3Base.vcxproj
+++ b/Client/N3Base/N3Base.vcxproj
@@ -363,7 +363,11 @@ if "%GitDir%"=="" (
 )
 
 :init_and_update_submodules
-"%GitDir%git.exe" submodule update --init --recursive
+if "$(NO_CLIENT_ASSETS)"=="1" (
+	"%GitDir%git.exe" submodule update --init --recursive --remote ../../deps/dx9sdk
+) else (
+	"%GitDir%git.exe" submodule update --init --recursive
+)
       </Command>
     </PreBuildEvent>
     <ClCompile>


### PR DESCRIPTION
* Add build.yml for basic client & server build (manually, on PR to master & on push to master)

* Add build_tools.yml for the various tools (manually, and weekly every Sunday at midnight)

The client & server build is already time consuming at ~3min+, so we'll keep the tool builds (which don't currently all build anyway) separate.

It may not necessarily be worth keeping the server build either, since most of the changes will rely on the client.

We may want to use labels as triggers to denote which actually needs building, although when multiple do, doing it this way will cause it to use the maximum amount of time rather than sharing the existing libs.

See #229 