### PR TITLE
Move CN3FXMgr, CN3UIDBCLButton, CN3UIIcon out of N3Base

### DIFF
--- a/Client/N3Base/N3Base.vcxproj
+++ b/Client/N3Base/N3Base.vcxproj
@@ -159,7 +159,6 @@
     <ClCompile Include="N3FXGroup.cpp">
       <ExcludedFromBuild Condition="'$(ToolBuild)'!='true'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="N3FXMgr.cpp" />
     <ClCompile Include="N3FXPartBase.cpp" />
     <ClCompile Include="N3FXPartBillBoard.cpp" />
     <ClCompile Include="N3FXPartBottomBoard.cpp" />
@@ -204,9 +203,7 @@
     <ClCompile Include="N3UIArea.cpp" />
     <ClCompile Include="N3UIBase.cpp" />
     <ClCompile Include="N3UIButton.cpp" />
-    <ClCompile Include="N3UIDBCLButton.cpp" />
     <ClCompile Include="N3UIEdit.cpp" />
-    <ClCompile Include="N3UIIcon.cpp" />
     <ClCompile Include="N3UIImage.cpp" />
     <ClCompile Include="N3UIList.cpp" />
     <ClCompile Include="N3UIProgress.cpp" />

--- a/Client/N3Base/N3Base.vcxproj.filters
+++ b/Client/N3Base/N3Base.vcxproj.filters
@@ -332,9 +332,6 @@
     <ClCompile Include="N3FXBundle.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="N3FXMgr.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="N3FXPartBase.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -446,13 +443,7 @@
     <ClCompile Include="N3UIButton.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="N3UIDBCLButton.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="N3UIEdit.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="N3UIIcon.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="N3UIImage.cpp">

--- a/Client/WarFare/N3FXMgr.cpp
+++ b/Client/WarFare/N3FXMgr.cpp
@@ -1,23 +1,18 @@
-﻿// N3FXMgr.cpp
-//
-/////////////
-/////////////////////////////////////////////////////////
+﻿#include "StdAfx.h"
+#include "N3FXMgr.h"
+#include "GameBase.h"
+#include "GameProcmain.h"
+#include "GameProcedure.h"
+#include "PlayerOtherMgr.h"
+#include "PlayerNPC.h"
+#include "PlayerMySelf.h"
+#include "N3FXBundleGame.h"
+#include "N3WorldManager.h"
+#include "MagicSkillMng.h"
+#include "APISocket.h"
+#include "PacketDef.h"
 
-#include "StdAfxBase.h"
-#include "..\WarFare\N3FXMgr.h"
-#include "..\WarFare\GameBase.h"
-#include "..\WarFare\GameProcmain.h"
-#include "..\WarFare\GameProcedure.h"
-#include "..\WarFare\PlayerOtherMgr.h"
-#include "..\WarFare\PlayerNPC.h"
-#include "..\WarFare\PlayerMySelf.h"
-#include "..\WarFare\N3FXBundleGame.h"
-#include "..\WarFare\N3WorldManager.h"
-#include "..\WarFare\MagicSkillMng.h"
-#include "..\WarFare\APISocket.h"
-#include "..\WarFare\PacketDef.h"
-
-#include "N3ShapeExtra.h"
+#include <N3Base/N3ShapeExtra.h>
 
 CN3FXMgr::CN3FXMgr()
 {

--- a/Client/WarFare/N3UIDBCLButton.cpp
+++ b/Client/WarFare/N3UIDBCLButton.cpp
@@ -1,11 +1,9 @@
-﻿// N3UIIcon.cpp: implementation of the CN3UIIcon class.
+﻿// N3UIDBCLButton.cpp: implementation of the CN3UIDBCLButton class.
 //
 //////////////////////////////////////////////////////////////////////
 
-#include "StdAfxBase.h"
-#include "..\WarFare\N3UIDBCLButton.h"
-#include "..\WarFare\GameProcedure.h"
-#include "..\WarFare\UIImageTooltipDlg.h"
+#include "StdAfx.h"
+#include "N3UIDBCLButton.h"
 
 #ifdef _DEBUG
 #undef THIS_FILE
@@ -18,7 +16,6 @@ static char THIS_FILE[]=__FILE__;
 
 CN3UIDBCLButton::CN3UIDBCLButton()
 {
-	CN3UIImage::CN3UIImage();
 }
 
 CN3UIDBCLButton::~CN3UIDBCLButton()

--- a/Client/WarFare/N3UIIcon.cpp
+++ b/Client/WarFare/N3UIIcon.cpp
@@ -2,14 +2,13 @@
 //
 //////////////////////////////////////////////////////////////////////
 
-#include "StdAfxBase.h"
-#include "..\WarFare\N3UIIcon.h"
-#include "..\WarFare\N3UIWndBase.h"
-#include "..\WarFare\GameProcedure.h"
-#include "..\WarFare\UIImageTooltipDlg.h"
+#include "StdAfx.h"
+#include "N3UIIcon.h"
+#include "GameProcedure.h"
+#include "UIImageTooltipDlg.h"
 
 #ifdef _N3GAME
-#include "..\WarFare\N3UIWndBase.h"
+#include "N3UIWndBase.h"
 #endif
 
 #ifdef _DEBUG
@@ -23,7 +22,6 @@ static char THIS_FILE[]=__FILE__;
 
 CN3UIIcon::CN3UIIcon()
 {
-	CN3UIImage::CN3UIImage();
 	m_eType = UI_TYPE_ICON;
 }
 

--- a/Client/WarFare/WarFare.vcxproj
+++ b/Client/WarFare/WarFare.vcxproj
@@ -117,6 +117,7 @@
     <ClCompile Include="MachineMng.cpp" />
     <ClCompile Include="MagicSkillMng.cpp" />
     <ClCompile Include="N3FXBundleGame.cpp" />
+    <ClCompile Include="N3FXMgr.cpp" />
     <ClCompile Include="N3FXPartBillBoardGame.cpp" />
     <ClCompile Include="N3FXPartBottomBoardGame.cpp" />
     <ClCompile Include="N3Pond.cpp" />
@@ -124,6 +125,8 @@
     <ClCompile Include="N3Terrain.cpp" />
     <ClCompile Include="N3TerrainManager.cpp" />
     <ClCompile Include="N3TerrainPatch.cpp" />
+    <ClCompile Include="N3UIDBCLButton.cpp" />
+    <ClCompile Include="N3UIIcon.cpp" />
     <ClCompile Include="N3UIWndBase.cpp" />
     <ClCompile Include="N3WorldBase.cpp" />
     <ClCompile Include="N3WorldManager.cpp" />

--- a/Client/WarFare/WarFare.vcxproj.filters
+++ b/Client/WarFare/WarFare.vcxproj.filters
@@ -327,6 +327,15 @@
     <ClCompile Include="N3Pond.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="N3UIIcon.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="N3FXMgr.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="N3UIDBCLButton.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameProcedure.h">


### PR DESCRIPTION
These are client classes, typically relying on game code. They shouldn't be in N3Base.