### PR TITLE
better solution to weight bug, which works in both clients

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -3299,7 +3299,7 @@ bool CGameProcMain::MsgRecv_ItemMove(Packet& pkt)
 	{
 		pInfoExt->iAttack = pkt.read<int16_t>();
 		pInfoExt->iGuard =	pkt.read<int16_t>();
-		pInfoExt->iWeightMax = static_cast<int>(pkt.read<uint16_t>());
+		pInfoExt->iWeightMax = pkt.read<int16_t>();
 		
 		pInfoBase->iHPMax = pkt.read<int16_t>();
 		pInfoExt->iMSPMax = pkt.read<int16_t>();
@@ -3655,8 +3655,8 @@ bool CGameProcMain::MsgRecv_MyInfo_LevelChange(Packet& pkt)
 		pInfoExt->iMSPMax		= pkt.read<int16_t>();
 		pInfoExt->iMSP			= pkt.read<int16_t>();
 
-		pInfoExt->iWeightMax	= static_cast<int>(pkt.read<uint16_t>());
-		pInfoExt->iWeight		= static_cast<int>(pkt.read<uint16_t>());
+		pInfoExt->iWeightMax	= pkt.read<int16_t>();
+		pInfoExt->iWeight		= pkt.read<int16_t>();
 
 		m_pUIVar->UpdateAllStates(&(s_pPlayer->m_InfoBase), &(s_pPlayer->m_InfoExt)); // 모든 정보 업데이트..
 

--- a/Server/Ebenezer/StdAfx.h
+++ b/Server/Ebenezer/StdAfx.h
@@ -13,6 +13,7 @@
 #define _WIN32_WINNT _WIN32_WINNT_MAXVER
 #define VC_EXTRALEAN		// Exclude rarely-used stuff from Windows headers
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
+#define NOMINMAX
 
 #include <afxwin.h>         // MFC core and standard components
 #include <afxext.h>         // MFC extensions

--- a/Server/Ebenezer/User.h
+++ b/Server/Ebenezer/User.h
@@ -37,7 +37,7 @@ public:
 	short	m_RegionZ;						// 현재 영역 Z 좌표
 
 	int		m_iMaxExp;						// 다음 레벨이 되기 위해 필요한 Exp량
-	short	m_sMaxWeight;					// 들 수 있는 최대 무게
+	int		m_iMaxWeight;					// 들 수 있는 최대 무게
 	BYTE    m_sSpeed;						// 스피드
 
 	short	m_sBodyAc;						// 맨몸 방어력
@@ -49,7 +49,7 @@ public:
 
 	short   m_sItemMaxHp;                   // 아이템 총 최대 HP Bonus
 	short   m_sItemMaxMp;                   // 아이템 총 최대 MP Bonus
-	short	m_sItemWeight;					// 아이템 총무게
+	int		m_iItemWeight;					// 아이템 총무게
 	short	m_sItemHit;						// 아이템 총타격치
 	short	m_sItemAc;						// 아이템 총방어력
 	short	m_sItemStr;						// 아이템 총힘 보너스
@@ -198,6 +198,8 @@ public:
 	BYTE				m_byPersonalRank;
 
 public:
+	int16_t GetMaxWeightForClient() const;
+	int16_t GetCurrentWeightForClient() const;
 	void RecvZoneChange(char* pBuf);
 	void GameStart(char* pBuf);
 	void GetUserInfo(char* buff, int& buff_index);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
weight works fine in compiled client but it does not work on binary client. Hence, instead of static casting int, weight limit set as INT16_MAX. Probably, officially it was in that way.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Max weight set as INT16_MAX on server side works in both clients.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
Old fix was not working on original exe.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
