### PR TITLE
Tidy up setup and submodule behaviour

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,15 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Build client
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Client.sln
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" Client.sln
 
     - name: Build server
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -21,38 +21,40 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Build N3CE
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" N3CE\N3CE.sln
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" N3CE\N3CE.sln
 
     - name: Build N3FXE
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" N3FXE\N3FXE.sln
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" N3FXE\N3FXE.sln
 
     - name: Build N3ME
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" N3ME\N3ME.sln
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" N3ME\N3ME.sln
 
     - name: Build N3TexViewer
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" N3TexViewer\N3TexViewer.sln
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" N3TexViewer\N3TexViewer.sln
 
     - name: Build N3Viewer
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" N3Viewer\N3Viewer.sln
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" N3Viewer\N3Viewer.sln
 
     - name: Build SkyViewer
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" SkyViewer\SkyViewer.sln
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" SkyViewer\SkyViewer.sln
 
     - name: Build TblEditor
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" TblEditor\TblEditor.sln
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" TblEditor\TblEditor.sln
 
     - name: Build UIE
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" UIE\UIE.sln
+      run: msbuild /p:Configuration="${{env.BUILD_CONFIGURATION}}" /p:Platform="${{env.BUILD_PLATFORM}}" UIE\UIE.sln

--- a/Client/N3Base/N3Base.vcxproj
+++ b/Client/N3Base/N3Base.vcxproj
@@ -338,38 +338,6 @@
     <TargetName>$(ProjectName)_tool</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>
-    <PreBuildEvent>
-      <Command>set "GitDir="
-where /q git
-if not errorlevel 1 (goto init_and_update_submodules)
-
-set GithubDir=%LOCALAPPDATA%\GitHubDesktop
-set "LocalGithubGitDir32=resources\app\git\mingw32\bin\"
-set "LocalGithubGitDir64=resources\app\git\mingw64\bin\"
-for /f "delims=" %%a in ('dir /b /ad /oN "%GithubDir%\app-*"') do (
-	if exist "%GithubDir%\%%a\%LocalGithubGitDir64%git.exe" (
-		set "GitDir=%GithubDir%\%%a\%LocalGithubGitDir64%"
-	) else (
-		if exist "%GithubDir%\%%a\%LocalGithubGitDir32%git.exe" (
-			set "GitDir=%GithubDir%\%%a\%LocalGithubGitDir32%"
-		)
-	)
-)
-
-if "%GitDir%"=="" (
-	ECHO Failed to update submodules: git.exe not found.
-	ECHO Ensure that git is installed and placed in your PATH environment variable.
-	EXIT /B
-)
-
-:init_and_update_submodules
-if "$(NO_CLIENT_ASSETS)"=="1" (
-	"%GitDir%git.exe" submodule update --init --recursive --remote ../../deps/dx9sdk
-) else (
-	"%GitDir%git.exe" submodule update --init --recursive
-)
-      </Command>
-    </PreBuildEvent>
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,74 @@
 # Open Knight Online (OpenKO)
 
-<p align="left">
 We started this project to learn more about how the MMORPG Knight Online works. MMORPGs are very intricate programs requiring knowledge in many areas of computer science such as TCP/IP, SQL server, performance tuning, 3D graphics and animation, load balancing, and more. Starting with the original leaked source we have updated to DirectX 9, added function flags so that various file formats may be supported while remaining backwards compatible, and much much more.
-</p>
 
-<p align="left">
 This code is for academic purposes only! If you have questions, or would like help getting started, feel free visit the <a href="http://ko4life.net/topic/50-the-openko-project/" target="_blank">forums</a>.
-</p>
+
+## Prerequisites
+
+### Visual Studio 2022
+
+You will also need the following components installed, which can be installed from within Visual Studio via:
+ * `Tools`
+ * `Get Tools and Features...`
+ * `Individual Components`.
+ 
+Use the search field to find them from there.
+
+#### Components to install:
+ * C++ ATL for latest v143 build tools (x86 & x64)
+ * C++ MFC for latest v143 build tools (x86 & x64)
+ * MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest) 
+
+### Microsoft SQL Server Express/Developer
+
+Along with its accompanying SQL Server Management Studio.
+
+Additionally, you will need to download and restore the database over on our <a href="http://ko4life.net/topic/50-the-openko-project/" target="_blank">ko4life thread</a>, which restores fine as of Microsoft SQL Server 2022.
+
+### Git or Github Desktop
+
+This is a personal preference.
+
+You can find Git for Windows here:
+https://git-scm.com/downloads/win
+
+Or Github Desktop here:
+https://desktop.github.com/download/
+
+## Getting started
+
+### Clone our repository
+
+```
+git clone https://github.com/Open-KO/KnightOnline.git
+```
+
+If using Github Desktop, you can instead clone via `File` -> `Clone repository...` -> `URL` and then paste in our URL:
+```
+https://github.com/Open-KO/KnightOnline.git
+```
+
+### Initialise our submodules
+ 
+You can double-click `update_submodules.cmd` in the root directory to automatically initialise and update all of our submodules.
+
+Alternatively, you can update them manually via:
+```
+git submodule update --init --recursive
+```
+
+### Run the solution
+
+Solutions are available in the root directory:
+
+Currently we have:
+* `Client.sln` - for just the client project and its dependencies.
+* `Server.sln` - for just the server projects and their dependencies.
+* `All.sln` - intended to house all of the various solutions, although at the current time we do not include most of the tools (these are instead found in their respective folders).
 
 ## Goals
 
-<p align="left">
 At this early stage in development, the goal of this project is to replicate official client functionality while preserving accuracy and compatibility with the official client and server.
 This allows us to be able to side-by-side the client/server for testing purposes.
 
@@ -20,27 +78,19 @@ We may deviate in some minor aspects where it makes sense to fix, for example, U
 
 Pull requests for such changes will be accepted on a case-by-case basis.
 
-As a hard-and-fast rule, this means we <b>DO NOT</b> change client assets or network protocol.
+As a hard-and-fast rule, this means we **DO NOT** change client assets or network protocol.
 
-The client <b>MUST</b> remain compatible with the official client and the official server.
+The client **MUST** remain compatible with the official client and the official server.
 
 Late in development when side-by-side development is rarely necessary, it will make sense to start deviating from official behaviour for improvements and custom features.
 At such time, we will welcome such changes, but doing so this early just creates incompatibilities (making it harder to test them side-by-side) and unnecessarily diverts
 attention when there's so much official behaviour/features still to implement, update and fix.
-</p>
 
-## Build notes:
-* All projects currently require Visual Studio 2022
-* This should be done for you when building, but if you're experiencing errors building DirectX, make sure that you initialise and fetch all dependencies after cloning:
-```
-git submodule update --init --recursive
-``` 
+## Intentional design decisions
 
-## Intentional design decisions:
 * _The project is currently focused around supporting the 1298/9 version of the game_. Version 1298/9 has most of the core functionality attributed to the game’s success. By ignoring later versions of the game we keep the system relatively simplistic. This allows us to strengthen the fundamental components of the game while minimizing the amount of reverse engineering necessary to make things work.
-* _We stick to the 1298/9 database schema_. To ensure compatibility with the 1298/9 version of the game we do not modify the basic database schema. This means the structure of the database and how information is stored in the database doesn’t change while we are working. This could change once the core functionality of the 1298/9 is in place.
 
-<br>
+* _We stick to the 1298/9 database schema_. To ensure compatibility with the 1298/9 version of the game we do not modify the basic database schema. This means the structure of the database and how information is stored in the database doesn’t change while we are working. This could change once the core functionality of the 1298/9 is in place.
 
 <p align="center">
 	<img src="https://github.com/Open-KO/KnightOnline/blob/master/openko_example.png?raw=true" />

--- a/update_submodules.cmd
+++ b/update_submodules.cmd
@@ -1,0 +1,46 @@
+@echo off
+
+ECHO.
+ECHO ** OpenKO repository setup **
+ECHO.
+ECHO Preparing to initialise and update submodules
+ECHO Finding git.exe...
+
+set "GitDir="
+where /q git
+if not errorlevel 1 (
+ 	ECHO Found git.exe in PATH
+ 	goto init_and_update_submodules
+)
+
+ECHO git.exe not found in PATH, checking for GitHub Desktop directories...
+
+set GithubDir=%LOCALAPPDATA%\GitHubDesktop
+set "LocalGithubGitDir32=resources\app\git\mingw32\bin\"
+set "LocalGithubGitDir64=resources\app\git\mingw64\bin\"
+for /f "delims=" %%a in ('dir /b /ad /oN "%GithubDir%\app-*"') do (
+	if exist "%GithubDir%\%%a\%LocalGithubGitDir64%git.exe" (
+		set "GitDir=%GithubDir%\%%a\%LocalGithubGitDir64%"
+	) else (
+		if exist "%GithubDir%\%%a\%LocalGithubGitDir32%git.exe" (
+			set "GitDir=%GithubDir%\%%a\%LocalGithubGitDir32%"
+		)
+	)
+)
+
+if "%GitDir%"=="" (
+	ECHO Failed to update submodules: git.exe not found.
+	ECHO Ensure that git is installed and placed in your PATH environment variable.
+	PAUSE
+	EXIT /B
+)
+
+ECHO Found git.exe in GitHub Desktop directory (%GitDir%)
+
+:init_and_update_submodules
+ECHO Initialising and updating submodules...
+"%GitDir%git.exe" submodule update --init --recursive
+
+ECHO.
+ECHO All done! You can close this window now.
+PAUSE


### PR DESCRIPTION
 * Take auto-submodule initialisation out of the project

   This was never ideal but was for simplicity, to avoid other people having to remember to do this. Instead, we move this to update_submodules.cmd in the root directory and update readme.md to explain running this on a new setup.

 * Update the build workflows to fetch submodules themselves and drop the override

   This is also not perfectly ideal, bout actions/checkout doesn't allow for excluding (or including) specific submodules. The only reason I didn't bother to have it just fetch everything was because of ko-client-assets; which is quite large, and unnecessary for it to fetch.

   Doing this, however, is in reality fairly instantaneous so it's probably not worth the effort.

 * Tidy up the readme in general to move the prerequisite and setup information towards the top, and clarify what's actually needed.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?

Currently, every build that invokes N3Base fetches and updates submodules.

## What is the new behaviour?

We just require new users to read the instructions in `readme.md` and run `setup_submodules.cmd` manually instead of having it automatically invoke on appropriate build.

## Why and how did I change this?

Fetching it automatically on appropriate builds is a little bit convenient for general use, but very inconvenient when specifically modifying these submodules, and just not good practice in general.

The entire point of the original implementation was to avoid people being confused with the DirectX setup, thinking they needed to modify the project paths for it, etc. Throwing it in the builds automatically meant they never really got a chance to see that.

But with proper documentation this shouldn't really be an issue in the first place. Better to keep this stuff aside.
This also better allows us a place for future setup.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
