### PR TITLE
Add "Wrong Warp Gate" error

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -5551,17 +5551,17 @@ void CGameProcMain::MsgRecv_ObjectEvent(Packet& pkt)
 	int iType = pkt.read<uint8_t>();		// Event Type
 	int iResult = pkt.read<uint8_t>();
 
-	if (OBJECT_TYPE_BINDPOINT == iType)
+	if (iType == OBJECT_TYPE_BINDPOINT)
 	{
 		std::string szMsg;
-		if (0x01 == iResult)
+		if (iResult == 1)
 			GetText(IDS_BIND_POINT_FAILED, &szMsg);
-		this->MsgOutput(szMsg, 0xff00ff00);
+		MsgOutput(szMsg, 0xff00ff00);
 	}
-	else if (OBJECT_TYPE_DOOR_LEFTRIGHT == iType
-		|| OBJECT_TYPE_DOOR_TOPDOWN == iType
-		|| OBJECT_TYPE_LEVER_TOPDOWN == iType
-		|| OBJECT_TYPE_FLAG == iType)
+	else if (iType == OBJECT_TYPE_DOOR_LEFTRIGHT
+		|| iType == OBJECT_TYPE_DOOR_TOPDOWN
+		|| iType == OBJECT_TYPE_LEVER_TOPDOWN
+		|| iType == OBJECT_TYPE_FLAG)
 	{
 		int iID = pkt.read<int16_t>();	// 열고 닫을 성문 ID
 		int iActivate = pkt.read<uint8_t>();	// 열고 닫음..
@@ -5644,15 +5644,15 @@ void CGameProcMain::MsgRecv_ObjectEvent(Packet& pkt)
 					else pSE->m_bVisible = false;
 				}
 			}
-			this->MsgOutput(szMsg, 0xff00ff00);
+			MsgOutput(szMsg, 0xff00ff00);
 		}
 	}
-	else if (OBJECT_TYPE_WARP_POINT == iType)	// Wrong warp gate
+	else if (iType == OBJECT_TYPE_WARP_POINT)
 	{
 		std::string szMsg;
-		if (0x00 == iResult)
+		if (iResult == 0)
 			GetText(IDS_WARP_WRONG_GATE, &szMsg);
-		this->MsgOutput(szMsg, 0xff00ff00);
+		MsgOutput(szMsg, 0xff00ff00);
 	}
 	else
 	{

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -5647,6 +5647,13 @@ void CGameProcMain::MsgRecv_ObjectEvent(Packet& pkt)
 			this->MsgOutput(szMsg, 0xff00ff00);
 		}
 	}
+	else if (OBJECT_TYPE_WARP_POINT == iType)	// Wrong warp gate
+	{
+		std::string szMsg;
+		if (0x00 == iResult)
+			GetText(IDS_WARP_WRONG_GATE, &szMsg);
+		this->MsgOutput(szMsg, 0xff00ff00);
+	}
 	else
 	{
 		__ASSERT(0, "Unknown Object Event");

--- a/Client/WarFare/resource.h
+++ b/Client/WarFare/resource.h
@@ -14,6 +14,7 @@
 #define IDS_BIND_POINT_FAILED           1001
 #define IDS_BIND_POINT_REQUEST_FAIL     1002
 #define IDS_BIND_POINT_SUCCESS          1003
+#define IDS_WARP_WRONG_GATE				1004	// You've selected the wrong Warp Gate.
 #define IDS_CHAT_SELECT_TARGET_FAIL     1101
 #define IDS_CHAT_SELECT_TARGET_SUCCESS  1102
 #define IDS_CHR_SELECT_FMT_INFO         1201

--- a/Client/WarFare/resource.h
+++ b/Client/WarFare/resource.h
@@ -14,7 +14,7 @@
 #define IDS_BIND_POINT_FAILED           1001
 #define IDS_BIND_POINT_REQUEST_FAIL     1002
 #define IDS_BIND_POINT_SUCCESS          1003
-#define IDS_WARP_WRONG_GATE				1004	// You've selected the wrong Warp Gate.
+#define IDS_WARP_WRONG_GATE             1004 // You've selected the wrong Warp Gate.
 #define IDS_CHAT_SELECT_TARGET_FAIL     1101
 #define IDS_CHAT_SELECT_TARGET_SUCCESS  1102
 #define IDS_CHR_SELECT_FMT_INFO         1201


### PR DESCRIPTION
Implemented wrong warp gate message for each nation when a character clicks on the other nations warp gate.

## Pull request type
Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
No message was provided to the user when they clicked on the other nations warp gate.

## What is the new behaviour?
An error message is displayed to the user when they click on the other nations warp gate. This is official behaviour.

## Why and how did I change this?
Packet is sent from the server when a user clicks on the warp gate object, however, the logic to handle the packet for an incorrect warp gate was not in the client.

Open item #182 

## Demo
Orc character using the El Morad warp gate during the invasion.
<img width="615" height="641" alt="wrong gate" src="https://github.com/user-attachments/assets/73b8bae6-8188-4d03-bf27-b07fb0801e43" />


## Checklist
- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).

## Summary by Sourcery

Add client-side handling for wrong warp gate selection by displaying an official error message when a player clicks on a warp gate of another nation.

New Features:
- Display an error message when a player clicks on an incorrect warp gate object
- Include a new resource string (IDS_WARP_WRONG_GATE) for the wrong warp gate message