### PR TITLE
Strip the useless template helpers

### DIFF
--- a/Client/N3Base/My_3DStruct.h
+++ b/Client/N3Base/My_3DStruct.h
@@ -1436,17 +1436,6 @@ inline float _Yaw2D(float fDirX, float fDirZ)
 inline int16_t _IsKeyDown(int iVirtualKey) { return (GetAsyncKeyState(iVirtualKey) & 0xff00); }
 inline int16_t _IsKeyDowned(int iVirtualKey) { return (GetAsyncKeyState(iVirtualKey) & 0x00ff); }
 
-
-//macro.. -> Template 로 바꿨다..
-template <class T> const T T_Max(const T a, const T b) { return ((a > b) ? b : a); }
-template <class T> const T T_Min(const T a, const T b) { return ((a > b) ? a : b); }
-template <class T> const T T_Abs(const T a) { return ((a > 0) ? a : -a); }
-
-template <class T> void T_Delete(T*& ptr) { delete ptr; ptr = NULL; } // Template Delete Pointer
-template <class T> void T_DeleteArray(T*& ptr) { delete [] ptr; ptr = NULL; } // Template Delete Pointer
-template <class T> void T_Tick(T& obj) { obj.Tick(); } // Template Delete Pointer
-template <class T> void T_Render(T& obj) { obj.Render(); } // Template Delete Pointer
-
 #if defined(_3DSERVER)
 inline void _LoadStringFromResource(DWORD dwID, std::string& szText, const int iOutputCodepage = 949)
 {

--- a/Client/N3Base/N3PMeshCreate.cpp
+++ b/Client/N3Base/N3PMeshCreate.cpp
@@ -105,7 +105,7 @@ void CN3PMeshCreate::combine_modified(float &sofar, uint16_t *tri, int which, in
 
 	// Calculate some statistics about the triangle change.
 	V1 = D3DXVECTOR3(m_pVertices[what_to].x, m_pVertices[what_to].y, m_pVertices[what_to].z) - in_plane;
-	float volume_change = T_Abs(D3DXVec3Dot(&V1, &oldcross));
+	float volume_change = std::abs(D3DXVec3Dot(&V1, &oldcross));
 
 	// The angle change weighted by the area of the triangle.
 	float weighted_angle_change = (1.0f - cosangdiff) * (oldarea + newarea);

--- a/Client/N3Base/N3Shape.cpp
+++ b/Client/N3Base/N3Shape.cpp
@@ -142,7 +142,7 @@ void CN3SPart::Tick(const __Matrix44& mtxParent, const __Quaternion& qRot, float
 //		else if(m_vWindFactorToReach != m_vWindFactorCur)
 		{
 //			float fFactor = s_fSecPerFrm * (m_vWindFactorToReach - m_vWindFactorCur).Magnitude();
-			float fFactor = s_fSecPerFrm * T_Abs(m_fWindFactorToReach - m_fWindFactorCur);
+			float fFactor = s_fSecPerFrm * std::abs(m_fWindFactorToReach - m_fWindFactorCur);
 
 //			if(m_vWindFactorCur.x < m_vWindFactorToReach.x) m_vWindFactorCur.x += fFactor;
 //			if(m_vWindFactorCur.x > m_vWindFactorToReach.x) m_vWindFactorCur.x -= fFactor;
@@ -153,10 +153,10 @@ void CN3SPart::Tick(const __Matrix44& mtxParent, const __Quaternion& qRot, float
 			if(m_fWindFactorCur < m_fWindFactorToReach) m_fWindFactorCur += fFactor;
 			if(m_fWindFactorCur > m_fWindFactorToReach) m_fWindFactorCur -= fFactor;
 
-//			if(T_Abs(m_vWindFactorToReach.x - m_vWindFactorCur.x) < fFactor) m_vWindFactorCur.x = m_vWindFactorToReach.x;
-//			if(T_Abs(m_vWindFactorToReach.y - m_vWindFactorCur.y) < fFactor) m_vWindFactorCur.y = m_vWindFactorToReach.y;
-//			if(T_Abs(m_vWindFactorToReach.z - m_vWindFactorCur.z) < fFactor) m_vWindFactorCur.z = m_vWindFactorToReach.z;
-			if(T_Abs(m_fWindFactorToReach - m_fWindFactorCur) < fFactor) m_fWindFactorCur = m_fWindFactorToReach;
+//			if(std::abs(m_vWindFactorToReach.x - m_vWindFactorCur.x) < fFactor) m_vWindFactorCur.x = m_vWindFactorToReach.x;
+//			if(std::abs(m_vWindFactorToReach.y - m_vWindFactorCur.y) < fFactor) m_vWindFactorCur.y = m_vWindFactorToReach.y;
+//			if(std::abs(m_vWindFactorToReach.z - m_vWindFactorCur.z) < fFactor) m_vWindFactorCur.z = m_vWindFactorToReach.z;
+			if(std::abs(m_fWindFactorToReach - m_fWindFactorCur) < fFactor) m_fWindFactorCur = m_fWindFactorToReach;
 			
 			__Vector3 vPos = m_vPivot * mtxParent;
 //			m_Matrix.Rotation(CN3Base::s_vWindFactor * m_fWindFactorCur);

--- a/Client/N3Base/N3ShapeExtra.cpp
+++ b/Client/N3Base/N3ShapeExtra.cpp
@@ -70,7 +70,7 @@ void CN3ShapeExtra::Tick(float fFrm)
 		
 		fRotDelta = pRot->fRadianPerSec * fDir * CN3Base::s_fSecPerFrm;
 		pRot->fRadianCur += fRotDelta;
-		if(T_Abs(pRot->fRadianToReach - pRot->fRadianCur) <= fRotDelta) /// 원하는 곳까지 다 열렸다!!
+		if(std::abs(pRot->fRadianToReach - pRot->fRadianCur) <= fRotDelta) /// 원하는 곳까지 다 열렸다!!
 		{
 			bNeedRemakeCollisionMeshes = true;
 			pRot->fRadianPerSec = 0;

--- a/Client/N3Base/N3Terrain.cpp
+++ b/Client/N3Base/N3Terrain.cpp
@@ -780,7 +780,7 @@ bool CN3Terrain::SetLODLevel(int level)
 	{
 		for(z=0;z<m_iNumPatch;z++)
 		{
-			dist = m_iDistanceTable[T_Abs(m_pat_Center2Side-x)][T_Abs(m_pat_Center2Side-z)];
+			dist = m_iDistanceTable[std::abs(m_pat_Center2Side-x)][std::abs(m_pat_Center2Side-z)];
 			if(dist <= m_iLodLevel) m_ppPatch[x][z].SetLevel(1);
 			else if(dist <= m_iLodLevel+3) m_ppPatch[x][z].SetLevel(2);
 			else m_ppPatch[x][z].SetLevel(3);

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -467,7 +467,7 @@ void CGameProcMain::InitPlayerPosition(const __Vector3& vPos) // 플레이어 �
 	float fYObject = ACT_WORLD->GetHeightNearstPosWithShape(vPos, 1.0f); // 오브젝트에서 가장 가까운 높이값 얻기..
 	if (!s_pWorldMgr->IsIndoor())
 	{
-		if (T_Abs(vPos.y - fYObject) < T_Abs(vPos.y - fYTerrain)) vPosFinal.y = fYObject; // 좀더 가까운 곳에 놓는다..
+		if (std::abs(vPos.y - fYObject) < std::abs(vPos.y - fYTerrain)) vPosFinal.y = fYObject; // 좀더 가까운 곳에 놓는다..
 		else vPosFinal.y = fYTerrain;
 	}
 	else

--- a/Client/WarFare/PlayerBase.cpp
+++ b/Client/WarFare/PlayerBase.cpp
@@ -625,7 +625,7 @@ void CPlayerBase::TickYaw()
 	{
 		float fYawDiff = m_fYawToReach - m_fYawCur; // 회전값 차이.
 		float fYawDelta = m_fRotRadianPerSec * s_fSecPerFrm; // 회전할 양
-		if(T_Abs(fYawDiff) <= fYawDelta)
+		if(std::abs(fYawDiff) <= fYawDelta)
 		{
 			m_fYawCur = m_fYawToReach; // 회전할 양이 작으면.. 바로 세팅
 		}
@@ -644,7 +644,7 @@ void CPlayerBase::TickYaw()
 
 			m_fYawCur += fYawDelta; // 회전..
 
-			if(T_Abs(m_fYawCur) > __PI)
+			if(std::abs(m_fYawCur) > __PI)
 			{
 				int iLot = (int)(m_fYawCur/__PI);
 				if(iLot) m_fYawCur -= iLot * __PI2; // 0 ~ 360 도 사이로 맞추고..

--- a/Client/WarFare/PlayerOtherMgr.cpp
+++ b/Client/WarFare/PlayerOtherMgr.cpp
@@ -31,21 +31,21 @@ CPlayerOtherMgr::~CPlayerOtherMgr()
 void CPlayerOtherMgr::ReleaseUPCs()
 {
 	it_UPC it = m_UPCs.begin(), itEnd = m_UPCs.end();
-	for(; it != itEnd; it++) T_Delete(it->second);
+	for(; it != itEnd; it++) delete it->second;
 	m_UPCs.clear();
 }
 
 void CPlayerOtherMgr::ReleaseNPCs()
 {
 	it_NPC it = m_NPCs.begin(), itEnd = m_NPCs.end();
-	for(; it != itEnd; it++) T_Delete(it->second);
+	for(; it != itEnd; it++)  delete it->second;
 	m_NPCs.clear();
 }
 
 void CPlayerOtherMgr::ReleaseCorpses()
 {
 	it_NPC it = m_Corpses.begin(), itEnd = m_Corpses.end();
-	for(; it != itEnd; it++) T_Delete(it->second);
+	for(; it != itEnd; it++)  delete it->second;
 	m_Corpses.clear();
 }
 //////////////////////////////////////////////////////////////////////
@@ -133,7 +133,7 @@ void CPlayerOtherMgr::Tick(const __Vector3& vPosPlayer)
 
 		if(pCorpse->m_fTimeAfterDeath >= TIME_CORPSE_REMAIN) // 죽은지 일정한 시간이 지나면..
 		{
-			T_Delete(pCorpse);
+			delete pCorpse;
 			it3 = m_Corpses.erase(it3); // 죽은놈 지우고..
 		}
 		else
@@ -427,7 +427,7 @@ void CPlayerOtherMgr::CorpseAdd(CPlayerNPC* pNPC)
 	std::pair<it_NPC, bool> result = m_Corpses.insert(val_NPC(pNPC->IDNumber(), pNPC));
 	if(false == result.second) // 중복되었으면..
 	{
-		T_Delete(result.first->second); // 전의걸 지워주고..
+		delete result.first->second; // 전의걸 지워주고..
 		result.first->second = pNPC; // 새로 포인터 넣는다...
 	}
 }

--- a/Client/WarFare/PlayerOtherMgr.h
+++ b/Client/WarFare/PlayerOtherMgr.h
@@ -143,7 +143,7 @@ inline void CPlayerOtherMgr::UPCAdd(CPlayerOther* pUPC)
 	}
 	else // 중복되었으면..
 	{
-		T_Delete(it->second);
+		delete it->second;
 		it->second = pUPC;
 	}
 }
@@ -153,7 +153,7 @@ inline bool CPlayerOtherMgr::UPCDelete(int iID)
 	it_UPC it = m_UPCs.find(iID);
 	if(it == m_UPCs.end()) return false;
 
-	T_Delete(it->second);
+	delete it->second;
 	m_UPCs.erase(it);
 	return true;
 }
@@ -167,7 +167,7 @@ inline void CPlayerOtherMgr::NPCAdd(CPlayerNPC* pNPC)
 	}
 	else // 중복되었으면..
 	{
-		T_Delete(it->second);
+		delete it->second;
 		it->second = pNPC;
 	}
 }
@@ -177,7 +177,7 @@ inline bool CPlayerOtherMgr::NPCDelete(int iID)
 	it_NPC it = m_NPCs.find(iID);
 	if(it == m_NPCs.end()) return false;
 
-	T_Delete(it->second);
+	delete it->second;
 	m_NPCs.erase(it);
 	return true;
 }

--- a/Client/WarFare/UIMessageBoxManager.cpp
+++ b/Client/WarFare/UIMessageBoxManager.cpp
@@ -84,7 +84,7 @@ std::string CUIMessageBoxManager::MessageBoxPost(const std::string& szMsg, const
 		pMB = it->second;
 		if( pMB && !pMB->IsVisible() )
 		{
-			T_Delete(pMB);
+			delete pMB;
 			it = m_UBMs.erase(it);
 			continue;
 		}
@@ -174,9 +174,7 @@ void CUIMessageBoxManager::Release()
 {
 	it_UBM it = m_UBMs.begin(), it_e = m_UBMs.end();
 	for(; it != it_e; it++)
-	{
-		T_Delete(it->second);
-	}
+		delete it->second;
 	m_UBMs.clear();
 
 	m_pMsgBoxLatestRef = NULL;

--- a/N3ME/LyTerrain.cpp
+++ b/N3ME/LyTerrain.cpp
@@ -3384,7 +3384,7 @@ void CLyTerrain::SetLightMap(int x, int z, int lcx, int lcz)
 	{
 		for(iz=lcz-PenSize+1; iz<lcz+PenSize; iz++)
 		{
-			dist = m_iDistanceTable[T_Abs(lcx-ix)][T_Abs(lcz-iz)] + 1;
+			dist = m_iDistanceTable[std::abs(lcx-ix)][std::abs(lcz-iz)] + 1;
 			if(dist > PenSize) continue;
 			
 			nx = x;
@@ -3473,7 +3473,7 @@ void CLyTerrain::MakeMoveTable(short** ppEvent)
 			if(fMax < m_ppMapData[x+1][z+1].fHeight) fMax = m_ppMapData[x+1][z+1].fHeight;
 			if(fMin > m_ppMapData[x+1][z+1].fHeight) fMin = m_ppMapData[x+1][z+1].fHeight;
 
-			if( NOTMOVE_HEIGHT <= T_Abs((int)(fMax-fMin)) )
+			if( NOTMOVE_HEIGHT <= std::abs((int)(fMax-fMin)) )
 			{
 				ppEvent[x][z] = 0;
 			}

--- a/N3ME/MapMng.cpp
+++ b/N3ME/MapMng.cpp
@@ -738,7 +738,7 @@ void CMapMng::FocusAll()
 	__Vector3 vDir = pCamera->Dir();
 	__Vector3 vAt;	vAt.Set(size.cx/2.0f, 0, size.cy/2.0f);
 	pCamera->AtPosSet(vAt);
-	pCamera->EyePosSet(vAt - vDir*((float)max(size.cx, size.cy))/tanf(pCamera->m_Data.fFOV/2.0f)/2.0f);
+	pCamera->EyePosSet(vAt - vDir*((float)std::max(size.cx, size.cy))/tanf(pCamera->m_Data.fFOV/2.0f)/2.0f);
 
 	
 	Invalidate();

--- a/N3ME/QTNode.cpp
+++ b/N3ME/QTNode.cpp
@@ -361,10 +361,10 @@ inline int CQTNode::Distance(int sx, int sz, int tx, int tz)
 	int iX = tx - sx;
 	int iZ = tz - sz;
 
-	iX = T_Abs(iX);
-	iZ = T_Abs(iZ);
+	iX = std::abs(iX);
+	iZ = std::abs(iZ);
 
-	int iMin = T_Min(iX, iZ);
+	int iMin = std::min(iX, iZ);
 
 	return (iX+iZ-(iMin>>1) - (iMin>>2) + (iMin>>4));
 }
@@ -1170,25 +1170,25 @@ int CQTNode::GetMaxLevel(eDIR dir)
 		{
 			l1 = m_pChild[DIR_TOP]->GetMaxLevel(DIR_RIGHT);
 			l2 = m_pChild[DIR_RIGHT]->GetMaxLevel(DIR_RIGHT);
-			return T_Max(l1,l2);
+			return std::max(l1,l2);
 		}
 		if(dir==DIR_LEFT)
 		{
 			l1 = m_pChild[DIR_LEFT]->GetMaxLevel(DIR_LEFT);
 			l2 = m_pChild[DIR_BOTTOM]->GetMaxLevel(DIR_LEFT);
-			return T_Max(l1,l2);
+			return std::max(l1,l2);
 		}
 		if(dir==DIR_TOP)
 		{
 			l1 = m_pChild[DIR_LEFT]->GetMaxLevel(DIR_TOP);
 			l2 = m_pChild[DIR_TOP]->GetMaxLevel(DIR_TOP);
-			return T_Max(l1,l2);
+			return std::max(l1,l2);
 		}
 		if(dir==DIR_BOTTOM)
 		{
 			l1 = m_pChild[DIR_BOTTOM]->GetMaxLevel(DIR_BOTTOM);
 			l2 = m_pChild[DIR_RIGHT]->GetMaxLevel(DIR_BOTTOM);
-			return T_Max(l1,l2);
+			return std::max(l1,l2);
 		}
 	}
 	return 0;

--- a/N3ME/StdAfx.h
+++ b/N3ME/StdAfx.h
@@ -14,6 +14,7 @@
 #endif // _MSC_VER > 1000
 
 #define VC_EXTRALEAN		// Exclude rarely-used stuff from Windows headers
+#define NOMINMAX 1
 
 #include <afxwin.h>         // MFC core and standard components
 #include <afxext.h>         // MFC extensions

--- a/TblEditor/framework.h
+++ b/TblEditor/framework.h
@@ -4,7 +4,7 @@
 #define VC_EXTRALEAN            // Exclude rarely-used stuff from Windows headers
 #endif
 
-#define NOMINMAX
+#define NOMINMAX 1
 
 #include "targetver.h"
 


### PR DESCRIPTION
Fairly explanatory; bunch of useless template helpers, mostly unused. T_Min() and T_Max() were implemented incorrectly (but assumed to be correct), T_Abs() was occasionally used, T_Delete() was used but only in conjunction with removing or replacing the pointer, so it initialising it to nullptr after-the-fact was pointless.

T_Min(), T_Max(), T_Abs() were all replaced with their std variants (std::min(), std::max(), std::abs()).
T_Delete() was just replaced with `delete`.

Everything else was just removed outright since there was nothing using them.