### PR TITLE
Update README.md to link database directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use the search field to find them from there.
 
 Along with its accompanying SQL Server Management Studio.
 
-Additionally, you will need to download and restore the database over on our <a href="http://ko4life.net/topic/50-the-openko-project/" target="_blank">ko4life thread</a>, which restores fine as of Microsoft SQL Server 2022.
+Additionally, you will need to download and restore [our database](https://mega.nz/file/C8VCAbaC#roPiSnFHzHRlet8cKuzqU8ZFB8kSRVjOCKyzNHpa47U), which restores fine as of Microsoft SQL Server 2022.
 
 ### Git or Github Desktop
 


### PR DESCRIPTION
Remove reference to the ko4life forums.
Who knows how long they'll exist for, and apparently they block certain countries.

## Summary by Sourcery

Documentation:
- Replace reference to the ko4life forums with a direct Mega.nz link for downloading the database