### PR TITLE
UISkillTree - Update

### DIFF
--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -274,12 +274,6 @@ bool CUISkillTreeDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 			SetPageInIconRegion(3, 0);
 		if ((pSender->m_szID == "btn_master"))
 			SetPageInIconRegion(4, 0);
-		/*
-		if( (pSender->m_szID == "btn_ranger3") || (pSender->m_szID == "btn_blade3") || (pSender->m_szID == "btn_mage3") || 
-				(pSender->m_szID == "btn_cleric3") || (pSender->m_szID == "btn_hunter3") || (pSender->m_szID == "btn_berserker3") || 
-				(pSender->m_szID == "btn_sorcerer3") || (pSender->m_szID == "btn_shaman3") )
-			SetPageInIconRegion(4, 0);
-		*/
 	}
 
 // Temp Define
@@ -803,13 +797,13 @@ void CUISkillTreeDlg::CheckButtonTooltipRenderEnable()
 			rect[SKILL_DEF_SPECIAL0]	= ((CN3UIButton* )GetChildByID("btn_blade0"))->GetClickRect();
 			rect[SKILL_DEF_SPECIAL1]	= ((CN3UIButton* )GetChildByID("btn_blade1"))->GetClickRect();
 			rect[SKILL_DEF_SPECIAL2]	= ((CN3UIButton* )GetChildByID("btn_blade2"))->GetClickRect();
-			//rect[SKILL_DEF_SPECIAL3]	= ((CN3UIButton* )GetChildByID("btn_blade3"))->GetClickRect();
+			rect[SKILL_DEF_SPECIAL3]	= ((CN3UIButton* )GetChildByID("btn_master"))->GetClickRect();
 			break;
 		case NATION_KARUS:
 			rect[SKILL_DEF_SPECIAL0]	= ((CN3UIButton* )GetChildByID("btn_berserker0"))->GetClickRect();
 			rect[SKILL_DEF_SPECIAL1]	= ((CN3UIButton* )GetChildByID("btn_berserker1"))->GetClickRect();
 			rect[SKILL_DEF_SPECIAL2]	= ((CN3UIButton* )GetChildByID("btn_berserker2"))->GetClickRect();
-			//rect[SKILL_DEF_SPECIAL3]	= ((CN3UIButton* )GetChildByID("btn_berserker3"))->GetClickRect();
+			rect[SKILL_DEF_SPECIAL3]	= ((CN3UIButton* )GetChildByID("btn_master"))->GetClickRect();
 			break;
 	}
 
@@ -822,6 +816,7 @@ void CUISkillTreeDlg::CheckButtonTooltipRenderEnable()
 	}
 }
 
+// Tool tip on hoverover of skill tabs
 void CUISkillTreeDlg::ButtonTooltipRender(int iIndex)
 {
 	std::string szStr;
@@ -830,106 +825,134 @@ void CUISkillTreeDlg::ButtonTooltipRender(int iIndex)
 
 	switch (iIndex)
 	{
-		case SKILL_DEF_BASIC:
+		case SKILL_DEF_BASIC:													// basic skill tab
 			CGameBase::GetText(IDS_SKILL_INFO_BASE, &szStr);
 			break;
 
-		case SKILL_DEF_SPECIAL0:
+		case SKILL_DEF_SPECIAL0:												// first skill tab
 			switch (CGameBase::s_pPlayer->m_InfoBase.eClass)
 			{
 				case CLASS_EL_BLADE:
+				case CLASS_EL_PROTECTOR:
 				case CLASS_KA_BERSERKER:
+				case CLASS_KA_GUARDIAN:
 					CGameBase::GetText(IDS_SKILL_INFO_BLADE0, &szStr);
 					break;
 
 				case CLASS_EL_RANGER:
+				case CLASS_EL_ASSASIN:
 				case CLASS_KA_HUNTER:
+				case CLASS_KA_PENETRATOR:
 					CGameBase::GetText(IDS_SKILL_INFO_RANGER0, &szStr);
 					break;
 
 				case CLASS_EL_CLERIC:
+				case CLASS_EL_DRUID:
 				case CLASS_KA_SHAMAN:
+				case CLASS_KA_DARKPRIEST:
 					CGameBase::GetText(IDS_SKILL_INFO_CLERIC0, &szStr);
 					break;
 
 				case CLASS_EL_MAGE:
+				case CLASS_EL_ENCHANTER:
 				case CLASS_KA_SORCERER:
+				case CLASS_KA_NECROMANCER:
 					CGameBase::GetText(IDS_SKILL_INFO_MAGE0, &szStr);
 					break;
 			}
 			break;
 
-		case SKILL_DEF_SPECIAL1:
+		case SKILL_DEF_SPECIAL1:											// second skill tab
 			switch (CGameBase::s_pPlayer->m_InfoBase.eClass)
 			{
 				case CLASS_EL_BLADE:
+				case CLASS_EL_PROTECTOR:
 				case CLASS_KA_BERSERKER:
+				case CLASS_KA_GUARDIAN:
 					CGameBase::GetText(IDS_SKILL_INFO_BLADE1, &szStr);
 					break;
 
 				case CLASS_EL_RANGER:
+				case CLASS_EL_ASSASIN:
 				case CLASS_KA_HUNTER:
+				case CLASS_KA_PENETRATOR:
 					CGameBase::GetText(IDS_SKILL_INFO_RANGER1, &szStr);
 					break;
 
 				case CLASS_EL_CLERIC:
+				case CLASS_EL_DRUID:
 				case CLASS_KA_SHAMAN:
+				case CLASS_KA_DARKPRIEST:
 					CGameBase::GetText(IDS_SKILL_INFO_CLERIC1, &szStr);
 					break;
 
 				case CLASS_EL_MAGE:
+				case CLASS_EL_ENCHANTER:
 				case CLASS_KA_SORCERER:
+				case CLASS_KA_NECROMANCER:
 					CGameBase::GetText(IDS_SKILL_INFO_MAGE1, &szStr);
 					break;
 			}
 			break;
 
-		case SKILL_DEF_SPECIAL2:
+		case SKILL_DEF_SPECIAL2:												// third skill tab
 			switch (CGameBase::s_pPlayer->m_InfoBase.eClass)
 			{
 				case CLASS_EL_BLADE:
+				case CLASS_EL_PROTECTOR:
 				case CLASS_KA_BERSERKER:
+				case CLASS_KA_GUARDIAN:
 					CGameBase::GetText(IDS_SKILL_INFO_BLADE2, &szStr);
 					break;
 
 				case CLASS_EL_RANGER:
+				case CLASS_EL_ASSASIN:
 				case CLASS_KA_HUNTER:
+				case CLASS_KA_PENETRATOR:
 					CGameBase::GetText(IDS_SKILL_INFO_RANGER2, &szStr);
 					break;
 
 				case CLASS_EL_CLERIC:
+				case CLASS_EL_DRUID:
 				case CLASS_KA_SHAMAN:
+				case CLASS_KA_DARKPRIEST:
 					CGameBase::GetText(IDS_SKILL_INFO_CLERIC2, &szStr);
 					break;
 
 				case CLASS_EL_MAGE:
+				case CLASS_EL_ENCHANTER:
 				case CLASS_KA_SORCERER:
+				case CLASS_KA_NECROMANCER:
 					CGameBase::GetText(IDS_SKILL_INFO_MAGE2, &szStr);
 					break;
 			}
 			break;
 
-		case SKILL_DEF_SPECIAL3:
+		case SKILL_DEF_SPECIAL3:												// master skill tab
 			switch (CGameBase::s_pPlayer->m_InfoBase.eClass)
 			{
-				case CLASS_EL_BLADE:
-				case CLASS_KA_BERSERKER:
+				case CLASS_EL_PROTECTOR:
+				case CLASS_KA_GUARDIAN:
 					CGameBase::GetText(IDS_SKILL_INFO_BLADE3, &szStr);
 					break;
 
-				case CLASS_EL_RANGER:
-				case CLASS_KA_HUNTER:
+				case CLASS_EL_ASSASIN:
+				case CLASS_KA_PENETRATOR:
 					CGameBase::GetText(IDS_SKILL_INFO_RANGER3, &szStr);
 					break;
 
-				case CLASS_EL_CLERIC:
-				case CLASS_KA_SHAMAN:
+				case CLASS_EL_DRUID:
+				case CLASS_KA_DARKPRIEST:
 					CGameBase::GetText(IDS_SKILL_INFO_CLERIC3, &szStr);
 					break;
 
-				case CLASS_EL_MAGE:
-				case CLASS_KA_SORCERER:
+				case CLASS_EL_ENCHANTER:
+				case CLASS_KA_NECROMANCER:
 					CGameBase::GetText(IDS_SKILL_INFO_MAGE3, &szStr);
+					break;
+
+				default:
+					szStr = "";
 					break;
 			}
 			break;
@@ -1221,118 +1244,156 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 	// All Button Set Invisible..
 	// Elmorad..
 	switch ( CGameBase::s_pPlayer->m_InfoBase.eNation )
-	{
-		case NATION_ELMORAD:
-			pButton = (CN3UIButton* )GetChildByID("btn_ranger0");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_ranger1");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_ranger2");	ASSET_0
-			//pButton = (CN3UIButton* )GetChildByID("btn_ranger3");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_blade0");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_blade1");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_blade2");	ASSET_0
-			//pButton = (CN3UIButton* )GetChildByID("btn_blade3");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_mage0");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_mage1");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_mage2");		ASSET_0
-			//pButton = (CN3UIButton* )GetChildByID("btn_mage3");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_cleric0");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_cleric1");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_cleric2");	ASSET_0
-			//pButton = (CN3UIButton* )GetChildByID("btn_cleric3");	ASSET_0
-			break;
+{
+	case NATION_ELMORAD:
+		pButton = (CN3UIButton* )GetChildByID("btn_ranger0");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_ranger1");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_ranger2");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_blade0");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_blade1");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_blade2");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_mage0");			ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_mage1");			ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_mage2");			ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_cleric0");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_cleric1");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_cleric2");		ASSET_0
+		pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_0
+		break;
 
-	// Karus..
-		case NATION_KARUS:
-			pButton = (CN3UIButton* )GetChildByID("btn_hunter0");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_hunter1");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_hunter2");		ASSET_0
-//			pButton = (CN3UIButton* )GetChildByID("btn_hunter3");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_berserker0");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_berserker1");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_berserker2");	ASSET_0
-//			pButton = (CN3UIButton* )GetChildByID("btn_berserker3");	ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_sorcerer0");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_sorcerer1");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_sorcerer2");		ASSET_0
-//			pButton = (CN3UIButton* )GetChildByID("btn_sorcerer3");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_shaman0");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_shaman1");		ASSET_0
-			pButton = (CN3UIButton* )GetChildByID("btn_shaman2");		ASSET_0
-//			pButton = (CN3UIButton* )GetChildByID("btn_shaman3");		ASSET_0	
-			break;
-	}
+// Karus..
+	case NATION_KARUS:
+		pButton = (CN3UIButton* )GetChildByID("btn_hunter0");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_hunter1");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_hunter2");		ASSET_0
+		pButton = (CN3UIButton*) GetChildByID("btn_hunter3");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_berserker0");	ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_berserker1");	ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_berserker2");	ASSET_0
+		pButton = (CN3UIButton*) GetChildByID("btn_berserker3");	ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_sorcerer0");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_sorcerer1");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_sorcerer2");		ASSET_0
+		pButton = (CN3UIButton*) GetChildByID("btn_sorcerer3");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_shaman0");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_shaman1");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_shaman2");		ASSET_0
+		pButton = (CN3UIButton*) GetChildByID("btn_shaman3");		ASSET_0
+		pButton = (CN3UIButton* )GetChildByID("btn_master");		ASSET_0	
+		break;
+}
 
-	if (m_iCurKindOf == 0)
-	{
-		pButton = (CN3UIButton* )GetChildByID("btn_public");
-		pButton->SetState(UI_STATE_BUTTON_DOWN);
-	}
+if (m_iCurKindOf == 0)
+{
+	pButton = (CN3UIButton* )GetChildByID("btn_public");
+	pButton->SetState(UI_STATE_BUTTON_DOWN);
+}
 
-	switch ( CGameBase::s_pPlayer->m_InfoBase.eClass )
-	{
-		case CLASS_KA_BERSERKER:
-		case CLASS_KA_GUARDIAN:
-			pButton = (CN3UIButton* )GetChildByID("btn_berserker0");	ASSET_1
-			pButton = (CN3UIButton* )GetChildByID("btn_berserker1");	ASSET_2
-			pButton = (CN3UIButton* )GetChildByID("btn_berserker2");	ASSET_3
-			//pButton = (CN3UIButton* )GetChildByID("btn_berserker3");	ASSET_4
-			break;
+switch ( CGameBase::s_pPlayer->m_InfoBase.eClass )
+{
+	case CLASS_KA_BERSERKER:
+		pButton = (CN3UIButton* )GetChildByID("btn_berserker0");	ASSET_1
+		pButton = (CN3UIButton* )GetChildByID("btn_berserker1");	ASSET_2
+		pButton = (CN3UIButton* )GetChildByID("btn_berserker2");	ASSET_3
+		break;
 
-		case CLASS_KA_PENETRATOR:
-		case CLASS_KA_HUNTER:
-			pButton = (CN3UIButton* )GetChildByID("btn_hunter0");		ASSET_1
-			pButton = (CN3UIButton* )GetChildByID("btn_hunter1");		ASSET_2
-			pButton = (CN3UIButton* )GetChildByID("btn_hunter2");		ASSET_3
-			//pButton = (CN3UIButton* )GetChildByID("btn_hunter3");		ASSET_4
-			break;
+	case CLASS_KA_GUARDIAN:
+		pButton = (CN3UIButton*) GetChildByID("btn_berserker0");	ASSET_1
+		pButton = (CN3UIButton*) GetChildByID("btn_berserker1");	ASSET_2
+		pButton = (CN3UIButton*) GetChildByID("btn_berserker2");	ASSET_3
+		pButton = (CN3UIButton* )GetChildByID("btn_master");		ASSET_4
+		break;
 
-		case CLASS_KA_SHAMAN:
-		case CLASS_KA_DARKPRIEST:
-			pButton = (CN3UIButton* )GetChildByID("btn_shaman0");		ASSET_1
-			pButton = (CN3UIButton* )GetChildByID("btn_shaman1");		ASSET_2
-			pButton = (CN3UIButton* )GetChildByID("btn_shaman2");		ASSET_3
-			//pButton = (CN3UIButton* )GetChildByID("btn_shaman3");		ASSET_4
-			break;
+	case CLASS_KA_HUNTER:
+		pButton = (CN3UIButton* )GetChildByID("btn_hunter0");		ASSET_1
+		pButton = (CN3UIButton* )GetChildByID("btn_hunter1");		ASSET_2
+		pButton = (CN3UIButton* )GetChildByID("btn_hunter2");		ASSET_3
+		break;
 
-		case CLASS_KA_SORCERER:
-		case CLASS_KA_NECROMANCER:
-			pButton = (CN3UIButton* )GetChildByID("btn_sorcerer0");		ASSET_1
-			pButton = (CN3UIButton* )GetChildByID("btn_sorcerer1");		ASSET_2
-			pButton = (CN3UIButton* )GetChildByID("btn_sorcerer2");		ASSET_3
-			//pButton = (CN3UIButton* )GetChildByID("btn_sorcerer3");		ASSET_4
-			break;
+	case CLASS_KA_PENETRATOR:
+		pButton = (CN3UIButton*) GetChildByID("btn_hunter0");		ASSET_1
+		pButton = (CN3UIButton*) GetChildByID("btn_hunter1");		ASSET_2
+		pButton = (CN3UIButton*) GetChildByID("btn_hunter2");		ASSET_3
+		pButton = (CN3UIButton* )GetChildByID("btn_master");		ASSET_4
+		break;
 
-		case CLASS_EL_BLADE:
-		case CLASS_EL_PROTECTOR:
-			pButton = (CN3UIButton* )GetChildByID("btn_blade0");	ASSET_1
-			pButton = (CN3UIButton* )GetChildByID("btn_blade1");	ASSET_2
-			pButton = (CN3UIButton* )GetChildByID("btn_blade2");	ASSET_3
-			//pButton = (CN3UIButton* )GetChildByID("btn_blade3");	ASSET_4
-			break;
+	case CLASS_KA_SHAMAN:
+		pButton = (CN3UIButton*) GetChildByID("btn_shaman0");		ASSET_1
+		pButton = (CN3UIButton*) GetChildByID("btn_shaman1");		ASSET_2
+		pButton = (CN3UIButton*) GetChildByID("btn_shaman2");		ASSET_3
+		break;
 
-		case CLASS_EL_RANGER:
-		case CLASS_EL_ASSASIN:
-			pButton = (CN3UIButton* )GetChildByID("btn_ranger0");	ASSET_1
-			pButton = (CN3UIButton* )GetChildByID("btn_ranger1");	ASSET_2
-			pButton = (CN3UIButton* )GetChildByID("btn_ranger2");	ASSET_3
-			//pButton = (CN3UIButton* )GetChildByID("btn_ranger3");	ASSET_4
-			break;
+	case CLASS_KA_DARKPRIEST:
+		pButton = (CN3UIButton* )GetChildByID("btn_shaman0");		ASSET_1
+		pButton = (CN3UIButton* )GetChildByID("btn_shaman1");		ASSET_2
+		pButton = (CN3UIButton* )GetChildByID("btn_shaman2");		ASSET_3
+		pButton = (CN3UIButton* )GetChildByID("btn_master");		ASSET_4
+		break;
 
-		case CLASS_EL_CLERIC:
-		case CLASS_EL_DRUID:
-			pButton = (CN3UIButton* )GetChildByID("btn_cleric0");	ASSET_1
-			pButton = (CN3UIButton* )GetChildByID("btn_cleric1");	ASSET_2
-			pButton = (CN3UIButton* )GetChildByID("btn_cleric2");	ASSET_3
-			//pButton = (CN3UIButton* )GetChildByID("btn_cleric3");	ASSET_4
-			break;
+	case CLASS_KA_SORCERER:
+		pButton = (CN3UIButton*) GetChildByID("btn_sorcerer0");		ASSET_1
+		pButton = (CN3UIButton*) GetChildByID("btn_sorcerer1");		ASSET_2
+		pButton = (CN3UIButton*) GetChildByID("btn_sorcerer2");		ASSET_3
+		break;
 
-		case CLASS_EL_MAGE:
-		case CLASS_EL_ENCHANTER:
-			pButton = (CN3UIButton* )GetChildByID("btn_mage0");		ASSET_1
-			pButton = (CN3UIButton* )GetChildByID("btn_mage1");		ASSET_2
-			pButton = (CN3UIButton* )GetChildByID("btn_mage2");		ASSET_3
-			//pButton = (CN3UIButton* )GetChildByID("btn_mage3");		ASSET_4
-			break;
+	case CLASS_KA_NECROMANCER:
+		pButton = (CN3UIButton* )GetChildByID("btn_sorcerer0");		ASSET_1
+		pButton = (CN3UIButton* )GetChildByID("btn_sorcerer1");		ASSET_2
+		pButton = (CN3UIButton* )GetChildByID("btn_sorcerer2");		ASSET_3
+		pButton = (CN3UIButton* )GetChildByID("btn_master");		ASSET_4
+		break;
+
+	case CLASS_EL_BLADE:
+		pButton = (CN3UIButton*) GetChildByID("btn_blade0");		ASSET_1
+		pButton = (CN3UIButton*) GetChildByID("btn_blade1");		ASSET_2
+		pButton = (CN3UIButton*) GetChildByID("btn_blade2");		ASSET_3
+		break;
+
+	case CLASS_EL_PROTECTOR:
+		pButton = (CN3UIButton* )GetChildByID("btn_blade0");		ASSET_1
+		pButton = (CN3UIButton* )GetChildByID("btn_blade1");		ASSET_2
+		pButton = (CN3UIButton* )GetChildByID("btn_blade2");		ASSET_3
+		pButton = (CN3UIButton* )GetChildByID("btn_master");		ASSET_4
+		break;
+
+	case CLASS_EL_RANGER:
+		pButton = (CN3UIButton*) GetChildByID("btn_ranger0");		ASSET_1
+		pButton = (CN3UIButton*) GetChildByID("btn_ranger1");		ASSET_2
+		pButton = (CN3UIButton*) GetChildByID("btn_ranger2");		ASSET_3
+		break;
+
+	case CLASS_EL_ASSASIN:
+		pButton = (CN3UIButton* )GetChildByID("btn_ranger0");		ASSET_1
+		pButton = (CN3UIButton* )GetChildByID("btn_ranger1");		ASSET_2
+		pButton = (CN3UIButton* )GetChildByID("btn_ranger2");		ASSET_3
+		pButton = (CN3UIButton* )GetChildByID("btn_master");		ASSET_4
+		break;
+
+	case CLASS_EL_CLERIC:
+		pButton = (CN3UIButton*) GetChildByID("btn_cleric0");		ASSET_1
+		pButton = (CN3UIButton*) GetChildByID("btn_cleric1");		ASSET_2
+		pButton = (CN3UIButton*) GetChildByID("btn_cleric2");		ASSET_3
+		break;
+
+	case CLASS_EL_DRUID:
+		pButton = (CN3UIButton* )GetChildByID("btn_cleric0");		ASSET_1
+		pButton = (CN3UIButton* )GetChildByID("btn_cleric1");		ASSET_2
+		pButton = (CN3UIButton* )GetChildByID("btn_cleric2");		ASSET_3
+		pButton = (CN3UIButton* )GetChildByID("btn_master");		ASSET_4
+		break;
+
+	case CLASS_EL_MAGE:
+		pButton = (CN3UIButton*) GetChildByID("btn_mage0");			ASSET_1
+		pButton = (CN3UIButton*) GetChildByID("btn_mage1");			ASSET_2
+		pButton = (CN3UIButton*) GetChildByID("btn_mage2");			ASSET_3
+		break;
+
+	case CLASS_EL_ENCHANTER:
+		pButton = (CN3UIButton* )GetChildByID("btn_mage0");			ASSET_1
+		pButton = (CN3UIButton* )GetChildByID("btn_mage1");			ASSET_2
+		pButton = (CN3UIButton* )GetChildByID("btn_mage2");			ASSET_3
+		pButton = (CN3UIButton* )GetChildByID("btn_master");		ASSET_4
+		break;
 	}
 }
 
@@ -1341,7 +1402,7 @@ void CUISkillTreeDlg::AddSkillToPage(__TABLE_UPC_SKILL* pUSkill, int iOffset, bo
 	int i, j;
 	bool bFound = false;
 
-	// m_pMySkillTree[iOffset]에 같은 아이디가 있는지 살펴본다..
+	// Check if the same ID exists for m_pMySkillTree[iOffset]
 	for( i = 0; i < MAX_SKILL_PAGE_NUM; i++ )
 		for ( j = 0; j < MAX_SKILL_IN_PAGE; j++ )
 		{
@@ -1352,7 +1413,7 @@ void CUISkillTreeDlg::AddSkillToPage(__TABLE_UPC_SKILL* pUSkill, int iOffset, bo
 			}
 		}
 
-	// m_pMySkillTree[iOffset]에 들어갈 수 있는지 살펴본다..
+	// Check if skill can be placed in m_pMySkillTree[iOffset]
 	for( i = 0; i < MAX_SKILL_PAGE_NUM; i++ )
 		for ( j = 0; j < MAX_SKILL_IN_PAGE; j++ )
 		{
@@ -1582,55 +1643,62 @@ void CUISkillTreeDlg::SetPageInIconRegion(int iKindOf, int iPageNum)		// 아이�
 	if(pStr) pStr->SetString(cstr);
 }
 
-void CUISkillTreeDlg::AllClearImageByName(const std::string& szFN, bool bTrueOrNot)
+void CUISkillTreeDlg::AllClearImageByName(const std::string& szFN, bool bVisible, const std::string& szFNMaster, bool bVisibleMaster)
 {
-//	CN3UIImage* pImage;
 	CN3UIBase* pBase;
 	CN3UIButton* pButton;
-
 	std::string str;
-	char	cstr[4];
 
-	for ( int i = 0; i < 4; i++ )
+	// 2nd job information
+	for (int i = 0; i < 4; i++)
 	{
-		str = "img_";	str += szFN;	sprintf(cstr, "_%d", i);	str+= cstr;
+		str = "img_" + szFN + "_" + std::to_string(i);
 		pBase = GetChildByID(str);
-		if (pBase) pBase->SetVisible(bTrueOrNot);	
+		if (pBase) pBase->SetVisible(bVisible);
 	}
 
-	str = "img_";	str += szFN;
-	pBase = GetChildByID(str);
-	if (pBase) pBase->SetVisible(bTrueOrNot);
-
-	for (int i = 0; i < 4; i++ )
+	if (!bVisibleMaster)
 	{
-		str = "btn_";	str += szFN;	sprintf(cstr, "%d", i);	str+= cstr;
-		pButton = GetChildButtonByName(str);
-		if (pButton) pButton->SetVisible(bTrueOrNot);
+		str = "img_" + szFN;
+		pBase = GetChildByID(str);
+		if (pBase) pBase->SetVisible(bVisible);
 	}
+
+	for (int i = 0; i < 4; i++)
+	{
+		str = "btn_" + szFN + std::to_string(i);
+		pButton = GetChildButtonByName(str);
+		if (pButton) pButton->SetVisible(bVisible);
+	}
+
+	// master information
+	pBase = GetChildByID("img_master");
+	if (pBase) pBase->SetVisible(bVisibleMaster);
+
+	pButton = GetChildButtonByName("btn_master");
+	if (pButton) pButton->SetVisible(bVisibleMaster);
+
+	str = "img_" + szFNMaster;
+	pBase = GetChildByID(str);
+	if (pBase) pBase->SetVisible(bVisibleMaster);
 }
 
 void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 페이지 설정..
 {
-	
+
 	AllClearImageByName("public", false);
 
-	switch ( CGameBase::s_pPlayer->m_InfoBase.eNation )
+	switch (CGameBase::s_pPlayer->m_InfoBase.eNation)
 	{
-		
+
 		case NATION_KARUS:			// 카루스..
-			AllClearImageByName("hunter", false);  
-			AllClearImageByName("berserker", false);
-			AllClearImageByName("sorcerer", false);
-			AllClearImageByName("shaman", false);
-			AllClearImageByName("Shadow Knight",false);
-			AllClearImageByName("Berserker Hero", false);
-			AllClearImageByName("Elemental Lord", false);
-			AllClearImageByName("Shadow Bane", false);
-			
+			AllClearImageByName("berserker", false, "Berserker Hero", false);
+			AllClearImageByName("hunter", false, "Shadow Bane", false);
+			AllClearImageByName("sorcerer", false, "Elemental Lord", false);
+			AllClearImageByName("shaman", false, "Shadow Knight", false);
 
 			// 직업.. 
-			switch ( CGameBase::s_pPlayer->m_InfoBase.eClass )
+			switch (CGameBase::s_pPlayer->m_InfoBase.eClass)
 			{
 				case CLASS_KA_WARRIOR:
 				case CLASS_KA_ROGUE:
@@ -1656,39 +1724,31 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 					break;
 
 				case CLASS_KA_GUARDIAN:
-					AllClearImageByName("berserker", true);
-					AllClearImageByName("Berserker Hero", true);
+					AllClearImageByName("berserker", true, "Berserker Hero", true);
 					break;
 
 				case CLASS_KA_PENETRATOR:
-					AllClearImageByName("hunter", true);
-					AllClearImageByName("Shadow Bane", true);
+					AllClearImageByName("hunter", true, "Shadow Bane", true);
 					break;
 
 				case CLASS_KA_NECROMANCER:
-					AllClearImageByName("sorcerer", true);
-					AllClearImageByName("Elemental Lord", true);
+					AllClearImageByName("sorcerer", true, "Elemental Lord", true);
 					break;
 
 				case CLASS_KA_DARKPRIEST:
-					AllClearImageByName("shaman", true);
-					AllClearImageByName("Shadow Knight", true);
+					AllClearImageByName("shaman", true, "Shadow Knight", true);
 					break;
 			}
 			break;
 
 		case NATION_ELMORAD:		// 엘모라도..
-			AllClearImageByName("ranger", false);
-			AllClearImageByName("blade", false);
-			AllClearImageByName("mage", false);
-			AllClearImageByName("cleric", false);
-			AllClearImageByName("Blade Master", false);
-			AllClearImageByName("Kasar Hood", false);
-			AllClearImageByName("Arc Mage", false);
-			AllClearImageByName("Paladin", false);
+			AllClearImageByName("blade", false, "Blade Master", false);
+			AllClearImageByName("ranger", false, "Kasar Hood", false);
+			AllClearImageByName("mage", false, "Arc Mage", false);
+			AllClearImageByName("cleric", false, "Paladin", false);
 
 			// 직업.. 
-			switch ( CGameBase::s_pPlayer->m_InfoBase.eClass )
+			switch (CGameBase::s_pPlayer->m_InfoBase.eClass)
 			{
 				case CLASS_EL_WARRIOR:
 				case CLASS_EL_ROGUE:
@@ -1714,29 +1774,23 @@ void CUISkillTreeDlg::SetPageInCharRegion()						// 문자 역역에서 현재 �
 					break;
 
 				case CLASS_EL_PROTECTOR:
-					AllClearImageByName("blade", true);
-					AllClearImageByName("Blade Master", true);
+					AllClearImageByName("blade", true, "Blade Master", true);
 					break;
 
 				case CLASS_EL_ASSASIN:
-					AllClearImageByName("ranger", true);
-					AllClearImageByName("Kasar Hood", true);
+					AllClearImageByName("ranger", true, "Kasar Hood", true);
 					break;
-					
+
 				case CLASS_EL_ENCHANTER:
-					AllClearImageByName("mage", true);
-					AllClearImageByName("Arc Mage", true);
+					AllClearImageByName("mage", true, "Arc Mage", true);
 					break;
 
 				case CLASS_EL_DRUID:
-					AllClearImageByName("cleric", true);
-					AllClearImageByName("Paladin", true);
+					AllClearImageByName("cleric", true, "Paladin", true);
 					break;
-
-			}
 			break;
+			}
 	}
-	
 }
 
 CN3UIImage*	CUISkillTreeDlg::GetChildImageByName(const std::string& szID)

--- a/Client/WarFare/UISkillTreeDlg.h
+++ b/Client/WarFare/UISkillTreeDlg.h
@@ -48,7 +48,7 @@ public:
 	int					m_iCurInPageOffset[MAX_SKILL_KIND_OF];										// 스킬당 현재 페이지 옵셋..
 
 protected:
-	void				AllClearImageByName(const std::string& szFN, bool bTrueOrNot);
+	void				AllClearImageByName(const std::string& szFN, bVisible, const std::string& szFNMaster = "", bool bMasterVisible = false);
 	RECT				GetSampleRect();
 	void				PageButtonInitialize();
 	bool				CheckSkillCanBeUse(__TABLE_UPC_SKILL* pUSkill);

--- a/Client/WarFare/resource.h
+++ b/Client/WarFare/resource.h
@@ -401,24 +401,23 @@
 #define IDS_HELP_TIP_ALL                5034
 #define IDS_EDIT_BOX_GOLD               6033
 #define IDS_EDIT_BOX_COUNT              6034
-#define IDS_SKILL_INFO_BASE             6035
-#define IDS_SKILL_INFO_BLADE0           6036
-#define IDS_SKILL_INFO_BLADE1           6037
-#define IDS_SKILL_INFO_BLADE2           6038
-#define IDS_SKILL_INFO_BLADE3           6039
-#define IDS_SKILL_INFO_RANGER0          6044
-#define IDS_SKILL_INFO_RANGER1          6045
-#define IDS_SKILL_INFO_RANGER2          6046
-#define IDS_SKILL_INFO_RANGER3          6047
-#define IDS_SKILL_INFO_MAGE0            6052
-#define IDS_SKILL_INFO_MAGE1            6053
-#define IDS_SKILL_INFO_MAGE2            6054
-#define IDS_SKILL_INFO_MAGE3            6055
-#define IDS_SKILL_INFO_CLERIC0          6060
-#define IDS_SKILL_INFO_CLERIC1          6061
-#define IDS_SKILL_INFO_CLERIC2          6062
-#define IDS_SKILL_INFO_CLERIC3          6063
-#define IDS_SKILL_INFO_SHAMAN3          6064
+#define IDS_SKILL_INFO_BASE             6035	// Basic skills that you get before you choose a specialty.
+#define IDS_SKILL_INFO_BLADE0           6036	// Learn various attack skills. 
+#define IDS_SKILL_INFO_BLADE1           6037	// Learn various defense skills. 
+#define IDS_SKILL_INFO_BLADE2           6038	// Increases Warrior's mental power.   
+#define IDS_SKILL_INFO_BLADE3           6039	// Learn the Master Skills of various weapons. 
+#define IDS_SKILL_INFO_RANGER0          6044	// Learn various archery skills.
+#define IDS_SKILL_INFO_RANGER1          6045	// Learn the various techniques of assassination.
+#define IDS_SKILL_INFO_RANGER2          6046	// Learn the various techniques of exploring. 
+#define IDS_SKILL_INFO_RANGER3          6047	// Learn the Master Skills of Archery and Assassination.
+#define IDS_SKILL_INFO_MAGE0            6052	// Learn various magic that uses flame. 
+#define IDS_SKILL_INFO_MAGE1            6053	// Learn various magic that uses Glacier. 
+#define IDS_SKILL_INFO_MAGE2            6054	// Learn various magic that uses Lightning. 
+#define IDS_SKILL_INFO_MAGE3            6055	// Learn the Master Skills of elemental magic.
+#define IDS_SKILL_INFO_CLERIC0          6060	// Learn various healing magic. 
+#define IDS_SKILL_INFO_CLERIC1          6061	// Learn magic that increase character's stat points. 
+#define IDS_SKILL_INFO_CLERIC2          6062	// Learn simple attack magic. 
+#define IDS_SKILL_INFO_CLERIC3          6063	// Learn the Master Skill of a Priest.
 #define IDS_ERR_CHARACTER_SELECT        6066
 #define IDS_DROPPED_NOAH_GET            6067
 #define IDS_DURABILITY_EXOAST           6068


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
1. When master, multiple job titles are shown at the top of the skill tree UI (layered).
2. For karus, the master skill tab is double layered due to duplication in the UIF file (berserker03 & master)
3. The master string for skill points is always displayed for jobs that are not masters
4. Some hover over tooltips are not currently displayed, mainly for 2nd job tabs and master tabs

## What is the new behaviour?
1. Single title is shown, based on the correct job
2. Master skill tab is displayed correctly and only when master job is applicable
3. Master skill point string is only displayed when character has a master job
4. Tool tips displayed in bottom part of the skill tree when hover over the relevant skill tab

## Why and how did I change this?
1. Modifications to the function - AllClearImageByName to consider for master jobs
2. Unusual situation in the original skilltree UIF files for Karus where berserker03 is a duplicate of the master tab button. The issue does not exist in the El Morad skill tree UIF. Someone has previously commented part of the code out that was calling blade03 for El Mord as it was likely causing a crash. Updated all references to master.
5. Refer to point 1 above.
6. Added additional information to the existing function - ButtonTooltipRender

## Demo
Baisc job
![basic](https://github.com/user-attachments/assets/052c6561-b0a9-400a-8f2a-8c7fc4b2aad1)

2nd job
![2nd](https://github.com/user-attachments/assets/52ecd883-5f31-47d7-bcaa-dd4f1b221e60)

Master job
![master](https://github.com/user-attachments/assets/7dca4802-8f05-4f43-9af9-5d42972e3600)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
