### PR TITLE
Restore CUIManager::SetVisibleFocusedUI() logic

### DIFF
--- a/Client/WarFare/UIManager.cpp
+++ b/Client/WarFare/UIManager.cpp
@@ -432,19 +432,20 @@ void CUIManager::SetVisibleFocusedUI(CN3UIBase *pUI)
 			}
 
 			dwUIHideStyle = pUIHide->GetStyle();
-			if(pUIHide->IsVisible() && pUI != pUIHide && (dwUIHideStyle & UISTYLE_SHOW_ME_ALONE))
-				pUIHide->SetVisibleWithNoSound(false, true);
-/*
-			if(pUIHide->IsVisible() && pUI != pUIHide)
+
+			if (pUIHide->IsVisible()
+				&& pUI != pUIHide)
 			{
-				if(dwUIHideStyle & UISTYLE_SHOW_ME_ALONE)
+				if ((dwUIHideStyle & UISTYLE_SHOW_ME_ALONE) != 0)
 					pUIHide->SetVisibleWithNoSound(false, true);
-				else if( (dwUIStyle & UISTYLE_POS_LEFT) && (dwUIHideStyle & UISTYLE_POS_LEFT) )
+				else if ((dwUIStyle & UISTYLE_POS_LEFT) != 0
+					&& (dwUIHideStyle & UISTYLE_POS_LEFT) != 0)
 					pUIHide->SetVisibleWithNoSound(false, true);
-				else if( (dwUIStyle & UISTYLE_POS_RIGHT) && (dwUIHideStyle & UISTYLE_POS_RIGHT) )
+				else if ((dwUIStyle & UISTYLE_POS_RIGHT) != 0
+					&& (dwUIHideStyle & UISTYLE_POS_RIGHT) != 0)
 					pUIHide->SetVisibleWithNoSound(false, true);
 			}
-*/
+
 			it++;
 		}
 	}


### PR DESCRIPTION
Its logic to close mutually exclusive UIs was commented out in the base source. This should be restored, as they did officially.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
UIs that use the styles UISTYLE_POS_LEFT, UISTYLE_POS_RIGHT or UISTYLE_SHOW_ME_ALONE are not currently closed when UIs they are mutually exclusive with are opened.

## What is the new behaviour?
These such UIs will now be correctly closed, so they aren't all up at the same time.

## Why and how did I change this?
This logic was commented out in the original leaked source, and later restored as evident in the official binary.
We should also restore it here, so that we don't have to implement visibility updating logic for these UIs manually.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
