### PR TITLE
Restore N3UIWndBase.cpp to client project

### DIFF
--- a/Client/N3Base/N3Base.vcxproj
+++ b/Client/N3Base/N3Base.vcxproj
@@ -234,7 +234,6 @@
     <ClCompile Include="N3UIString.cpp" />
     <ClCompile Include="N3UITooltip.cpp" />
     <ClCompile Include="N3UITrackBar.cpp" />
-    <ClCompile Include="N3UIWndBase.cpp" />
     <ClCompile Include="N3VMesh.cpp" />
     <ClCompile Include="N3WorldBase.cpp" />
     <ClCompile Include="N3WorldManager.cpp" />

--- a/Client/N3Base/N3Base.vcxproj.filters
+++ b/Client/N3Base/N3Base.vcxproj.filters
@@ -539,9 +539,6 @@
     <ClCompile Include="N3UITrackBar.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="N3UIWndBase.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="N3VMesh.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Client/WarFare/N3UIWndBase.cpp
+++ b/Client/WarFare/N3UIWndBase.cpp
@@ -2,14 +2,14 @@
 //
 //////////////////////////////////////////////////////////////////////
 
-#include "StdAfxBase.h"
-#include "../WarFare/N3UIWndBase.h"
+#include "StdAfx.h"
+#include "N3UIWndBase.h"
 
-#include "../WarFare/GameProcMain.h"
-#include "../WarFare/UIImageTooltipDlg.h"
-#include "../WarFare/UITransactionDlg.h"
-#include "../WarFare/UIManager.h"
-#include "../WarFare/CountableItemEditDlg.h"
+#include "GameProcMain.h"
+#include "UIImageTooltipDlg.h"
+#include "UITransactionDlg.h"
+#include "UIManager.h"
+#include "CountableItemEditDlg.h"
 
 #include <N3Base/N3UITooltip.h>
 #include <N3Base/N3SndObj.h>

--- a/Client/WarFare/WarFare.vcxproj
+++ b/Client/WarFare/WarFare.vcxproj
@@ -121,6 +121,7 @@
     <ClCompile Include="MachineBase.cpp" />
     <ClCompile Include="MachineMng.cpp" />
     <ClCompile Include="MagicSkillMng.cpp" />
+    <ClCompile Include="N3UIWndBase.cpp" />
     <ClCompile Include="OrderMessage.cpp" />
     <ClCompile Include="PlayerBase.cpp" />
     <ClCompile Include="PlayerMySelf.cpp" />

--- a/Client/WarFare/WarFare.vcxproj.filters
+++ b/Client/WarFare/WarFare.vcxproj.filters
@@ -291,6 +291,9 @@
     <ClCompile Include="UILogin_1298.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="N3UIWndBase.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameProcedure.h">


### PR DESCRIPTION
It was only partially moved into the N3Base project for some reason, when this is a client wrapper. I suspect the reason it was initially moved was because some of the controls (e.g. CN3UIArea) reference this, but they continue to refer to the header in its original place so... I don't think the mission was accomplished there.

It doesn't really need to be building for tools and such though. It's intended to be game code.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Other (please describe):

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).