### PR TITLE
CUILogIn_1298: Fix various server list logic

### DIFF
--- a/Client/WarFare/UILogin_1298.cpp
+++ b/Client/WarFare/UILogin_1298.cpp
@@ -132,12 +132,12 @@ bool CUILogIn_1298::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 	{
 		for (int i = 0; i < MAX_SERVERS; i++)
 		{
-			if (m_pServer_Group[i] == nullptr)
+			if (m_pList_Group[i] == nullptr)
 				continue;
 
 			if (pSender == m_pList_Group[i])
 			{
-				m_iSelectedServerIndex = i;
+				SelectServer(i);
 				CGameProcedure::s_pProcLogIn->ConnectToGameServer();
 				return true;
 			}
@@ -148,17 +148,10 @@ bool CUILogIn_1298::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 	{
 		for (int i = 0; i < MAX_SERVERS; i++)
 		{
-			if (m_pServer_Group[i] != nullptr)
-				m_pList_Group[i]->SetColor(D3DCOLOR_XRGB(255, 255, 255)); // white
-		}
-
-		for (int i = 0; i < MAX_SERVERS; i++)
-		{
-			if (m_pServer_Group[i] != nullptr
+			if (m_pList_Group[i] != nullptr
 				&& pSender == m_pList_Group[i])
 			{
-				m_pList_Group[i]->SetColor(D3DCOLOR_XRGB(0, 255, 0)); // green
-				m_iSelectedServerIndex = i;
+				SelectServer(i);
 				return true;
 			}
 		}
@@ -263,7 +256,7 @@ bool CUILogIn_1298::Load(HANDLE hFile)
 		N3_VERIFY_UI_COMPONENT(m_pList_Group[i], (CN3UIString*) m_pServer_Group[i]->GetChildByID("List_Server"));
 	}
 
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Connect , (CN3UIButton* )m_pGroup_ServerList->GetChildByID("Btn_Connect"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Connect, (CN3UIButton*) m_pGroup_ServerList->GetChildByID("Btn_Connect"));
 		
 	return true;
 }
@@ -571,8 +564,7 @@ void CUILogIn_1298::OpenServerList()
 		m_pStr_Premium->SetVisible(true);
 
 	// Select first server by default.
-	if (m_pList_Group[0] != nullptr)
-		ReceiveMessage(m_pList_Group[0], UIMSG_STRING_LCLICK);
+	SelectServer(0);
 
 	m_bIsNewsVisible = false;
 }
@@ -613,7 +605,7 @@ bool CUILogIn_1298::OnKeyPress(int iKey)
 				if (m_iSelectedServerIndex < 0)
 					m_iSelectedServerIndex = iServerCount - 1;
 
-				ReceiveMessage(m_pList_Group[m_iSelectedServerIndex], UIMSG_STRING_LCLICK);
+				SelectServer(m_iSelectedServerIndex);
 			}
 			return true;
 
@@ -627,22 +619,15 @@ bool CUILogIn_1298::OnKeyPress(int iKey)
 				if (m_iSelectedServerIndex >= iServerCount)
 					m_iSelectedServerIndex = 0;
 
-				ReceiveMessage(m_pList_Group[m_iSelectedServerIndex], UIMSG_STRING_LCLICK);
+				SelectServer(m_iSelectedServerIndex);
 			}
 			return true;
 
 			case DIK_NUMPADENTER:
 			case DIK_RETURN:
-			{
-				// select the first server if user presses enter at server select screen
-				if (m_iSelectedServerIndex == -1)
-				{
-					m_iSelectedServerIndex = 0;
-					ReceiveMessage(m_pList_Group[m_iSelectedServerIndex], UIMSG_STRING_LCLICK);
-				}
-
-			}
-			return true;
+				// connect to the selected server if user presses enter at server select screen
+				ReceiveMessage(m_pList_Group[m_iSelectedServerIndex], UIMSG_STRING_LDCLICK);
+				return true;
 		}
 	}
 	else if (m_bIsNewsVisible)
@@ -656,5 +641,21 @@ bool CUILogIn_1298::OnKeyPress(int iKey)
 	}
 
 	return CN3UIBase::OnKeyPress(iKey);
+}
+
+void CUILogIn_1298::SelectServer(int iServerListIndex)
+{
+	m_iSelectedServerIndex = std::clamp(iServerListIndex, 0, MAX_SERVERS - 1);
+
+	for (int i = 0; i < MAX_SERVERS; i++)
+	{
+		if (m_pList_Group[i] == nullptr)
+			continue;
+
+		if (i == m_iSelectedServerIndex)
+			m_pList_Group[i]->SetColor(D3DCOLOR_XRGB(0, 255, 0)); // green
+		else
+			m_pList_Group[i]->SetColor(D3DCOLOR_XRGB(255, 255, 255)); // white
+	}
 }
 #endif

--- a/Client/WarFare/UILogin_1298.h
+++ b/Client/WarFare/UILogin_1298.h
@@ -91,6 +91,7 @@ protected:
 	std::string m_strNoticeText;
 public:
 	void SetRequestedLogIn(bool bLogIn) { m_bLogIn = bLogIn; }
+	void SelectServer(int iServerListIndex);
 	bool OnKeyPress(int iKey);
 	void SetVisibleLogInUIs(bool bEnable); // 계정 LogIn 에 필요한 UI 들을 숨긴다..
 	void OpenServerList();


### PR DESCRIPTION
 * Move server selection logic into a separate method to be invoked on-demand.
 * Rather than reset everything to white on any string selection, require a list entry to actually be selected.
 * Also allow for any selected server to be connected to when pressing enter.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
Currently, we have 2 main issues:
1. Any string click triggers all server list entries to effectively become visually unselected.
2. For some reason, the behaviour for 'enter' merely selects the first server if one's not already selected.

## What is the new behaviour?
1. String clicks no longer inherently visually reset the list. Only string clicks on valid list entries do, because they also mark their corresponding selected entry as such.
2. Enter will now just trigger a connect on the selected server. As we (as of 5e6c1ed80fe38813d492aa8462a0194a1bcaa779) default the selected server to the first server, the previous behaviour kind've broke as a result. Since there's no groups/subservers, the logical thing behaviour here on a selected server -- of which it's guaranteed to be selected -- is to attempt to connect to it.

## Why and how did I change this?
With 5e6c1ed80fe38813d492aa8462a0194a1bcaa779, we broke the behaviour of the 2nd issue, but it didn't really make sense to begin with.
Additionally, the string clicks (and fact we had to awkwardly simulate a click in the first place) is what prompted the change to shift it into another method, and correct its logic.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
