### PR TITLE
weight bug fix

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -1848,8 +1848,8 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 	s_pPlayer->m_InfoBase.iHP = pkt.read<int16_t>(); 
 	s_pPlayer->m_InfoExt.iMSPMax = pkt.read<int16_t>();
 	s_pPlayer->m_InfoExt.iMSP = pkt.read<int16_t>();
-	s_pPlayer->m_InfoExt.iWeightMax = pkt.read<int16_t>(); 
-	s_pPlayer->m_InfoExt.iWeight = pkt.read<int16_t>(); 
+	s_pPlayer->m_InfoExt.iWeightMax = static_cast<int>(pkt.read<uint16_t>());
+	s_pPlayer->m_InfoExt.iWeight = static_cast<int>(pkt.read<uint16_t>());
 
 	s_pPlayer->m_InfoExt.iStrength = pkt.read<uint8_t>();
 	s_pPlayer->m_InfoExt.iStrength_Delta = pkt.read<uint8_t>();
@@ -3299,7 +3299,7 @@ bool CGameProcMain::MsgRecv_ItemMove(Packet& pkt)
 	{
 		pInfoExt->iAttack = pkt.read<int16_t>();
 		pInfoExt->iGuard =	pkt.read<int16_t>();
-		pInfoExt->iWeightMax = pkt.read<int16_t>();
+		pInfoExt->iWeightMax = static_cast<int>(pkt.read<uint16_t>());
 		
 		pInfoBase->iHPMax = pkt.read<int16_t>();
 		pInfoExt->iMSPMax = pkt.read<int16_t>();
@@ -3655,8 +3655,8 @@ bool CGameProcMain::MsgRecv_MyInfo_LevelChange(Packet& pkt)
 		pInfoExt->iMSPMax		= pkt.read<int16_t>();
 		pInfoExt->iMSP			= pkt.read<int16_t>();
 
-		pInfoExt->iWeightMax	= pkt.read<int16_t>();
-		pInfoExt->iWeight		= pkt.read<int16_t>();
+		pInfoExt->iWeightMax	= static_cast<int>(pkt.read<uint16_t>());
+		pInfoExt->iWeight		= static_cast<int>(pkt.read<uint16_t>());
 
 		m_pUIVar->UpdateAllStates(&(s_pPlayer->m_InfoBase), &(s_pPlayer->m_InfoExt)); // 모든 정보 업데이트..
 
@@ -3745,7 +3745,7 @@ void CGameProcMain::MsgRecv_MyInfo_PointChange(Packet& pkt)
 	s_pPlayer->m_InfoBase.iHPMax =		pkt.read<int16_t>();
 	s_pPlayer->m_InfoExt.iMSPMax =		pkt.read<int16_t>();
 	s_pPlayer->m_InfoExt.iAttack =		pkt.read<int16_t>();
-	s_pPlayer->m_InfoExt.iWeightMax =	pkt.read<int16_t>();
+	s_pPlayer->m_InfoExt.iWeightMax =	static_cast<int>(pkt.read<uint16_t>());
 
 	m_pUIVar->m_pPageState->UpdateHP(s_pPlayer->m_InfoBase.iHP, s_pPlayer->m_InfoBase.iHPMax);
 	m_pUIStateBarAndMiniMap->UpdateHP(s_pPlayer->m_InfoBase.iHP, s_pPlayer->m_InfoBase.iHPMax, false);
@@ -6520,7 +6520,7 @@ void CGameProcMain::MsgRecv_AllPointInit(Packet& pkt)			// All Point 초기화..
 			s_pPlayer->m_InfoBase.iHPMax =		pkt.read<int16_t>();
 			s_pPlayer->m_InfoExt.iMSPMax =		pkt.read<int16_t>();
 			s_pPlayer->m_InfoExt.iAttack =		pkt.read<int16_t>();
-			s_pPlayer->m_InfoExt.iWeightMax =	pkt.read<int16_t>();
+			s_pPlayer->m_InfoExt.iWeightMax		= static_cast<int>(pkt.read<uint16_t>());
 
 			m_pUIVar->m_pPageState->UpdateHP(s_pPlayer->m_InfoBase.iHP, s_pPlayer->m_InfoBase.iHPMax);
 			m_pUIStateBarAndMiniMap->UpdateHP(s_pPlayer->m_InfoBase.iHP, s_pPlayer->m_InfoBase.iHPMax, false);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
weight info sent as uint16_t from server but read as int16_t at client. Therefore, overflow happens when the user have higher numbers than 3276,7 ( 32767 int16_t max) . 

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
static cast to int after reading as uint16_t so it does not overflow anymore.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
For a high level character with maxed STR, game is unplayable. Because of this bug, user cannot buy / trade items.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
