### PR TITLE
Simplify workflows

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -6,15 +6,47 @@
 name: Build all
 
 on:
-  pull_request:
-    types: [labeled]
-    
-  workflow_dispatch:
+  push:
+    branches:
+    - master
 
+    # This specifically builds when anything relating to a build changes.
+    # Everything else can be ignored.
+    paths:
+      - '.github/workflows/build_all.yml'
+      - '**/*.props'
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.hpp'
+      - '**/*.ixx'
+      - '**/*.vcxproj'
+      - 'deps/**'
+      - 'All.sln'
+      - 'ThirdParty.sln'
+
+  pull_request:
+    branches:
+    - master
+
+    # This specifically builds when anything relating to a build changes.
+    # Everything else can be ignored.
+    paths:
+      - '.github/workflows/build_all.yml'
+      - '**/*.props'
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.hpp'
+      - '**/*.ixx'
+      - '**/*.vcxproj'
+      - 'deps/**'
+      - 'All.sln'
+      - 'ThirdParty.sln'
+
+  merge_group: 
+  workflow_dispatch:
+  
 jobs:
   build:
-    if: |
-      github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'build-all')
     runs-on: windows-latest
 
     strategy:
@@ -32,6 +64,23 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
 
-    - name: Build all
+    # NOTE: We could simply run All.sln, but it makes it far more obvious in the Github output when it's broken up across its solutions.
+    - name: Build third party dependencies
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" All.sln
+      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" ThirdParty.sln
+
+    - name: Build client
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Client.sln
+
+    - name: Build server
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Server.sln
+
+    - name: Build tools
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" Tools.sln
+
+    - name: Build client tools
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /p:Configuration="${{matrix.BUILD_CONFIGURATION}}" /p:Platform="${{matrix.BUILD_PLATFORM}}" /p:NO_CLIENT_ASSETS="1" ClientTools.sln

--- a/.github/workflows/build_client.yml
+++ b/.github/workflows/build_client.yml
@@ -7,42 +7,16 @@ name: Build client
 
 on:
   push:
-    branches:
-    - master
-
-    # This specifically builds only the client (KnightOnline.exe) project.
-    # Everything else can be ignored.
     paths:
       - '.github/workflows/build_client.yml'
-      - 'props/**'
-      - 'deps/dx9sdk/**'
-      - 'deps/libjpeg-turbo/**'
-      - 'deps/libjpeg-turbo-msvc/**'
-      - 'Client/JpegFile/**'
-      - 'Client/N3Base/**'
-      - 'Client/WarFare/**'
-      - 'Server/shared/**'
-      - 'Client.sln'
 
   pull_request:
     branches:
     - master
 
-    # This specifically builds only the client (KnightOnline.exe) project.
-    # Everything else can be ignored.
     paths:
       - '.github/workflows/build_client.yml'
-      - 'props/**'
-      - 'deps/dx9sdk/**'
-      - 'deps/libjpeg-turbo/**'
-      - 'deps/libjpeg-turbo-msvc/**'
-      - 'Client/JpegFile/**'
-      - 'Client/N3Base/**'
-      - 'Client/WarFare/**'
-      - 'Server/shared/**'
-      - 'Client.sln'
- 
-  merge_group:
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_client_tools.yml
+++ b/.github/workflows/build_client_tools.yml
@@ -7,44 +7,16 @@ name: Build client tools
 
 on:
   push:
-    branches:
-    - master
-
-    # This specifically builds only the client tool projects.
-    # Everything else can be ignored.
     paths:
       - '.github/workflows/build_client_tools.yml'
-      - 'props/**'
-      - 'deps/dx9sdk/**'
-      - 'deps/libjpeg-turbo/**'
-      - 'deps/libjpeg-turbo-msvc/**'
-      - 'Client/JpegFile/**'
-      - 'Client/KscViewer/**'
-      - 'Client/Launcher/**'
-      - 'Client/Option/**'
-      - 'ClientTools.sln'
-      - 'ThirdParty.sln'
 
   pull_request:
     branches:
     - master
 
-    # This specifically builds only the client tool projects.
-    # Everything else can be ignored.
     paths:
       - '.github/workflows/build_client_tools.yml'
-      - 'props/**'
-      - 'deps/dx9sdk/**'
-      - 'deps/libjpeg-turbo/**'
-      - 'deps/libjpeg-turbo-msvc/**'
-      - 'Client/JpegFile/**'
-      - 'Client/KscViewer/**'
-      - 'Client/Launcher/**'
-      - 'Client/Option/**'
-      - 'ClientTools.sln'
-      - 'ThirdParty.sln'
  
-  merge_group: 
   workflow_dispatch:
 
 # These should really be moved into the one solution.

--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -7,56 +7,16 @@ name: Build server
 
 on:
   push:
-    branches:
-    - master
-
-    # This specifically builds only the server projects.
-    # Everything else can be ignored.
     paths:
       - '.github/workflows/build_server.yml'
-      - 'props/**'
-      - 'deps/dx9sdk/**'
-      - 'deps/ZipArchive/**'
-      - 'deps/zlib/**'
-      - 'deps/zlib-msvc/**'
-      - 'Server/AIServer/**'
-      - 'Server/Aujard/**'
-      - 'Server/Ebenezer/**'
-      - 'Server/ItemManager/**'
-      - 'Server/shared/**'
-      - 'Server/VersionManager/**'
-      - 'Client/N3Base/My_3DStruct.h'
-      - 'Client/N3Base/N3ShapeMgr.h'
-      - 'Client/N3Base/N3ShapeMgr.cpp'
-      - 'Server.sln'
-      - 'ThirdParty.sln'
 
   pull_request:
     branches:
     - master
 
-    # This specifically builds only the server projects.
-    # Everything else can be ignored.
     paths:
       - '.github/workflows/build_server.yml'
-      - 'props/**'
-      - 'deps/dx9sdk/**'
-      - 'deps/ZipArchive/**'
-      - 'deps/zlib/**'
-      - 'deps/zlib-msvc/**'
-      - 'Server/AIServer/**'
-      - 'Server/Aujard/**'
-      - 'Server/Ebenezer/**'
-      - 'Server/ItemManager/**'
-      - 'Server/shared/**'
-      - 'Server/VersionManager/**'
-      - 'Client/N3Base/My_3DStruct.h'
-      - 'Client/N3Base/N3ShapeMgr.h'
-      - 'Client/N3Base/N3ShapeMgr.cpp'
-      - 'Server.sln'
-      - 'ThirdParty.sln'
- 
-  merge_group:
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -7,54 +7,16 @@ name: Build tools
 
 on:
   push:
-    branches:
-    - master
-
-    # This specifically builds only the tool projects.
-    # Everything else can be ignored.
     paths:
       - '.github/workflows/build_tools.yml'
-      - 'props/**'
-      - 'deps/dx9sdk/**'
-      - 'ItemEditor/**'
-      - 'N3CE/**'
-      - 'N3FXE/**'
-      - 'N3ME/**'
-      - 'N3TexViewer/**'
-      - 'N3Viewer/**'
-      - 'SkyViewer/**'
-      - 'TblEditor/**'
-      - 'UIE/**'
-      - 'Server/shared/**'
-      - 'Client/N3Base/**'
-      - 'Tools.sln'
-      - 'ThirdParty.sln'
 
   pull_request:
     branches:
     - master
 
-    # This specifically builds only the tool projects.
-    # Everything else can be ignored.
     paths:
       - '.github/workflows/build_tools.yml'
-      - 'props/**'
-      - 'deps/dx9sdk/**'
-      - 'ItemEditor/**'
-      - 'N3CE/**'
-      - 'N3FXE/**'
-      - 'N3ME/**'
-      - 'N3TexViewer/**'
-      - 'N3Viewer/**'
-      - 'SkyViewer/**'
-      - 'TblEditor/**'
-      - 'UIE/**'
-      - 'Server/shared/**'
-      - 'Client/N3Base/**'
-      - 'Tools.sln'
-      - 'ThirdParty.sln'
- 
-  merge_group: 
+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Go back to triggering build_all.yml for everything. Only trigger the others if we explicitly change those workflows (or if we manually request it).

Additionally, in "all", rather than just running All.sln (and having no idea how many are actually left), we run each of the individual solutions to break up the workflow's progress in a measurable way.