### PR TITLE
Test PR

### DIFF
--- a/Client/WarFare/UIHotKeyDlg.cpp
+++ b/Client/WarFare/UIHotKeyDlg.cpp
@@ -933,6 +933,55 @@ bool CUIHotKeyDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 	return false;
 }
 
+bool CUIHotKeyDlg::SetReceiveSelectedItem(int iIndex)
+{
+	if (CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWnd != UIWND_INVENTORY)
+		return false;
+	
+	__IconItemSkill* spSkill, * spItem;
+
+	spItem = CN3UIWndBase::m_sSelectedIconInfo.pItemSelect;
+
+	__TABLE_UPC_SKILL* pUSkill = CGameBase::s_pTbl_Skill.Find(spItem->pItemBasic->dwEffectID1);
+	if (pUSkill == nullptr) return false;
+	if (pUSkill->dwID < UIITEM_TYPE_SONGPYUN_ID_MIN) return false;
+
+	spSkill = new __IconItemSkill();
+	spSkill->pSkill = pUSkill;
+
+	// Create the icon name
+	std::vector<char> buffer(256, NULL);
+	sprintf(&buffer[0], "UI\\skillicon_%.2d_%d.dxt", spItem->pItemBasic->dwEffectID1 % 100, spItem->pItemBasic->dwEffectID1 / 100);
+	spSkill->szIconFN = &buffer[0];
+
+	// load icon
+	spSkill->pUIIcon = new CN3UIIcon;
+	spSkill->pUIIcon->Init(this);
+	spSkill->pUIIcon->SetTex(spSkill->szIconFN);
+	spSkill->pUIIcon->SetUVRect(0, 0, 1.0f, 1.0f);
+	spSkill->pUIIcon->SetUIType(UI_TYPE_ICON);
+	spSkill->pUIIcon->SetStyle(UISTYLE_ICON_SKILL);
+
+	uint32_t bitMask = UISTYLE_ICON_SKILL;
+	if (!CGameProcedure::s_pProcMain->m_pMagicSkillMng->CheckValidSkillMagic(spSkill->pSkill))
+		bitMask |= UISTYLE_DISABLE_SKILL;
+	spSkill->pUIIcon->SetStyle(bitMask);
+
+	CN3UIArea* pArea = nullptr;
+	pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_SKILL_HOTKEY, iIndex);
+	
+	if (pArea != nullptr)
+	{
+		spSkill->pUIIcon->SetRegion(pArea->GetRegion());
+		spSkill->pUIIcon->SetMoveRect(pArea->GetRegion());
+	}
+	
+	m_pMyHotkey[m_iCurPage][iIndex] = spSkill;
+
+	CloseIconRegistry();
+	return true;
+}
+
 bool CUIHotKeyDlg::EffectTriggerByMouse()
 {
 	if(m_iSelectIndex < 0 || m_iSelectIndex >= 8) return false;

--- a/Client/WarFare/UIHotKeyDlg.h
+++ b/Client/WarFare/UIHotKeyDlg.h
@@ -76,6 +76,7 @@ public:
 //	bool				ReceiveSelectedSkill();
 	bool				IsSelectedSkillInRealIconArea();
 	void				SetReceiveSelectedSkill(int iIndex);
+	bool				SetReceiveSelectedItem(int iIndex);
 	bool				GetEmptySlotIndex(int &iIndex);
 
 	void				AllFactorClear();

--- a/Client/WarFare/UIInventory.cpp
+++ b/Client/WarFare/UIInventory.cpp
@@ -19,6 +19,7 @@
 #include "UIRepairTooltipDlg.h"
 #include "UIHotKeyDlg.h"
 #include "UISkillTreeDlg.h"
+#include "MagicSkillMng.h"
 
 #include "resource.h"
 
@@ -1484,16 +1485,37 @@ bool CUIInventory::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 					
 					// Get Item..
 					spItem = GetHighlightIconItem((CN3UIIcon* )pSender);
-
-					CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWnd = UIWND_INVENTORY;
-					if (bSlot)
-						CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict = UIWND_DISTRICT_INVENTORY_SLOT;
-					else
-						CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict = UIWND_DISTRICT_INVENTORY_INV;
 					
+					CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWnd = UIWND_INVENTORY;
 					CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.iOrder = iRBtn;
 					CN3UIWndBase::m_sSelectedIconInfo.pItemSelect = spItem;
-					
+					if (bSlot) //player clicked on equiped items
+					{
+						CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict = UIWND_DISTRICT_INVENTORY_SLOT;
+					}
+					else //player clicked on item which is not equiped
+					{
+						CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict = UIWND_DISTRICT_INVENTORY_INV;
+						
+						//right click on item to hotkey (skillbar)
+						if (spItem->pItemBasic->byClass == 97) //usable items
+						{
+							CUIHotKeyDlg* pDlg = CGameProcedure::s_pProcMain->m_pUIHotKeyDlg;
+							int iIndex;
+							if (pDlg->GetEmptySlotIndex(iIndex))
+							{
+								bool bResult = false;
+								CN3UIWndBase::m_sSkillSelectInfo.UIWnd = UIWND_INVENTORY;
+								bResult = pDlg->SetReceiveSelectedItem(iIndex);
+
+								//no sound on success
+								if (bResult) 
+									return true;
+									
+							}
+						}
+					}
+
 					if (spItem) PlayItemSound(spItem->pItemBasic);
 
 					//..


### PR DESCRIPTION
Test PR. Don't mind me.

## Summary by Sourcery

Enable hotkey assignment for usable inventory items via right-click and support placing them into hotkey slots

New Features:
- Introduce SetReceiveSelectedItem to assign a selected inventory item to a hotkey slot with icon creation and validation
- Enable right-click on usable items in the inventory to automatically place them into the first available hotkey slot

Enhancements:
- Refactor CUIInventory::ReceiveMessage to streamline UI selection logic and include MagicSkillMng header