### PR TITLE
Default login server IP to 127.0.0.1 in debug builds

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -23,6 +23,17 @@
 
 constexpr int CURRENT_VERSION = 1298;//1068; // 현재 버전
 
+// Server.ini doesn't exist by default with our assets.
+// For simplicity, have the login server default to a local server in debug builds
+// if it's not otherwise supplied.
+#if defined(_DEBUG)
+static constexpr int DEFAULT_LOGIN_SERVER_COUNT = 1;
+static constexpr char DEFAULT_LOGIN_SERVER_IP[] = "127.0.0.1";
+#else
+static constexpr int DEFAULT_LOGIN_SERVER_COUNT = 0;
+static constexpr char DEFAULT_LOGIN_SERVER_IP[] = "";
+#endif
+
 constexpr float PACKET_INTERVAL_MOVE = 1.5f;				// 정기적으로 보내는 패킷 시간 간격..
 constexpr float PACKET_INTERVAL_ROTATE = 4.0f;
 constexpr float PACKET_INTERVAL_REQUEST_TARGET_HP = 2.0f;

--- a/Client/WarFare/GameProcLogIn_1098.cpp
+++ b/Client/WarFare/GameProcLogIn_1098.cpp
@@ -126,18 +126,17 @@ void CGameProcLogIn_1098::Init()
 	lstrcat(szIniPath, "Server.Ini");
 
 	char szRegistrationSite[_MAX_PATH] = {};
-
 	GetPrivateProfileString("Join", "Registration site", "", szRegistrationSite, _MAX_PATH, szIniPath);
 	m_szRegistrationSite = szRegistrationSite;
 
-	int iServerCount = GetPrivateProfileInt("Server", "Count", 0, szIniPath);
+	int iServerCount = GetPrivateProfileInt("Server", "Count", DEFAULT_LOGIN_SERVER_COUNT, szIniPath);
 
 	char szIPs[256][32] = {};
 	for (int i = 0; i < iServerCount; i++)
 	{
 		char szKey[32] = "";
 		sprintf(szKey, "IP%d", i);
-		GetPrivateProfileString("Server", szKey, "", szIPs[i], 32, szIniPath);
+		GetPrivateProfileString("Server", szKey, DEFAULT_LOGIN_SERVER_IP, szIPs[i], 32, szIniPath);
 	}
 
 	int iServer = -1;

--- a/Client/WarFare/GameProcLogIn_1298.cpp
+++ b/Client/WarFare/GameProcLogIn_1298.cpp
@@ -86,18 +86,17 @@ void CGameProcLogIn_1298::Init()
 	lstrcat(szIniPath, "Server.Ini");
 
 	char szRegistrationSite[_MAX_PATH] = {};
-
 	GetPrivateProfileString("Join", "Registration site", "", szRegistrationSite, _MAX_PATH, szIniPath);
 	m_szRegistrationSite = szRegistrationSite;
 
-	int iServerCount = GetPrivateProfileInt("Server", "Count", 0, szIniPath);
+	int iServerCount = GetPrivateProfileInt("Server", "Count", DEFAULT_LOGIN_SERVER_COUNT, szIniPath);
 
 	char szIPs[256][32] = {};
 	for (int i = 0; i < iServerCount; i++)
 	{
 		char szKey[32] = "";
 		sprintf(szKey, "IP%d", i);
-		GetPrivateProfileString("Server", szKey, "", szIPs[i], 32, szIniPath);
+		GetPrivateProfileString("Server", szKey, DEFAULT_LOGIN_SERVER_IP, szIPs[i], 32, szIniPath);
 	}
 
 	int iServer = -1;


### PR DESCRIPTION
Since a default isn't otherwise provided with the assets, I think defaulting this in debug builds is a fair compromise.

We should probably just create a default when it's pulled, but for now this helps things to "just run".

There's no reason to keep this behaviour in release builds since it's only intended for local development.

They can setup server.ini if they need to.