### PR TITLE
code cleanup for ui transaction

### DIFF
--- a/Client/WarFare/UITransactionDlg.cpp
+++ b/Client/WarFare/UITransactionDlg.cpp
@@ -35,20 +35,21 @@ static char THIS_FILE[]=__FILE__;
 
 CUITransactionDlg::CUITransactionDlg()
 {
-	int i, j;
 	m_iCurPage = 0;
-	for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )		
-			m_pMyTrade[j][i] = NULL;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )	m_pMyTradeInv[i] = NULL;
+	
+	for(int i = 0; i < MAX_ITEM_TRADE_PAGE; i++ )
+		for(int j = 0; j < MAX_ITEM_TRADE; j++ )		
+			m_pMyTrade[i][j] = nullptr;
 
-	m_pUITooltipDlg = NULL;
-	m_pStrMyGold    = NULL;
+	for(int i = 0; i < MAX_ITEM_INVENTORY; i++ )	
+		m_pMyTradeInv[i] = nullptr;
 
-	m_pUIInn		= NULL;
-	m_pUIBlackSmith	= NULL;
-	m_pUIStore		= NULL;
-	m_pText_Weight = nullptr;
+	m_pUITooltipDlg = nullptr;
+	m_pStrMyGold    = nullptr;
+	m_pUIInn		= nullptr;
+	m_pUIBlackSmith	= nullptr;
+	m_pUIStore		= nullptr;
+	m_pText_Weight	= nullptr;
 
 	this->SetVisible(false);
 }
@@ -62,38 +63,35 @@ void CUITransactionDlg::Release()
 {
 	CN3UIBase::Release();
 
-	int i, j;
-	for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for(int i = 0; i < MAX_ITEM_TRADE_PAGE; i++ )
+		for(int j = 0; j < MAX_ITEM_TRADE; j++ )
 		{
-			if ( m_pMyTrade[j][i] != NULL )
+			if ( m_pMyTrade[i][j] != nullptr )
 			{
-				delete m_pMyTrade[j][i];
-				m_pMyTrade[j][i] = NULL;
+				delete m_pMyTrade[i][j];
+				m_pMyTrade[i][j] = nullptr;
 			}
 		}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for(int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
-		if ( m_pMyTradeInv[i] != NULL )
+		if ( m_pMyTradeInv[i] != nullptr)
 		{
 			delete m_pMyTradeInv[i];
-			m_pMyTradeInv[i] = NULL;
+			m_pMyTradeInv[i] = nullptr;
 		}
 	}
 }
 
 void CUITransactionDlg::Render()
 {
-	if (!m_bVisible) return;	// 보이지 않으면 자식들을 render하지 않는다.
-
-	int i;
+	if (!m_bVisible) return;	// If not visible, do not render the children.
 
 	POINT ptCur = CGameProcedure::s_pLocalInput->MouseGetPos();
 	m_pUITooltipDlg->DisplayTooltipsDisable();
 
 	bool bTooltipRender = false;
-	__IconItemSkill* spItem = NULL;
+	__IconItemSkill* spItem = nullptr;
 
 	for(UIListReverseItor itor = m_Children.rbegin(); m_Children.rend() != itor; ++itor)
 	{
@@ -109,13 +107,13 @@ void CUITransactionDlg::Render()
 		}
 	}
 
-	// 갯수 표시되야 할 아이템 갯수 표시..
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	// Display the number of items that should be shown.
+	for(int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyTradeInv[i] && ( (m_pMyTradeInv[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) || 
 			(m_pMyTradeInv[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) ) )
 		{
-			// string 얻기..
+			// Get the string.
 			CN3UIString* pStr = GetChildStringByiOrder(i);
 			if(pStr) 
 			{
@@ -140,7 +138,7 @@ void CUITransactionDlg::Render()
 		}
 		else
 		{
-			// string 얻기..
+			// Get the string.
 			CN3UIString* pStr = GetChildStringByiOrder(i);
 			if(pStr) 
 				pStr->SetVisible(false);
@@ -173,16 +171,16 @@ void CUITransactionDlg::InitIconWnd(e_UIWND eWnd)
 	m_pUITooltipDlg->Init(this);
 	m_pUITooltipDlg->LoadFromFile(pTbl->szItemInfo);
 	m_pUITooltipDlg->InitPos();
-	m_pUITooltipDlg->SetVisible(FALSE);	
+	m_pUITooltipDlg->SetVisible(false);	
 
 	CN3UIWndBase::InitIconWnd(eWnd);
+	N3_VERIFY_UI_COMPONENT(m_pStrMyGold, (CN3UIString*) GetChildByID("string_item_name"));
 
-	m_pStrMyGold    = (CN3UIString* )GetChildByID("string_item_name"); __ASSERT(m_pStrMyGold, "NULL UI Component!!");
-	if(m_pStrMyGold) m_pStrMyGold->SetString("0");
+	if(m_pStrMyGold != nullptr) m_pStrMyGold->SetString("0");
 
-	m_pUIInn		= (CN3UIImage*)GetChildByID("img_inn");			__ASSERT(m_pUIInn, "NULL UI Component!!");
-	m_pUIBlackSmith = (CN3UIImage*)GetChildByID("img_blacksmith");	__ASSERT(m_pUIBlackSmith, "NULL UI Component!!");
-	m_pUIStore		= (CN3UIImage*)GetChildByID("img_store");		__ASSERT(m_pUIStore, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pUIInn, (CN3UIImage*) GetChildByID("img_inn"));
+	N3_VERIFY_UI_COMPONENT(m_pUIBlackSmith, (CN3UIImage*) GetChildByID("img_blacksmith"));
+	N3_VERIFY_UI_COMPONENT(m_pUIStore, (CN3UIImage*) GetChildByID("img_store"));
 	N3_VERIFY_UI_COMPONENT(m_pText_Weight, (CN3UIString*) GetChildByID("text_weight"));
 }
 
@@ -190,24 +188,23 @@ void CUITransactionDlg::InitIconUpdate()
 {
 	CN3UIArea* pArea;
 	float fUVAspect = (float)45.0f/(float)64.0f;
-	int i, j;
 
-	for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	for(int i = 0; i < MAX_ITEM_TRADE_PAGE; i++ )
+		for(int j = 0; j < MAX_ITEM_TRADE; j++ )
 		{
-			if ( m_pMyTrade[j][i] != NULL )
+			if ( m_pMyTrade[i][j] != nullptr )
 			{
-				m_pMyTrade[j][i]->pUIIcon = new CN3UIIcon;
-				m_pMyTrade[j][i]->pUIIcon->Init(this);
-				m_pMyTrade[j][i]->pUIIcon->SetTex(m_pMyTrade[j][i]->szIconFN);
-				m_pMyTrade[j][i]->pUIIcon->SetUVRect(0,0,fUVAspect,fUVAspect);
-				m_pMyTrade[j][i]->pUIIcon->SetUIType(UI_TYPE_ICON);
-				m_pMyTrade[j][i]->pUIIcon->SetStyle(UISTYLE_ICON_ITEM|UISTYLE_ICON_CERTIFICATION_NEED);
-				pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_NPC, i);
+				m_pMyTrade[i][j]->pUIIcon = new CN3UIIcon;
+				m_pMyTrade[i][j]->pUIIcon->Init(this);
+				m_pMyTrade[i][j]->pUIIcon->SetTex(m_pMyTrade[i][j]->szIconFN);
+				m_pMyTrade[i][j]->pUIIcon->SetUVRect(0,0,fUVAspect,fUVAspect);
+				m_pMyTrade[i][j]->pUIIcon->SetUIType(UI_TYPE_ICON);
+				m_pMyTrade[i][j]->pUIIcon->SetStyle(UISTYLE_ICON_ITEM|UISTYLE_ICON_CERTIFICATION_NEED);
+				pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_NPC, j);
 				if ( pArea )
 				{
-					m_pMyTrade[j][i]->pUIIcon->SetRegion(pArea->GetRegion());
-					m_pMyTrade[j][i]->pUIIcon->SetMoveRect(pArea->GetRegion());
+					m_pMyTrade[i][j]->pUIIcon->SetRegion(pArea->GetRegion());
+					m_pMyTrade[i][j]->pUIIcon->SetMoveRect(pArea->GetRegion());
 				}
 			}
 		}
@@ -215,69 +212,69 @@ void CUITransactionDlg::InitIconUpdate()
 
 __IconItemSkill* CUITransactionDlg::GetHighlightIconItem(CN3UIIcon* pUIIcon)
 {
-	int i;
-	for( i = 0; i < MAX_ITEM_TRADE; i++ )
+
+	for(int i = 0; i < MAX_ITEM_TRADE; i++)
 	{
-		if ( (m_pMyTrade[m_iCurPage][i] != NULL) && (m_pMyTrade[m_iCurPage][i]->pUIIcon == pUIIcon) )
+		if ( (m_pMyTrade[m_iCurPage][i] != nullptr) && (m_pMyTrade[m_iCurPage][i]->pUIIcon == pUIIcon) )
 			return m_pMyTrade[m_iCurPage][i];
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for(int i = 0; i < MAX_ITEM_INVENTORY; i++)
 	{
-		if ( (m_pMyTradeInv[i] != NULL) && (m_pMyTradeInv[i]->pUIIcon == pUIIcon) ) 
+		if ( (m_pMyTradeInv[i] != nullptr) && (m_pMyTradeInv[i]->pUIIcon == pUIIcon) ) 
 			return m_pMyTradeInv[i];
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 void CUITransactionDlg::EnterTransactionState()
 {
-	int i, j;
-	for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
-		for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	
+	for(int j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+		for(int i = 0; i < MAX_ITEM_TRADE; i++ )
 		{
-			if ( m_pMyTrade[j][i] != NULL )
+			if ( m_pMyTrade[j][i] != nullptr )
 			{
 				if ( m_pMyTrade[j][i]->pUIIcon )
 				{
 					RemoveChild(m_pMyTrade[j][i]->pUIIcon);
 					m_pMyTrade[j][i]->pUIIcon->Release();
 					delete m_pMyTrade[j][i]->pUIIcon;
-					m_pMyTrade[j][i]->pUIIcon = NULL;
+					m_pMyTrade[j][i]->pUIIcon = nullptr;
 				}
 				delete m_pMyTrade[j][i];	
-				m_pMyTrade[j][i] = NULL;
+				m_pMyTrade[j][i] = nullptr;
 			}
 		}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for(int i = 0; i < MAX_ITEM_INVENTORY; i++)
 	{
-		if ( m_pMyTradeInv[i] != NULL )
+		if ( m_pMyTradeInv[i] != nullptr )
 		{
 			if ( m_pMyTradeInv[i]->pUIIcon )
 			{
 				RemoveChild(m_pMyTradeInv[i]->pUIIcon);
 				m_pMyTradeInv[i]->pUIIcon->Release();
 				delete m_pMyTradeInv[i]->pUIIcon;
-				m_pMyTradeInv[i]->pUIIcon = NULL;
+				m_pMyTradeInv[i]->pUIIcon = nullptr;
 			}
 			delete m_pMyTradeInv[i];	
-			m_pMyTradeInv[i] = NULL;
+			m_pMyTradeInv[i] = nullptr;
 		}
 	}
 
 	std::string szIconFN;
-	__IconItemSkill*	spItem = NULL;
-	__TABLE_ITEM_BASIC*	pItem = NULL;													// 아이템 테이블 구조체 포인터..
-	__TABLE_ITEM_EXT*	pItemExt = NULL;
+	__IconItemSkill*	spItem = nullptr;
+	__TABLE_ITEM_BASIC*	pItem = nullptr; //Pointer to the item table structure
+	__TABLE_ITEM_EXT*	pItemExt = nullptr;
 
 	int iOrg = m_iTradeID/1000;
 	int iExt = m_iTradeID%1000;
 	int iSize = CGameBase::s_pTbl_Items_Basic.GetSize();
 
-	j = 0;	int k = 0;
-	for ( i = 0; i < iSize; i++ )
+	int j = 0, k = 0;
+	for (int i = 0; i < iSize; i++ )
 	{
 		if (k >= MAX_ITEM_TRADE)
 		{
@@ -288,9 +285,9 @@ void CUITransactionDlg::EnterTransactionState()
 			break;
 
 		pItem = CGameBase::s_pTbl_Items_Basic.GetIndexedData(i);
-		if(NULL == pItem) // 아이템이 없으면..
+		if(pItem == nullptr) // If there are no items...
 		{
-			__ASSERT(0, "아이템 포인터 테이블에 없음!!");
+			__ASSERT(0, "Item pointer not found in the table!!");
 			CLogWriter::Write("CUITransactionDlg::EnterTransactionState - Invalid Item ID : %d, %d", iOrg, iExt);
 			continue;
 		}
@@ -302,9 +299,9 @@ void CUITransactionDlg::EnterTransactionState()
 			continue;
 
 		pItemExt = CGameBase::s_pTbl_Items_Exts[pItem->byExtIndex].Find(iExt);	
-		if(NULL == pItemExt) // 아이템이 없으면..
+		if(pItemExt == nullptr) // If there is no item
 		{
-			__ASSERT(0, "아이템 포인터 테이블에 없음!!");
+			__ASSERT(0, "Item pointer not found in the table!!");
 			CLogWriter::Write("CUITransactionDlg::EnterTransactionState - Invalid Item ID : %d, %d", iOrg, iExt);
 			continue;
 		}
@@ -314,13 +311,13 @@ void CUITransactionDlg::EnterTransactionState()
 
 		e_PartPosition ePart;
 		e_PlugPosition ePlug;
-		e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+		e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, nullptr, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
 		__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item");
 
 		spItem = new __IconItemSkill;
 		spItem->pItemBasic	= pItem;
 		spItem->pItemExt	= pItemExt;
-		spItem->szIconFN	= szIconFN; // 아이콘 파일 이름 복사..
+		spItem->szIconFN	= szIconFN; // Copy the icon file name...
 		spItem->iCount		= 1;
 		spItem->iDurability = pItem->siMaxDurability+pItemExt->siMaxDurability;
 
@@ -339,22 +336,22 @@ void CUITransactionDlg::EnterTransactionState()
 		pStr->SetString(pszID);
 	}
 
-	for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+	for(int i = 0; i < MAX_ITEM_TRADE_PAGE; i++ )
 	{
-		if (j == m_iCurPage)
+		if (i == m_iCurPage)
 		{
-			for( i = 0; i < MAX_ITEM_TRADE; i++ )
+			for(int j = 0; j < MAX_ITEM_TRADE; j++ )
 			{
-				if ( m_pMyTrade[j][i] != NULL )
-					m_pMyTrade[j][i]->pUIIcon->SetVisible(true);
+				if ( m_pMyTrade[i][j] != nullptr )
+					m_pMyTrade[i][j]->pUIIcon->SetVisible(true);
 			}	
 		}
 		else
 		{
-			for( i = 0; i < MAX_ITEM_TRADE; i++ )
+			for(int j = 0; j < MAX_ITEM_TRADE; j++ )
 			{
-				if ( m_pMyTrade[j][i] != NULL )
-					m_pMyTrade[j][i]->pUIIcon->SetVisible(false);
+				if ( m_pMyTrade[i][j] != nullptr )
+					m_pMyTrade[i][j]->pUIIcon->SetVisible(false);
 			}	
 		}
 	}
@@ -395,20 +392,19 @@ void CUITransactionDlg::ItemMoveFromInvToThis()
 	CUIInventory* pInven = CGameProcedure::s_pProcMain->m_pUIInventory;
 	if(!pInven) return;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for(int i = 0; i < MAX_ITEM_INVENTORY; i++)
 	{
-		m_pMyTradeInv[i] = NULL;
+		m_pMyTradeInv[i] = nullptr;
 	}
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for(int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(pInven->m_pMyInvWnd[i])
 		{
 			__IconItemSkill* spItem = pInven->m_pMyInvWnd[i];
 			spItem->pUIIcon->SetParent(this);
 
-			pInven->m_pMyInvWnd[i] = NULL;
+			pInven->m_pMyInvWnd[i] = nullptr;
 			CN3UIArea* pArea;
 
 			pArea = GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_MY, i);
@@ -433,7 +429,7 @@ void CUITransactionDlg::LeaveTransactionState()
 	SetState(UI_STATE_COMMON_NONE);
 	CN3UIWndBase::AllHighLightIconFree();
 
-	// 이 윈도우의 inv 영역의 아이템을 이 인벤토리 윈도우의 inv영역으로 옮긴다..	
+	// Move the item from the inv area of this window to the inv area of this inventory window...
 	ItemMoveFromThisToInv();
 
 	if (CGameProcedure::s_pProcMain->m_pUISkillTreeDlg) CGameProcedure::s_pProcMain->m_pUISkillTreeDlg->UpdateDisableCheck();
@@ -445,15 +441,15 @@ void CUITransactionDlg::ItemMoveFromThisToInv()
 	CUIInventory* pInven = CGameProcedure::s_pProcMain->m_pUIInventory;
 	if(!pInven) return;
 
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	
+	for(int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if(m_pMyTradeInv[i])
 		{
 			__IconItemSkill* spItem = m_pMyTradeInv[i];
 			spItem->pUIIcon->SetParent(pInven);
 
-			m_pMyTradeInv[i] = NULL;
+			m_pMyTradeInv[i] = nullptr;
 
 			CN3UIArea* pArea;
 
@@ -472,13 +468,13 @@ void CUITransactionDlg::ItemMoveFromThisToInv()
 void CUITransactionDlg::ItemCountOK()
 {
 	int iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
-	__IconItemSkill* spItem, *spItemNew = NULL;
+	__IconItemSkill* spItem, *spItemNew = nullptr;
 	__InfoPlayerMySelf*	pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
 	int iWeight;
 
 	switch (CN3UIWndBase::m_pCountableItemEdit->GetCallerWndDistrict())
 	{
-		case UIWND_DISTRICT_TRADE_NPC:		// 사는 경우..
+		case UIWND_DISTRICT_TRADE_NPC:		// In case of purchase...
 			spItem = m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder];
 
 			switch (spItem->pItemBasic->byContable)
@@ -487,7 +483,7 @@ void CUITransactionDlg::ItemCountOK()
 				case UIITEM_TYPE_SOMOONE:
 					iWeight = spItem->pItemBasic->siWeight;
 
-					// 무게 체크..
+					// Weight check.
 					if ( (pInfoExt->iWeight + iWeight) > pInfoExt->iWeightMax)
 					{	 
 						std::string szMsg;
@@ -563,7 +559,7 @@ void CUITransactionDlg::ItemCountOK()
 
 					iWeight = iGold * spItem->pItemBasic->siWeight;
 
-					// 무게 체크..
+					// Check weight.
 					if ( (pInfoExt->iWeight + iWeight) > pInfoExt->iWeightMax)
 					{	 
 						std::string szMsg;
@@ -576,13 +572,13 @@ void CUITransactionDlg::ItemCountOK()
 
 			s_bWaitFromServer = true;
 
-			if ( m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder] )	// 해당 위치에 아이콘이 있으면..
+			if ( m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder] )	//If there is an icon at the specified position...
 			{
-				//  숫자 업데이트..
+				// Update the number.
 				m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder]->iCount += iGold;
 
-				// 표시는 아이콘 렌더링할때.. Inventory의 Render에서..
-				// 서버에게 보냄..
+				// Display happens during icon rendering... in Inventory's Render.
+				// Send to the server
 				SendToServerBuyMsg(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->dwID+
 					CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemExt->dwID, 
 					CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder, iGold);
@@ -594,11 +590,11 @@ void CUITransactionDlg::ItemCountOK()
 				spItemNew				= new __IconItemSkill;
 				spItemNew->pItemBasic	= spItem->pItemBasic;
 				spItemNew->pItemExt		= spItem->pItemExt;
-				spItemNew->szIconFN		= spItem->szIconFN; // 아이콘 파일 이름 복사..
+				spItemNew->szIconFN		= spItem->szIconFN; // Copy the icon file name
 				spItemNew->iCount		= iGold;
 				spItemNew->iDurability  = spItem->pItemBasic->siMaxDurability+spItem->pItemExt->siMaxDurability;
 
-				// 아이콘 리소스 만들기..
+				// Create the icon resource.
 				spItemNew->pUIIcon = new CN3UIIcon;
 				float fUVAspect		= (float)45.0f/(float)64.0f;
 				spItemNew->pUIIcon->Init(this); 
@@ -616,7 +612,7 @@ void CUITransactionDlg::ItemCountOK()
 
 				m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder] = spItemNew;
 
-				// 서버에게 보냄..
+				// Send to the server
 				SendToServerBuyMsg(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->dwID+
 					CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemExt->dwID, 
 					CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder, iGold);
@@ -625,7 +621,7 @@ void CUITransactionDlg::ItemCountOK()
 			if (CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic) PlayItemSound(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic);
 			break;
 
-		case UIWND_DISTRICT_TRADE_MY:		//  파는 경우..
+		case UIWND_DISTRICT_TRADE_MY:		// In case of selling
 			spItem = m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder];
 
 			if ( iGold <= 0 ) return;
@@ -635,7 +631,7 @@ void CUITransactionDlg::ItemCountOK()
 
 			if ( (spItem->iCount - iGold) > 0 )
 			{	
-				//  숫자 업데이트..
+				// Update number..
 				spItem->iCount -= iGold;
 			}
 			else
@@ -643,7 +639,7 @@ void CUITransactionDlg::ItemCountOK()
 				spItem->pUIIcon->SetVisible(false);
 			}
 
-			// 서버에게 보냄..
+			// Send to the server..
 			SendToServerSellMsg(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->dwID+
 				CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemExt->dwID, 
 				CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder, iGold);
@@ -655,10 +651,10 @@ void CUITransactionDlg::ItemCountOK()
 
 void CUITransactionDlg::ItemCountCancel()
 {
-	// Sound..
+	// Sound
 	if (CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic) PlayItemSound(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic);
 
-	// 취소..
+	// Cancel
 	s_bWaitFromServer				= false;
 	m_sRecoveryJobInfo.pItemSource	= nullptr;
 	m_sRecoveryJobInfo.pItemTarget	= nullptr;
@@ -719,13 +715,13 @@ void CUITransactionDlg::ReceiveResultTradeMoveFail()
 	CN3UIArea* pArea;
 	s_bWaitFromServer = false;
 
-	__IconItemSkill *spItemSource = NULL, *spItemTarget = NULL;
+	__IconItemSkill *spItemSource = nullptr, *spItemTarget = nullptr;
 	spItemSource = CN3UIWndBase::m_sRecoveryJobInfo.pItemSource;
 	spItemTarget = CN3UIWndBase::m_sRecoveryJobInfo.pItemTarget;
 
 	if (spItemSource)
 	{
-		pArea = NULL;
+		pArea = nullptr;
 		pArea = GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_MY, CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder);
 		if ( pArea )
 		{
@@ -738,7 +734,7 @@ void CUITransactionDlg::ReceiveResultTradeMoveFail()
 
 	if (spItemTarget)
 	{
-		pArea = NULL;
+		pArea = nullptr;
 		pArea = GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_MY, CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder);
 		if ( pArea )
 		{
@@ -750,7 +746,7 @@ void CUITransactionDlg::ReceiveResultTradeMoveFail()
 	}
 	else
 	{
-		m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder] = NULL;
+		m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder] = nullptr;
 	}
 
 	CN3UIWndBase::AllHighLightIconFree();
@@ -759,7 +755,8 @@ void CUITransactionDlg::ReceiveResultTradeMoveFail()
 
 void CUITransactionDlg::ReceiveItemDropByTradeSuccess()
 {
-	// 원래 아이템을 삭제해야 하지만.. 되살릴 방법이 없기 때문에 원래 위치로 옮기고.. 
+	// The original item should be deleted, 
+	// but since there is no way to restore it, move it back to the original position 
 	__IconItemSkill* spItem;
 	spItem = CN3UIWndBase::m_sRecoveryJobInfo.pItemSource;
 
@@ -772,39 +769,41 @@ void CUITransactionDlg::ReceiveItemDropByTradeSuccess()
 		spItem->pUIIcon->SetMoveRect(pArea->GetRegion());
 	}
 
-	// Invisible로 하고 삭제는 서버가 성공을 줄때 한다..
+	// Set to invisible and delete only when the server confirms success
 	spItem->pUIIcon->SetVisible(false);
 
 	if( (spItem->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) || (spItem->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) )
 	{
-		// 활이나 물약등 아이템인 경우..
+		// In case of items like bows or potions
 		spItem->pUIIcon->SetVisible(true);
 	}
 }
 
 bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 {
-// Temp Define 
-#define FAIL_RETURN {	\
-		CN3UIWndBase::AllHighLightIconFree();	\
-		SetState(UI_STATE_COMMON_NONE);	\
-		return false;	\
-	}
+	// Temp Define 
+	auto FAIL_RETURN = [&]() -> bool
+		{
+			CN3UIWndBase::AllHighLightIconFree();
+			SetState(UI_STATE_COMMON_NONE);
+			return false;
+		};
 
 	CN3UIArea* pArea;
 	e_UIWND_DISTRICT eUIWnd = UIWND_DISTRICT_UNKNOWN;
 	if (!m_bVisible) return false;
 
-	// 내가 가졌던 아이콘이 아니면..
-	if ( CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWnd != m_eUIWnd )
-		FAIL_RETURN
+	// If it is not an icon I owned
+	if (CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWnd != m_eUIWnd)
+		FAIL_RETURN();
+
 	if ( (CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict != UIWND_DISTRICT_TRADE_NPC) &&
 			(CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict != UIWND_DISTRICT_TRADE_MY) )
-		FAIL_RETURN
+		FAIL_RETURN();
 
-	// 내가 가졌던 아이콘이면.. npc영역인지 검사한다..
-	int i, iDestiOrder = -1; bool bFound = false;
-	for( i = 0; i < MAX_ITEM_TRADE; i++ )
+	// If it is an icon I owned, check whether it is in the NPC area
+	int iDestiOrder = -1; bool bFound = false;
+	for(int i = 0; i < MAX_ITEM_TRADE; i++ )
 	{
 		pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_NPC, i);
 		if ( (pArea) && (pArea->IsIn(ptCur.x, ptCur.y)) )
@@ -817,7 +816,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 
 	if (!bFound)
 	{
-		for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+		for(int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 		{
 			pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_MY, i);
 			if ( (pArea) && (pArea->IsIn(ptCur.x, ptCur.y)) )
@@ -829,13 +828,16 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 		}
 	}
 
-	if (!bFound)	FAIL_RETURN
+	if (!bFound) FAIL_RETURN();
 
-	// 같은 윈도우 내에서의 움직임은 fail!!!!!
-	if ( (eUIWnd == CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict) && (eUIWnd != UIWND_DISTRICT_TRADE_MY))	FAIL_RETURN
+	//  Movement within the same window is a fail!
+	if ((eUIWnd == CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict) && 
+		(eUIWnd != UIWND_DISTRICT_TRADE_MY))	
+		FAIL_RETURN();
 
-	// 본격적으로 Recovery Info를 활용하기 시작한다..
-	// 먼저 WaitFromServer를 On으로 하고.. Select Info를 Recovery Info로 복사.. 이때 Dest는 팰요없다..
+	// Start using Recovery Info in earnest
+	// First, set WaitFromServer to On, then copy Select Info to Recovery Info 
+	// Destination is not needed at this time.
 	if ( spItem != CN3UIWndBase::m_sSelectedIconInfo.pItemSelect )
 		CN3UIWndBase::m_sSelectedIconInfo.pItemSelect = spItem;
 
@@ -849,7 +851,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 	m_sRecoveryJobInfo.UIWndSourceEnd.UIWnd				= UIWND_TRANSACTION;
 	m_sRecoveryJobInfo.UIWndSourceEnd.UIWndDistrict		= eUIWnd;
 
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for(int i = 0; i < MAX_ITEM_INVENTORY; i++)
 	{
 		pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_MY, i);
 		if ( pArea && pArea->IsIn(ptCur.x, ptCur.y) )
@@ -862,16 +864,16 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 	switch (CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict)
 	{
 		case UIWND_DISTRICT_TRADE_NPC:
-			if (eUIWnd == UIWND_DISTRICT_TRADE_MY)		// 사는 경우..
+			if (eUIWnd == UIWND_DISTRICT_TRADE_MY)		// In case of buying
 			{
 				if( (CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) ||
 					(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) )
 				{
-					// 활이나 물약등 아이템인 경우..
-					// 면저 인벤토리에 해당 아이콘이 있는지 알아본다..
+					// In case of items like bows or potions
+					// First, check if the icon exists in the inventory.
 					bFound = false;
 
-					for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+					for(int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 					{
 						if ( bFound )
 						{
@@ -887,13 +889,13 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 						}
 					}
 
-					// 못찾았으면.. 
+					// If not found 
 					if ( !bFound )
 					{
-						if ( m_pMyTradeInv[iDestiOrder] )	// 해당 위치에 아이콘이 있으면..
+						if ( m_pMyTradeInv[iDestiOrder] )	// If there is an icon at the specified position
 						{
-							// 인벤토리 빈슬롯을 찾아 들어간다..
-							for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+							// Find an empty slot in the inventory and insert it
+							for(int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 							{
 								if ( !m_pMyTradeInv[i] )
 								{
@@ -903,12 +905,12 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 								}
 							}
 
-							if ( !bFound )	// 빈 슬롯을 찾지 못했으면..
+							if ( !bFound )	// If an empty slot was not found
 							{
 								s_bWaitFromServer				= false;
 								m_sRecoveryJobInfo.pItemSource	= nullptr;
 								m_sRecoveryJobInfo.pItemTarget	= nullptr;
-								FAIL_RETURN
+								FAIL_RETURN();
 							}
 						}
 					}
@@ -917,13 +919,13 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					s_bWaitFromServer							= false;
 
 					m_pCountableItemEdit->Open(UIWND_TRANSACTION, m_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
-					FAIL_RETURN
+					FAIL_RETURN();
 				}
 				else
 				{
 					__InfoPlayerMySelf*	pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
 
-					// 매수가 X 갯수가 내가 가진 돈보다 많으면.. 그냥 리턴..
+					// If the purchase quantity X is more than the money I have... just return.
 					if ( (CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->iPrice)	> pInfoExt->iGold )	
 					{
 						std::string szMsg;
@@ -933,10 +935,10 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 						s_bWaitFromServer				= false;
 						m_sRecoveryJobInfo.pItemSource	= nullptr;
 						m_sRecoveryJobInfo.pItemTarget	= nullptr;
-						FAIL_RETURN	
+						FAIL_RETURN();
 					}
 
-					// 무게 체크..
+					// Weight check.
 					if ( (pInfoExt->iWeight + CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->siWeight) > pInfoExt->iWeightMax)
 					{	 
 						std::string szMsg;
@@ -946,15 +948,15 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 						s_bWaitFromServer				= false;
 						m_sRecoveryJobInfo.pItemSource	= nullptr;
 						m_sRecoveryJobInfo.pItemTarget	= nullptr;
-						FAIL_RETURN	
+						FAIL_RETURN();
 					}
 
-					// 일반 아이템인 경우..
-					if ( m_pMyTradeInv[iDestiOrder] )	// 해당 위치에 아이콘이 있으면..
+					// In case of a normal item...
+					if ( m_pMyTradeInv[iDestiOrder] )	// If there is an icon at the specified position...
 					{
-						// 인벤토리 빈슬롯을 찾아 들어간다..
+						// Find an empty slot in the inventory and place it there...
 						bFound = false;
-						for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+						for(int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 						{
 							if ( !m_pMyTradeInv[i] )
 							{
@@ -964,12 +966,12 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 							}
 						}
 
-						if ( !bFound )	// 빈 슬롯을 찾지 못했으면..
+						if ( !bFound )	// If no empty slot is found...
 						{
 							s_bWaitFromServer				= false;
 							m_sRecoveryJobInfo.pItemSource	= nullptr;
 							m_sRecoveryJobInfo.pItemTarget	= nullptr;
-							FAIL_RETURN
+							FAIL_RETURN();
 						}
 
 						CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder	= iDestiOrder;
@@ -985,18 +987,18 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					e_PartPosition ePart;
 					e_PlugPosition ePlug;
 					CGameProcedure::MakeResrcFileNameForUPC(m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->pItemBasic, 
-						NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+						nullptr, &szIconFN, ePart, ePlug); // Create the file name according to the item
 
 					__IconItemSkill* spItemNew;
 					spItemNew				= new __IconItemSkill;
 					spItemNew->pItemBasic	= m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->pItemBasic;
 					spItemNew->pItemExt		= m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->pItemExt;
-					spItemNew->szIconFN		= szIconFN; // 아이콘 파일 이름 복사..
+					spItemNew->szIconFN		= szIconFN; // Copy the icon file name.
 					spItemNew->iCount		= 1;
 					spItemNew->iDurability	= m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->pItemBasic->siMaxDurability
 						+m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->pItemExt->siMaxDurability;
 
-					// 아이콘 리소스 만들기..
+					// Create the icon resource.
 					spItemNew->pUIIcon = new CN3UIIcon;
 					float fUVAspect		= (float)45.0f/(float)64.0f;
 					spItemNew->pUIIcon->Init(this); 
@@ -1013,7 +1015,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					}
 
 					m_pMyTradeInv[iDestiOrder] = spItemNew;
-					FAIL_RETURN
+					FAIL_RETURN();
 				}
 			}
 			else
@@ -1021,30 +1023,31 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 				s_bWaitFromServer				= false;
 				m_sRecoveryJobInfo.pItemSource	= nullptr;
 				m_sRecoveryJobInfo.pItemTarget	= nullptr;
-				FAIL_RETURN					
+				FAIL_RETURN();
 			}
 			break;
 
 		case UIWND_DISTRICT_TRADE_MY:
-			if (eUIWnd == UIWND_DISTRICT_TRADE_NPC)		// 파는 경우..
+			if (eUIWnd == UIWND_DISTRICT_TRADE_NPC)		// In case of selling...
 			{
 				if( (CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) ||
 					(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) )
 				{
-					// 활이나 물약등 아이템인 경우..
+					// In case of items like bows or potions
 					s_bWaitFromServer = false;
 					m_pCountableItemEdit->Open(UIWND_TRANSACTION, m_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
 				}
 				else
 				{
-					// Server에게 보낸다..
+					// Send to the server.
 					SendToServerSellMsg(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->dwID+
 						CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemExt->dwID, 
 						CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder, 
 						CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->iCount);
 
-					// 원래 아이템을 삭제해야 하지만.. 되살릴 방법이 없기 때문에 원래 위치로 옮기고.. 
-					pArea = NULL;
+					// The original item should be deleted, but since there is no way to restore it,
+					// move it back to the original position
+					pArea = nullptr;
 					pArea = GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_MY, CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder);
 					if ( pArea )
 					{
@@ -1052,18 +1055,18 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 						spItem->pUIIcon->SetMoveRect(pArea->GetRegion());
 					}
 
-					// Invisible로 하고 삭제는 서버가 성공을 줄때 한다..
+					// Set to invisible and delete only when the server confirms success.
 					spItem->pUIIcon->SetVisible(false);
 				}
-				FAIL_RETURN
+				FAIL_RETURN();
 			}
 			else	
 			{
-				// 이동.. 
-				__IconItemSkill *spItemSource, *spItemTarget = NULL;
+				// Move 
+				__IconItemSkill *spItemSource, *spItemTarget = nullptr;
 				spItemSource = CN3UIWndBase::m_sRecoveryJobInfo.pItemSource;
 
-				pArea = NULL;
+				pArea = nullptr;
 				pArea = GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_MY, iDestiOrder);
 				if ( pArea )
 				{
@@ -1072,20 +1075,19 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 				}
 
 				CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder				= iDestiOrder;
-				if ( m_pMyTradeInv[iDestiOrder] )	// 해당 위치에 아이콘이 있으면..
+				if ( m_pMyTradeInv[iDestiOrder] )	// If there is an icon at the specified position
 				{
-					CN3UIWndBase::m_sRecoveryJobInfo.pItemTarget					= m_pMyTradeInv[iDestiOrder];
-					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetStart.UIWnd			= UIWND_TRANSACTION;
+					CN3UIWndBase::m_sRecoveryJobInfo.pItemTarget = m_pMyTradeInv[iDestiOrder];
+					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetStart.UIWnd	= UIWND_TRANSACTION;
 					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetStart.UIWndDistrict = UIWND_DISTRICT_TRADE_MY;
-					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetStart.iOrder		= iDestiOrder;
-					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetEnd.UIWnd			= UIWND_TRANSACTION;
-					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetEnd.UIWndDistrict	= UIWND_DISTRICT_TRADE_MY;
-					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetEnd.iOrder			= 
-						CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder;
+					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetStart.iOrder = iDestiOrder;
+					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetEnd.UIWnd = UIWND_TRANSACTION;
+					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetEnd.UIWndDistrict = UIWND_DISTRICT_TRADE_MY;
+					CN3UIWndBase::m_sRecoveryJobInfo.UIWndTargetEnd.iOrder = CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder;
 
 					spItemTarget = CN3UIWndBase::m_sRecoveryJobInfo.pItemTarget;
 
-					pArea = NULL;
+					pArea = nullptr;
 					pArea = GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_MY, CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder);
 					if ( pArea )
 					{
@@ -1094,7 +1096,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					}
 				}
 				else
-					CN3UIWndBase::m_sRecoveryJobInfo.pItemTarget					= NULL;
+					CN3UIWndBase::m_sRecoveryJobInfo.pItemTarget = nullptr;
 
 				m_pMyTradeInv[iDestiOrder] = spItemSource;
 				m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder] = spItemTarget;
@@ -1104,7 +1106,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 						CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder, 
 						iDestiOrder );
 				//TRACE("Source %d, Target %d \n", CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder, iDestiOrder);
-				FAIL_RETURN					
+				FAIL_RETURN();
 			}				
 			break;
 		}
@@ -1118,14 +1120,14 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 void CUITransactionDlg::ReceiveResultTradeFromServer(byte bResult, byte bType, int	iMoney)
 {
 	s_bWaitFromServer = false;
-	__IconItemSkill* spItem = NULL;
+	__IconItemSkill* spItem = nullptr;
 	__InfoPlayerMySelf*	pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
 
-	// 소스 영역이 UIWND_DISTRICT_TRADE_NPC 이면 아이템 사는거..
+	// If the source area is UIWND_DISTRICT_TRADE_NPC, it means buying an item
 	switch ( CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.UIWndDistrict )
 	{
 		case UIWND_DISTRICT_TRADE_NPC:
-			if ( bResult != 0x01 )	// 실패라면.. 
+			if ( bResult != 0x01 )	// If it is a failure
 			{	
 				if( (CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) ||
 					(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) )
@@ -1134,47 +1136,47 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(byte bResult, byte bType, i
 
 					if ( (m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder]->iCount - iGold) > 0 )
 					{	
-						//  숫자 업데이트..
+						// Update the number
 						m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder]->iCount -= iGold;
 					}
 					else
 					{
-						// 아이템 삭제.. 현재 인벤토리 윈도우만.. 
+						// Delete item... only in the current inventory window.
 						__IconItemSkill* spItem;
 						spItem = m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder];
 
-						// 인벤토리에서도 지운다..
-						m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder] = NULL;
+						// Also remove it from the inventory.
+						m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder] = nullptr;
 
-						// iOrder로 내 매니저의 아이템을 리스트에서 삭제한다..
+						// Remove my manager's item from the list using iOrder.
 						RemoveChild(spItem->pUIIcon);
 
-						// 아이콘 리소스 삭제...
+						// Delete the icon resource
 						spItem->pUIIcon->Release();
 						delete spItem->pUIIcon;
-						spItem->pUIIcon = NULL;
+						spItem->pUIIcon = nullptr;
 						delete spItem;
-						spItem = NULL;
+						spItem = nullptr;
 					}
 				}
 				else
 				{
-					// 아이템 삭제.. 현재 인벤토리 윈도우만.. 
+					// Delete the item... only from the current inventory window
 					__IconItemSkill* spItem;
 					spItem = m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder];
 
-					// 인벤토리에서도 지운다..
-					m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder] = NULL;
+					// Also delete it from the inventory
+					m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder] = nullptr;
 
-					// iOrder로 내 매니저의 아이템을 리스트에서 삭제한다..
+					// Delete my manager's item from the list using iOrder.
 					RemoveChild(spItem->pUIIcon);
 
-					// 아이콘 리소스 삭제...
+					// Delete the icon resource.
 					spItem->pUIIcon->Release();
 					delete spItem->pUIIcon;
-					spItem->pUIIcon = NULL;
+					spItem->pUIIcon = nullptr;
 					delete spItem;
-					spItem = NULL;
+					spItem = nullptr;
 				}
 
 				if (bType == 0x04)
@@ -1197,7 +1199,7 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(byte bResult, byte bType, i
 			break;
 
 		case UIWND_DISTRICT_TRADE_MY:
-			if ( bResult != 0x01 )	// 실패라면.. 
+			if ( bResult != 0x01 )	// If it fails 
 			{	
 				if( (CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) ||
 					(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) )
@@ -1206,53 +1208,53 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(byte bResult, byte bType, i
 
 					if (m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->pUIIcon->IsVisible()) // 기존 아이콘이 보인다면..
 					{
-						// 숫자만 바꿔준다..
+						// Only update the number.
 						m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->iCount += iGold;
 					}
 					else
 					{
-						// 기존 아이콘이 안 보인다면..
+						// If the existing icon is not visible
 						m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->iCount = iGold;
 
-						// 아이콘이 보이게..
+						// Make the icon visible
 						m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->pUIIcon->SetVisible(true);
 					}
 				}
 				else
 				{
-					// Invisible로 아쳬杉?Icon Visible로..					
+					// Change from Invisible to Icon Visible.					
 					spItem = m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder];
 					spItem->pUIIcon->SetVisible(true);
 				}
 			}
 			else
 			{
-				// 활이나 물약등 아이템인 경우 기존 아이콘이 안보인다면.. 아이템 삭제..
+				// In case of items like bows or potions, if the existing icon is not visible... delete the item.
 				if( ( ((CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) || 
 					(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL))
 					&&	!m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->pUIIcon->IsVisible()) ||
 					((CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable != UIITEM_TYPE_COUNTABLE) &&
 					(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable != UIITEM_TYPE_COUNTABLE_SMALL)) )
 				{
-					// 아이템 삭제.. 현재 내 영역 윈도우만.. 
+					// Delete the item. only in my current area window.
 					__IconItemSkill* spItem;
 					spItem = m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder];
 
-					// 내 영역에서도 지운다..
-					m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder] = NULL;
+					// Also delete it from my area.
+					m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder] = nullptr;
 
-					// iOrder로 내 매니저의 아이템을 리스트에서 삭제한다..
+					// Remove my manager's item from the list using iOrder.
 					RemoveChild(spItem->pUIIcon);
 
-					// 아이콘 리소스 삭제...
+					// Delete the icon resource.
 					spItem->pUIIcon->Release();
 					delete spItem->pUIIcon;
-					spItem->pUIIcon = NULL;
+					spItem->pUIIcon = nullptr;
 					delete spItem;
-					spItem = NULL;
+					spItem = nullptr;
 				}
 
-				// 성공이면.. 돈 업데이트..
+				// If successful... update the money.
 				pInfoExt->iGold = iMoney;
 
 				CGameProcedure::s_pProcMain->m_pUIInventory->GoldUpdate();
@@ -1284,7 +1286,7 @@ void CUITransactionDlg::IconRestore()
 	switch ( CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict )
 	{
 		case UIWND_DISTRICT_TRADE_NPC:
-			if ( m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.iOrder] != NULL )
+			if ( m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.iOrder] != nullptr)
 			{
 				pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_NPC, CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.iOrder);
 				if ( pArea )
@@ -1296,7 +1298,7 @@ void CUITransactionDlg::IconRestore()
 			break;
 
 		case UIWND_DISTRICT_TRADE_MY:
-			if ( m_pMyTradeInv[CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.iOrder] != NULL )
+			if ( m_pMyTradeInv[CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.iOrder] != nullptr)
 			{
 				pArea = CN3UIWndBase::GetChildAreaByiOrder(UI_AREA_TYPE_TRADE_MY, CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.iOrder);
 				if ( pArea )
@@ -1315,7 +1317,7 @@ uint32_t CUITransactionDlg::MouseProc(uint32_t dwFlags, const POINT& ptCur, cons
 	if (!m_bVisible) return dwRet;
 	if (s_bWaitFromServer) { dwRet |= CN3UIBase::MouseProc(dwFlags, ptCur, ptOld);  return dwRet; }
 
-	// 드래그 되는 아이콘 갱신..
+	// Update the dragged icon.
 	if ( (GetState() == UI_STATE_ICON_MOVING) && 
 			(CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWnd == UIWND_TRANSACTION) )
 	{
@@ -1336,7 +1338,7 @@ int CUITransactionDlg::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT e
 		case UIWND_DISTRICT_TRADE_NPC:
 			for( i = 0; i < MAX_ITEM_TRADE; i++ )
 			{
-				if ( (m_pMyTrade[m_iCurPage][i] != NULL) && (m_pMyTrade[m_iCurPage][i] == spItem) )
+				if ( (m_pMyTrade[m_iCurPage][i] != nullptr) && (m_pMyTrade[m_iCurPage][i] == spItem) )
 					return i;
 			}
 			break;
@@ -1344,7 +1346,7 @@ int CUITransactionDlg::GetItemiOrder(__IconItemSkill* spItem, e_UIWND_DISTRICT e
 		case UIWND_DISTRICT_TRADE_MY:
 			for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
 			{
-				if ( (m_pMyTradeInv[i] != NULL) && (m_pMyTradeInv[i] == spItem) )
+				if ( (m_pMyTradeInv[i] != nullptr) && (m_pMyTradeInv[i] == spItem) )
 					return i;
 			}
 			break;
@@ -1372,13 +1374,13 @@ e_UIWND_DISTRICT CUITransactionDlg::GetWndDistrict(__IconItemSkill* spItem)
 {
 	for( int i = 0; i < MAX_ITEM_TRADE; i++ )
 	{
-		if ( (m_pMyTrade[m_iCurPage][i] != NULL) && (m_pMyTrade[m_iCurPage][i] == spItem) )
+		if ( (m_pMyTrade[m_iCurPage][i] != nullptr) && (m_pMyTrade[m_iCurPage][i] == spItem) )
 			return UIWND_DISTRICT_TRADE_NPC;
 	}
 
 	for(int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
-		if ( (m_pMyTradeInv[i] != NULL) && (m_pMyTradeInv[i] == spItem) )
+		if ( (m_pMyTradeInv[i] != nullptr) && (m_pMyTradeInv[i] == spItem) )
 			return UIWND_DISTRICT_TRADE_MY;
 	}
 	return UIWND_DISTRICT_UNKNOWN;
@@ -1392,8 +1394,7 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 				return false;	\
 			}
 
-	if(NULL == pSender) return false;
-	int i, j;
+	if(pSender == nullptr) return false;
 
 	if (dwMsg == UIMSG_BUTTON_CLICK)					
 	{
@@ -1405,8 +1406,7 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 		if(pSender == m_pBtnPageUp)
 		{
 			m_iCurPage--;
-			if(m_iCurPage<0)
-				m_iCurPage = 0;
+			if(m_iCurPage<0) m_iCurPage = 0;
 
 			pStr = (CN3UIString* )GetChildByID("string_page");
 			if (pStr)
@@ -1416,22 +1416,22 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 				pStr->SetString(pszID);
 			}
 
-			for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+			for(int i = 0; i < MAX_ITEM_TRADE_PAGE; i++ )
 			{
-				if (j == m_iCurPage)
+				if (i == m_iCurPage)
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for(int j = 0; j < MAX_ITEM_TRADE; j++ )
 					{
-						if ( m_pMyTrade[j][i] != NULL )
-							m_pMyTrade[j][i]->pUIIcon->SetVisible(true);
+						if ( m_pMyTrade[i][j] != nullptr )
+							m_pMyTrade[i][j]->pUIIcon->SetVisible(true);
 					}	
 				}
 				else
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for(int j = 0; j < MAX_ITEM_TRADE; j++ )
 					{
-						if ( m_pMyTrade[j][i] != NULL )
-							m_pMyTrade[j][i]->pUIIcon->SetVisible(false);
+						if ( m_pMyTrade[i][j] != nullptr )
+							m_pMyTrade[i][j]->pUIIcon->SetVisible(false);
 					}	
 				}
 			}
@@ -1451,29 +1451,29 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 				pStr->SetString(pszID);
 			}
 
-			for( j = 0; j < MAX_ITEM_TRADE_PAGE; j++ )
+			for(int i = 0; i < MAX_ITEM_TRADE_PAGE; i++)
 			{
-				if (j == m_iCurPage)
+				if (i == m_iCurPage)
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for(int j = 0; j < MAX_ITEM_TRADE; j++ )
 					{
-						if ( m_pMyTrade[j][i] != NULL )
-							m_pMyTrade[j][i]->pUIIcon->SetVisible(true);
+						if ( m_pMyTrade[i][j] != nullptr )
+							m_pMyTrade[i][j]->pUIIcon->SetVisible(true);
 					}	
 				}
 				else
 				{
-					for( i = 0; i < MAX_ITEM_TRADE; i++ )
+					for(int j = 0; j < MAX_ITEM_TRADE; j++ )
 					{
-						if ( m_pMyTrade[j][i] != NULL )
-							m_pMyTrade[j][i]->pUIIcon->SetVisible(false);
+						if ( m_pMyTrade[i][j] != nullptr )
+							m_pMyTrade[i][j]->pUIIcon->SetVisible(false);
 					}	
 				}
 			}
 		}
 	}
 
-	__IconItemSkill* spItem = NULL;
+	__IconItemSkill* spItem = nullptr;
 	e_UIWND_DISTRICT eUIWnd;
 	int iOrder;
 
@@ -1504,9 +1504,9 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 			break;
 
 		case UIMSG_ICON_UP:
-			// 아이콘 매니저 윈도우들을 돌아 다니면서 검사..
+			// Iterate through icon manager windows and check...
 			if ( !CGameProcedure::s_pUIMgr->BroadcastIconDropMsg(CN3UIWndBase::m_sSelectedIconInfo.pItemSelect) )
-				// 아이콘 위치 원래대로..
+				// Reset icon position to original.
 				IconRestore();
 			// Sound..
 			if (CN3UIWndBase::m_sSelectedIconInfo.pItemSelect) PlayItemSound(CN3UIWndBase::m_sSelectedIconInfo.pItemSelect->pItemBasic);
@@ -1544,7 +1544,7 @@ CN3UIBase* CUITransactionDlg::GetChildButtonByName(const std::string& szFN)
 			return pChild;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 void CUITransactionDlg::ShowTitle(e_NpcTrade eNT)
@@ -1596,7 +1596,7 @@ void CUITransactionDlg::SetVisibleWithNoSound(bool bVisible, bool bWork, bool bR
 		SetState(UI_STATE_COMMON_NONE);
 		CN3UIWndBase::AllHighLightIconFree();
 
-		// 이 윈도우의 inv 영역의 아이템을 이 인벤토리 윈도우의 inv영역으로 옮긴다..	
+		// Move the items from the inv area of this window to the inv area of this inventory window.
 		ItemMoveFromThisToInv();
 
 		if (CGameProcedure::s_pProcMain->m_pUISkillTreeDlg) CGameProcedure::s_pProcMain->m_pUISkillTreeDlg->UpdateDisableCheck();
@@ -1609,9 +1609,9 @@ bool CUITransactionDlg::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pBtnClose		= (CN3UIButton*)(this->GetChildByID("btn_close"));		__ASSERT(m_pBtnClose, "NULL UI Component!!");
-	m_pBtnPageUp	= (CN3UIButton*)(this->GetChildByID("btn_page_up"));	__ASSERT(m_pBtnPageUp, "NULL UI Component!!");
-	m_pBtnPageDown	= (CN3UIButton*)(this->GetChildByID("btn_page_down"));	__ASSERT(m_pBtnPageDown, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtnClose, (CN3UIButton*) GetChildByID("btn_close"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnPageUp, (CN3UIButton*) GetChildByID("btn_page_up"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnPageDown, (CN3UIButton*) GetChildByID("btn_page_down"));
 
 	return true;
 }

--- a/Client/WarFare/UITransactionDlg.cpp
+++ b/Client/WarFare/UITransactionDlg.cpp
@@ -782,7 +782,7 @@ void CUITransactionDlg::ReceiveItemDropByTradeSuccess()
 bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 {
 	// Temp Define 
-	auto FAIL_RETURN = [&]() -> bool
+	auto fail_return = [&]() -> bool
 		{
 			CN3UIWndBase::AllHighLightIconFree();
 			SetState(UI_STATE_COMMON_NONE);
@@ -795,11 +795,11 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 
 	// If it is not an icon I owned
 	if (CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWnd != m_eUIWnd)
-		FAIL_RETURN();
+		return fail_return();
 
 	if ( (CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict != UIWND_DISTRICT_TRADE_NPC) &&
 			(CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict != UIWND_DISTRICT_TRADE_MY) )
-		FAIL_RETURN();
+		return fail_return();
 
 	// If it is an icon I owned, check whether it is in the NPC area
 	int iDestiOrder = -1; bool bFound = false;
@@ -828,12 +828,12 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 		}
 	}
 
-	if (!bFound) FAIL_RETURN();
+	if (!bFound) return fail_return();
 
 	//  Movement within the same window is a fail!
 	if ((eUIWnd == CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.UIWndDistrict) && 
 		(eUIWnd != UIWND_DISTRICT_TRADE_MY))	
-		FAIL_RETURN();
+		return fail_return();
 
 	// Start using Recovery Info in earnest
 	// First, set WaitFromServer to On, then copy Select Info to Recovery Info 
@@ -910,7 +910,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 								s_bWaitFromServer				= false;
 								m_sRecoveryJobInfo.pItemSource	= nullptr;
 								m_sRecoveryJobInfo.pItemTarget	= nullptr;
-								FAIL_RETURN();
+								return fail_return();
 							}
 						}
 					}
@@ -919,7 +919,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					s_bWaitFromServer							= false;
 
 					m_pCountableItemEdit->Open(UIWND_TRANSACTION, m_sSelectedIconInfo.UIWndSelect.UIWndDistrict, false);
-					FAIL_RETURN();
+					return fail_return();
 				}
 				else
 				{
@@ -935,7 +935,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 						s_bWaitFromServer				= false;
 						m_sRecoveryJobInfo.pItemSource	= nullptr;
 						m_sRecoveryJobInfo.pItemTarget	= nullptr;
-						FAIL_RETURN();
+						return fail_return();
 					}
 
 					// Weight check.
@@ -948,7 +948,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 						s_bWaitFromServer				= false;
 						m_sRecoveryJobInfo.pItemSource	= nullptr;
 						m_sRecoveryJobInfo.pItemTarget	= nullptr;
-						FAIL_RETURN();
+						return fail_return();
 					}
 
 					// In case of a normal item...
@@ -971,7 +971,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 							s_bWaitFromServer				= false;
 							m_sRecoveryJobInfo.pItemSource	= nullptr;
 							m_sRecoveryJobInfo.pItemTarget	= nullptr;
-							FAIL_RETURN();
+							return fail_return();
 						}
 
 						CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder	= iDestiOrder;
@@ -1015,7 +1015,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					}
 
 					m_pMyTradeInv[iDestiOrder] = spItemNew;
-					FAIL_RETURN();
+					return fail_return();
 				}
 			}
 			else
@@ -1023,7 +1023,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 				s_bWaitFromServer				= false;
 				m_sRecoveryJobInfo.pItemSource	= nullptr;
 				m_sRecoveryJobInfo.pItemTarget	= nullptr;
-				FAIL_RETURN();
+				return fail_return();
 			}
 			break;
 
@@ -1058,7 +1058,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					// Set to invisible and delete only when the server confirms success.
 					spItem->pUIIcon->SetVisible(false);
 				}
-				FAIL_RETURN();
+				return fail_return();
 			}
 			else	
 			{
@@ -1106,7 +1106,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 						CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder, 
 						iDestiOrder );
 				//TRACE("Source %d, Target %d \n", CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder, iDestiOrder);
-				FAIL_RETURN();
+				return fail_return();
 			}				
 			break;
 		}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Code style update (formatting, renaming)

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
* NULL macro replaced with nullptr
* N3_VERIFY_UI_COMPONENT macro is used on required places.
* Comments translated from Korean to English ( by AI )
* predefination of i,j,k moved inside loops as local scope
* FAIL_RETURN inline macro replaced with lambda

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
To obtain more readability.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).

## Summary by Sourcery

Modernize UITransactionDlg code style and enhance readability

Enhancements:
- Replace NULL with nullptr throughout the UI transaction code
- Declare loop indices locally inside their loops for tighter scope
- Replace existing FAIL_RETURN macro with a lambda-based early-return mechanism
- Use N3_VERIFY_UI_COMPONENT macro for consistent UI component validation
- Translate Korean comments into English for improved clarity