### PR TITLE
Wait for DX9 device to be restored

### DIFF
--- a/Client/N3Base/N3Eng.h
+++ b/Client/N3Base/N3Eng.h
@@ -34,9 +34,9 @@ public:
 	LPDIRECTDRAW m_lpDD;
 
 public:
-	void Release(void);
+	void Release();
 	void SetViewPort(RECT& pRC);
-	void SetDefaultEnvironment(void);
+	static void SetDefaultEnvironment();
 	void LookAt(const __Vector3& vEye, const __Vector3& vAt, const __Vector3& vUp);
 	bool Reset(bool bWindowed, uint32_t dwWidth, uint32_t dwHeight, uint32_t dwBPP);
 	void SetProjection(float fNear, float fFar, float fLens, float fAspect);
@@ -45,6 +45,7 @@ public:
 	static void ClearZBuffer(const RECT* pRC = NULL);
 	static void Clear(D3DCOLOR crFill, RECT* pRC = NULL);
 	static void Present(HWND hWnd, RECT* pRC = NULL);
+	static void WaitForDeviceRestoration();
 
 	bool Init(
 		BOOL bWindowed,


### PR DESCRIPTION
In DX8 this automatically blocked until this happened, in DX9 this has to be done manually.

This is roughly the official implementation for this, give or take the log messages using %X (hex) for the error codes (more meaningful for these error codes) rather than %d.