### PR TITLE
replace formatnumber function inside gamebase

### DIFF
--- a/Client/WarFare/GameBase.cpp
+++ b/Client/WarFare/GameBase.cpp
@@ -604,3 +604,25 @@ CPlayerBase* CGameBase::CharacterGetByID(int iID, bool bFromAlive)
 	return s_pOPMgr->CharacterGetByID(iID, bFromAlive);
 }
 
+std::string CGameBase::FormatNumber(int iNumber)
+{
+	char szBuff[32] = "";
+	sprintf(szBuff, "%d", iNumber);
+
+	int iBuffLength = strlen(szBuff);
+	int iNumberLength = iBuffLength + (iBuffLength / 3) - (iBuffLength % 3 == 0 ? 1 : 0);
+
+	std::string szNumber(iNumberLength, '\0');
+
+	for (int i = iBuffLength - 1, k = iNumberLength - 1; i >= 0; i--, k--)
+	{
+		//change separator with respect to language tail
+		if ((iBuffLength - 1 - i) % 3 == 0 && (iBuffLength - 1 != i))
+			szNumber[k--] = ',';
+
+		szNumber[k] = szBuff[i];
+	}
+
+	return szNumber;
+}
+

--- a/Client/WarFare/GameBase.cpp
+++ b/Client/WarFare/GameBase.cpp
@@ -606,23 +606,38 @@ CPlayerBase* CGameBase::CharacterGetByID(int iID, bool bFromAlive)
 
 std::string CGameBase::FormatNumber(int iNumber)
 {
-	char szBuff[32] = "";
-	sprintf(szBuff, "%d", iNumber);
+	// Original unformatted number in string form
+	const std::string szOrigNum = std::to_string(iNumber);
 
-	int iBuffLength = strlen(szBuff);
-	int iNumberLength = iBuffLength + (iBuffLength / 3) - (iBuffLength % 3 == 0 ? 1 : 0);
+	// Where the digits actually start - if it has a sign, this will be at 1.
+	// Otherwise, it will start at 0.
+	size_t nDigitStart = (iNumber < 0 ? 1 : 0);
 
-	std::string szNumber(iNumberLength, '\0');
+	// Full number of digits (excluding the sign).
+	size_t nDigitCount = szOrigNum.size() - nDigitStart;
 
-	for (int i = iBuffLength - 1, k = iNumberLength - 1; i >= 0; i--, k--)
+	// Number of commas that will be generated.
+	size_t nCommaCount = (nDigitCount - 1) / 3;
+
+	// Number of leading digits. 
+	size_t nLeadingDigits = nDigitCount % 3;
+	if (nLeadingDigits == 0)
+		nLeadingDigits = 3;
+
+	// Pre-reserve the buffer for us to append to.
+	std::string szFormattedNum;
+	szFormattedNum.reserve(szOrigNum.size() + nCommaCount);
+
+	// Append sign (if applicable) and variable number of leading digits.
+	size_t nStartPos = nDigitStart + nLeadingDigits;
+	szFormattedNum.append(szOrigNum, 0, nStartPos);
+
+	// The remaining groups of 3 are guaranteed, so we can append them in their full 3s.
+	for (size_t i = nStartPos; i < szOrigNum.size(); i += 3)
 	{
-		//change separator with respect to language tail
-		if ((iBuffLength - 1 - i) % 3 == 0 && (iBuffLength - 1 != i))
-			szNumber[k--] = ',';
-
-		szNumber[k] = szBuff[i];
+		szFormattedNum += ',';
+		szFormattedNum.append(szOrigNum, i, 3);
 	}
 
-	return szNumber;
+	return szFormattedNum;
 }
-

--- a/Client/WarFare/GameBase.h
+++ b/Client/WarFare/GameBase.h
@@ -50,7 +50,8 @@ public:
 
 	class CPlayerBase*	CharacterGetByID(int iID, bool bFromAlive);
 	bool				IsValidCharacter(CPlayerBase* pCharacter);
-	
+	static std::string FormatNumber(int iNumber);
+
 	CGameBase();
 	virtual ~CGameBase();
 };

--- a/Client/WarFare/UIInventory.cpp
+++ b/Client/WarFare/UIInventory.cpp
@@ -193,27 +193,15 @@ void CUIInventory::Open(e_InvenState eIS)
 
 void CUIInventory::GoldUpdate()
 {
-	CN3UIString* pStatic = (CN3UIString* )GetChildByID("text_gold"); __ASSERT(pStatic, "NULL UI Component!!");
-	if(pStatic)
+	CN3UIString* pUITextGold;
+
+	N3_VERIFY_UI_COMPONENT(pUITextGold, (CN3UIString*) GetChildByID("text_gold"));
+
+	if (pUITextGold != nullptr)
 	{
-		char szBuff[32] = "";
-		sprintf(szBuff, "%d", CGameBase::s_pPlayer->m_InfoExt.iGold);
-		int buffLength = strlen(szBuff);
-		int goldLength = buffLength + (buffLength / 3) - (buffLength % 3 == 0 ? 1 : 0);
-
-		char szGold[42] = "";
-		szGold[goldLength] = '\0';
-
-		for (int i = buffLength - 1, k = goldLength - 1; i >= 0; i--, k--)
-		{
-			if ((buffLength - 1 - i) % 3 == 0 && (buffLength - 1 != i))
-				szGold[k--] = ',';
-
-			szGold[k] = szBuff[i];
-		}
-
-
-		pStatic->SetString(szGold);
+		std::string szTemp;
+		szTemp = CGameBase::FormatNumber(CGameBase::s_pPlayer->m_InfoExt.iGold);
+		pUITextGold->SetString(szTemp);
 	}
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:


- [x] Code style update (formatting, renaming)


## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
format number works inside UIInventory, however other UI components need similar function to format gold such as : UITransactions, UIWarehouse etc.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
FormatNumber function is carried under GameBase and can be accessed from other UI elements. In addition, future update to change separator from "," to "." can be performed with respect to language tail.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
to decrease amount of code repeat.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
