### PR TITLE
weight text update while trading with NPC

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -3357,6 +3357,8 @@ bool CGameProcMain::MsgRecv_ItemWeightChange(Packet& pkt)		// 아이템 무게 �
 	pInfoExt->iWeight = pkt.read<int16_t>();
 	m_pUIVar->m_pPageState->UpdateWeight(pInfoExt->iWeight, pInfoExt->iWeightMax);
 
+	m_pUITransactionDlg->UpdateWeight(pInfoExt->iWeight, pInfoExt->iWeightMax);
+
 	return true;
 }
 
@@ -4318,6 +4320,10 @@ void CGameProcMain::DoCommercialTransaction(int iTradeID)
 		m_pUISkillTreeDlg->Close();
 
 	m_pUITransactionDlg->EnterTransactionState();
+
+	__InfoPlayerMySelf* pInfoExt = &(s_pPlayer->m_InfoExt);
+	if(pInfoExt != nullptr)
+	m_pUITransactionDlg->UpdateWeight(pInfoExt->iWeight, pInfoExt->iWeightMax);
 }
 
 bool CGameProcMain::MsgRecv_ItemTradeStart(Packet& pkt)			// 아이템 상거래..

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -3353,11 +3353,9 @@ bool CGameProcMain::MsgRecv_ItemMove(Packet& pkt)
 
 bool CGameProcMain::MsgRecv_ItemWeightChange(Packet& pkt)		// 아이템 무게 변화..
 {
-	__InfoPlayerMySelf* pInfoExt = &(s_pPlayer->m_InfoExt);
+	__InfoPlayerMySelf* pInfoExt = &s_pPlayer->m_InfoExt;
 	pInfoExt->iWeight = pkt.read<int16_t>();
 	m_pUIVar->m_pPageState->UpdateWeight(pInfoExt->iWeight, pInfoExt->iWeightMax);
-
-	m_pUITransactionDlg->UpdateWeight(pInfoExt->iWeight, pInfoExt->iWeightMax);
 
 	return true;
 }
@@ -4320,10 +4318,6 @@ void CGameProcMain::DoCommercialTransaction(int iTradeID)
 		m_pUISkillTreeDlg->Close();
 
 	m_pUITransactionDlg->EnterTransactionState();
-
-	__InfoPlayerMySelf* pInfoExt = &(s_pPlayer->m_InfoExt);
-	if(pInfoExt != nullptr)
-	m_pUITransactionDlg->UpdateWeight(pInfoExt->iWeight, pInfoExt->iWeightMax);
 }
 
 bool CGameProcMain::MsgRecv_ItemTradeStart(Packet& pkt)			// 아이템 상거래..

--- a/Client/WarFare/UITransactionDlg.cpp
+++ b/Client/WarFare/UITransactionDlg.cpp
@@ -365,8 +365,7 @@ void CUITransactionDlg::EnterTransactionState()
 	}
 
 	ItemMoveFromInvToThis();
-	
-	UpdateWeight();
+
 
 	if(m_pStrMyGold)
 	{
@@ -386,26 +385,20 @@ void CUITransactionDlg::EnterTransactionState()
 	}
 }
 
-void CUITransactionDlg::UpdateWeight()
+void CUITransactionDlg::UpdateWeight(int iVal, int iValMax)
 {
 	if (m_pText_Weight == nullptr)
 		return;
 
-	__InfoPlayerMySelf* pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
-	
-	if (pInfoExt == nullptr)
-		return;
-
 	char szVal[64] = "0 / 0";
-
-	sprintf(szVal, "%.1f/%.1f", (pInfoExt->iWeight * 0.1f), (pInfoExt->iWeightMax * 0.1f));
+	sprintf(szVal, "%.1f/%.1f", (iVal * 0.1f), (iValMax * 0.1f));
 
 	std::string szMsg;
 	CGameBase::GetTextF(IDS_INVEN_WEIGHT, &szMsg);
 
-	std::string strWeight = szMsg + szVal;
-
-	m_pText_Weight->SetString(strWeight);
+	std::string str = szMsg + szVal;
+	
+	m_pText_Weight->SetString(str);
 
 }
 
@@ -1218,9 +1211,6 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(byte bResult, byte bType, i
 				__ASSERT(pStatic, "NULL UI Component!!");
 				if(pStatic)	pStatic->SetStringAsInt(pInfoExt->iGold);
 				if(m_pStrMyGold)	m_pStrMyGold->SetStringAsInt(pInfoExt->iGold); // 상거래창..
-
-				//update weight
-				UpdateWeight();
 			}
 			
 			CN3UIWndBase::AllHighLightIconFree();
@@ -1289,8 +1279,6 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(byte bResult, byte bType, i
 				__ASSERT(pStatic, "NULL UI Component!!");
 				if(pStatic)	pStatic->SetStringAsInt(pInfoExt->iGold);
 				if(m_pStrMyGold) m_pStrMyGold->SetStringAsInt(pInfoExt->iGold); // 상거래창..
-
-				UpdateWeight();
 			}
 
 			CN3UIWndBase::AllHighLightIconFree();

--- a/Client/WarFare/UITransactionDlg.cpp
+++ b/Client/WarFare/UITransactionDlg.cpp
@@ -53,6 +53,7 @@ CUITransactionDlg::CUITransactionDlg()
 	m_pUIInn		= NULL;
 	m_pUIBlackSmith	= NULL;
 	m_pUIStore		= NULL;
+	m_pText_Weight = nullptr;
 
 	this->SetVisible(false);
 }
@@ -187,6 +188,7 @@ void CUITransactionDlg::InitIconWnd(e_UIWND eWnd)
 	m_pUIInn		= (CN3UIImage*)GetChildByID("img_inn");			__ASSERT(m_pUIInn, "NULL UI Component!!");
 	m_pUIBlackSmith = (CN3UIImage*)GetChildByID("img_blacksmith");	__ASSERT(m_pUIBlackSmith, "NULL UI Component!!");
 	m_pUIStore		= (CN3UIImage*)GetChildByID("img_store");		__ASSERT(m_pUIStore, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_Weight, (CN3UIString*) GetChildByID("text_weight"));
 }
 
 void CUITransactionDlg::InitIconUpdate()
@@ -363,6 +365,8 @@ void CUITransactionDlg::EnterTransactionState()
 	}
 
 	ItemMoveFromInvToThis();
+	
+	UpdateWeight();
 
 	if(m_pStrMyGold)
 	{
@@ -380,6 +384,29 @@ void CUITransactionDlg::EnterTransactionState()
 			ShowTitle(UI_STORE);
 			break;
 	}
+}
+
+void CUITransactionDlg::UpdateWeight()
+{
+	if (m_pText_Weight == nullptr)
+		return;
+
+	__InfoPlayerMySelf* pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
+	
+	if (pInfoExt == nullptr)
+		return;
+
+	char szVal[64] = "0 / 0";
+
+	sprintf(szVal, "%.1f/%.1f", (pInfoExt->iWeight * 0.1f), (pInfoExt->iWeightMax * 0.1f));
+
+	std::string szMsg;
+	CGameBase::GetTextF(IDS_INVEN_WEIGHT, &szMsg);
+
+	std::string strWeight = szMsg + szVal;
+
+	m_pText_Weight->SetString(strWeight);
+
 }
 
 void CUITransactionDlg::GoldUpdate()
@@ -1191,6 +1218,9 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(byte bResult, byte bType, i
 				__ASSERT(pStatic, "NULL UI Component!!");
 				if(pStatic)	pStatic->SetStringAsInt(pInfoExt->iGold);
 				if(m_pStrMyGold)	m_pStrMyGold->SetStringAsInt(pInfoExt->iGold); // 상거래창..
+
+				//update weight
+				UpdateWeight();
 			}
 			
 			CN3UIWndBase::AllHighLightIconFree();
@@ -1259,6 +1289,8 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(byte bResult, byte bType, i
 				__ASSERT(pStatic, "NULL UI Component!!");
 				if(pStatic)	pStatic->SetStringAsInt(pInfoExt->iGold);
 				if(m_pStrMyGold) m_pStrMyGold->SetStringAsInt(pInfoExt->iGold); // 상거래창..
+
+				UpdateWeight();
 			}
 
 			CN3UIWndBase::AllHighLightIconFree();

--- a/Client/WarFare/UITransactionDlg.cpp
+++ b/Client/WarFare/UITransactionDlg.cpp
@@ -385,21 +385,10 @@ void CUITransactionDlg::EnterTransactionState()
 	}
 }
 
-void CUITransactionDlg::UpdateWeight(int iVal, int iValMax)
+void CUITransactionDlg::UpdateWeight(const std::string& szWeight)
 {
-	if (m_pText_Weight == nullptr)
-		return;
-
-	char szVal[64] = "0 / 0";
-	sprintf(szVal, "%.1f/%.1f", (iVal * 0.1f), (iValMax * 0.1f));
-
-	std::string szMsg;
-	CGameBase::GetTextF(IDS_INVEN_WEIGHT, &szMsg);
-
-	std::string str = szMsg + szVal;
-	
-	m_pText_Weight->SetString(str);
-
+	if (m_pText_Weight != nullptr)
+		m_pText_Weight->SetString(szWeight);
 }
 
 void CUITransactionDlg::GoldUpdate()

--- a/Client/WarFare/UITransactionDlg.h
+++ b/Client/WarFare/UITransactionDlg.h
@@ -111,7 +111,7 @@ public:
 	void				ShowTitle(e_NpcTrade eNT);
 
 	void				GoldUpdate();
-	void				UpdateWeight();
+	void				UpdateWeight(int iVal, int iValMax);
 };
 
 #endif // !defined(AFX_UITRANSACTIONDLG_H__42671245_FF4F_42FC_AF7B_DACEDA8734B7__INCLUDED_)

--- a/Client/WarFare/UITransactionDlg.h
+++ b/Client/WarFare/UITransactionDlg.h
@@ -111,7 +111,7 @@ public:
 	void				ShowTitle(e_NpcTrade eNT);
 
 	void				GoldUpdate();
-	void				UpdateWeight(int iVal, int iValMax);
+	void				UpdateWeight(const std::string& szWeight);
 };
 
 #endif // !defined(AFX_UITRANSACTIONDLG_H__42671245_FF4F_42FC_AF7B_DACEDA8734B7__INCLUDED_)

--- a/Client/WarFare/UITransactionDlg.h
+++ b/Client/WarFare/UITransactionDlg.h
@@ -32,6 +32,7 @@ public:
 	__IconItemSkill*		m_pMyTrade[MAX_ITEM_TRADE_PAGE][MAX_ITEM_TRADE];
 	__IconItemSkill*		m_pMyTradeInv[MAX_ITEM_INVENTORY];
 	CN3UIString*			m_pStrMyGold;
+	CN3UIString*			m_pText_Weight;
 
 	int						m_iCurPage;
 	int						m_iTradeID;
@@ -110,6 +111,7 @@ public:
 	void				ShowTitle(e_NpcTrade eNT);
 
 	void				GoldUpdate();
+	void				UpdateWeight();
 };
 
 #endif // !defined(AFX_UITRANSACTIONDLG_H__42671245_FF4F_42FC_AF7B_DACEDA8734B7__INCLUDED_)

--- a/Client/WarFare/UIVarious.cpp
+++ b/Client/WarFare/UIVarious.cpp
@@ -5,6 +5,7 @@
 #include "stdafx.h"
 #include "resource.h"
 #include "UIVarious.h"
+#include "UITransactionDlg.h"
 #include "GameProcMain.h"
 #include "PlayerMySelf.h"
 #include "PlayerOtherMgr.h"
@@ -277,7 +278,8 @@ void CUIState::UpdateGuardPoint(int iVal, int iDelta)
 
 void CUIState::UpdateWeight(int iVal, int iValMax)
 {
-	if(NULL == m_pText_Weight) return;
+	if (m_pText_Weight == nullptr)
+		return;
 
 	char szVal[64] = "0 / 0";
 	sprintf(szVal, "%.1f/%.1f", (iVal * 0.1f), (iValMax * 0.1f));
@@ -289,8 +291,12 @@ void CUIState::UpdateWeight(int iVal, int iValMax)
 	std::string str = szMsg + szVal;
 
 	CUIInventory* pInv = CGameProcedure::s_pProcMain->m_pUIInventory;
-	if (pInv)
+	if (pInv != nullptr)
 		pInv->UpdateWeight(str);
+
+	CUITransactionDlg* pUITransactionDlg = CGameProcedure::s_pProcMain->m_pUITransactionDlg;
+	if (pUITransactionDlg != nullptr)
+		pUITransactionDlg->UpdateWeight(str);
 }
 
 void CUIState::UpdateStrength(int iVal, int iDelta)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature


## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
weight text is not used although it presents on uif file. User cannot see weight change on the state of trading with NPC.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
weight is updated after trade, and text is visible on ui.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
it was missing core feature

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
