### PR TITLE
Server list focus after news #251

### DIFF
--- a/Client/WarFare/UILogin_1298.cpp
+++ b/Client/WarFare/UILogin_1298.cpp
@@ -570,6 +570,13 @@ void CUILogIn_1298::OpenServerList()
 	if (m_pStr_Premium != nullptr)
 		m_pStr_Premium->SetVisible(true);
 
+	if (m_pServer_Group[0] != nullptr && m_pList_Group[0] != nullptr)
+	{
+		// Set top server as selected
+		m_pList_Group[0]->SetColor(D3DCOLOR_XRGB(0, 255, 0)); // Green (selected)
+		m_iSelectedServerIndex = 0;
+	}
+	
 	m_bIsNewsVisible = false;
 }
 


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature

## What is the current behaviour?
Once news is closed, the first server list entry is not selected.

## What is the new behaviour?
Once news is closed, the first server list entry is selected and pushing enter once will trigger entry into the server.

## Why and how did I change this?
Issue #251 

## Checklist
- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
