### PR TITLE
AG_COMPRESSED_DATA checksums should be of the decompressed data

### DIFF
--- a/Server/AIServer/GameSocket.cpp
+++ b/Server/AIServer/GameSocket.cpp
@@ -900,10 +900,15 @@ void CGameSocket::RecvCompressedData(char* pBuf)
 		&decompressedBuffer[0],
 		sOrgLen);
 
+	_ASSERT(nDecompressedLength == sOrgLen);
+
 	if (nDecompressedLength != sOrgLen)
 		return;
 
 	dwActualCrcValue = crc32(&decompressedBuffer[0], sOrgLen);
+
+	_ASSERT(dwCrcValue == dwActualCrcValue);
+
 	if (dwCrcValue != dwActualCrcValue)
 		return;
 

--- a/Server/AIServer/ServerDlg.cpp
+++ b/Server/AIServer/ServerDlg.cpp
@@ -1981,6 +1981,9 @@ void CServerDlg::SendCompressedData(int nZone)
 	uint32_t crc_value = 0;
 
 	comp_data_len = lzf_compress(m_CompBuf, m_iCompIndex, comp_buff, sizeof(comp_buff));
+
+	_ASSERT(comp_data_len != 0 && comp_data_len <= sizeof(comp_buff));
+
 	if (comp_data_len == 0
 		|| comp_data_len > sizeof(comp_buff))
 	{
@@ -1988,7 +1991,7 @@ void CServerDlg::SendCompressedData(int nZone)
 		return;
 	}
 
-	crc_value = crc32(comp_buff, comp_data_len);
+	crc_value = crc32(reinterpret_cast<uint8_t*>(m_CompBuf), m_iCompIndex);
 
 	SetByte(send_buff, AG_COMPRESSED_DATA, send_index);
 	SetShort(send_buff, (short) comp_data_len, send_index);

--- a/Server/Ebenezer/AISocket.cpp
+++ b/Server/Ebenezer/AISocket.cpp
@@ -1278,10 +1278,15 @@ void CAISocket::RecvCompressedData(char* pBuf)
 		&decompressedBuffer[0],
 		sOrgLen);
 
+	_ASSERT(nDecompressedLength == sOrgLen);
+
 	if (nDecompressedLength != sOrgLen)
 		return;
 
 	dwActualCrcValue = crc32(&decompressedBuffer[0], sOrgLen);
+
+	_ASSERT(dwCrcValue == dwActualCrcValue);
+
 	if (dwCrcValue != dwActualCrcValue)
 		return;
 

--- a/Server/Ebenezer/EbenezerDlg.cpp
+++ b/Server/Ebenezer/EbenezerDlg.cpp
@@ -2957,6 +2957,9 @@ void CEbenezerDlg::SendCompressedData()
 	uint32_t crc_value = 0;
 
 	comp_data_len = lzf_compress(m_CompBuf, m_iCompIndex, comp_buff, sizeof(comp_buff));
+
+	_ASSERT(comp_data_len != 0 && comp_data_len <= sizeof(comp_buff));
+
 	if (comp_data_len == 0
 		|| comp_data_len > sizeof(comp_buff))
 	{
@@ -2964,7 +2967,7 @@ void CEbenezerDlg::SendCompressedData()
 		return;
 	}
 
-	crc_value = crc32(comp_buff, comp_data_len);
+	crc_value = crc32(reinterpret_cast<uint8_t*>(m_CompBuf), m_iCompIndex);
 
 	SetByte(send_buff, AG_COMPRESSED_DATA, send_index);
 	SetShort(send_buff, (short) comp_data_len, send_index);


### PR DESCRIPTION
AG_COMPRESSED_DATA checksums should be of the decompressed data.

Additionally, we should throw assertions for these cases rather than simply silently ignoring them.