### PR TITLE
#323 Fix auto-attack

### DIFF
--- a/Client/N3Base/N3SkyMng.cpp
+++ b/Client/N3Base/N3SkyMng.cpp
@@ -1152,7 +1152,8 @@ int	CN3SkyMng::GetDayChangePos_AfterNSec(uint32_t dwCurGameTime, float fSec)
 
 	// n초후의 queue의 위치 찾기
 	while(iCheckDayChangeCurPos<m_DayChanges.size() &&
-		m_DayChanges[m_iDayChangeCurPos].dwWhen < dwCheckGameTime) ++iCheckDayChangeCurPos;
+		m_DayChanges[m_iDayChangeCurPos].dwWhen < dwCheckGameTime)
+		++iCheckDayChangeCurPos;
 	if (iCheckDayChangeCurPos >= m_DayChanges.size()) iCheckDayChangeCurPos = m_DayChanges.size() - 1;
 	return iCheckDayChangeCurPos;
 }

--- a/Client/N3Base/N3VMesh.cpp
+++ b/Client/N3Base/N3VMesh.cpp
@@ -241,7 +241,8 @@ void CN3VMesh::FindMinMax()
 
 bool CN3VMesh::CheckCollision(const __Matrix44& MtxWorld, const __Vector3& v0, const __Vector3& v1, __Vector3* pVCol, __Vector3* pVNormal)
 {
-	if(m_nVC <= 0) return false;
+	if(m_nVC <= 0)
+		return false;
 
 	static __Vector3 vPos0, vPos1, vDir, vColTmp;
 	static __Matrix44 mtxWI, mtxWIRot, mtxRot;

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -1247,7 +1247,18 @@ void CGameProcMain::ProcessLocalInput(uint32_t dwMouseFlags)
 		}
 
 		if (s_pLocalInput->IsKeyPress(KM_TOGGLE_ATTACK))
-			CommandToggleAttackContinous();		// 자동 공격..
+		{
+			// if the player is already attacking, stop it
+			if (s_pPlayer->m_bAttackContinous)
+			{
+				CommandEnableAttackContinous(false, nullptr);
+			}
+			// otherwise, start the auto-attack process
+			else
+			{
+				TryStartAttack();
+			}
+		}
 		if (s_pLocalInput->IsKeyPress(KM_TOGGLE_RUN))
 			CommandToggleWalkRun();				// 걷기 / 뛰기 토글	
 		if (s_pLocalInput->IsKeyPress(KM_TARGET_NEAREST_ENEMY))
@@ -4581,76 +4592,114 @@ void CGameProcMain::CommandMove(e_MoveDirection eMD, bool bStartOrEnd)
 	}
 }
 
+/// \brief toggles the player's autoattack
 void CGameProcMain::CommandEnableAttackContinous(bool bEnable, CPlayerBase* pTarget)
 {
-	if(bEnable == s_pPlayer->m_bAttackContinous) return;
-	if(bEnable)
+	// no change
+	if (bEnable == s_pPlayer->m_bAttackContinous)
+		return;
+
+	// invalid target
+	if (pTarget == nullptr)
 	{
-		this->CloseUIs(); // 각종 상거래, 워프등등... UI 닫기..
-		s_pUIMgr->UserMoveHideUIs();
-
-		if(s_pPlayer->m_bStun) return; // 기절해 있음 공격 못함..
-		if(NULL == pTarget) return;
-		s_pPlayer->RotateTo(pTarget); // 방향을 돌린다.
-		if(pTarget->m_InfoBase.eNation == s_pPlayer->m_InfoBase.eNation) return; // 국가가 같으면 넘어간다..
-
-		//-------------------------------------------------------------------------
-		/*
-		// TODO(srmeier): need to use ZoneAbilityType here
-		// NOTE(srmeier): using zoneability information to determine if target is attackable
-		if (!ACT_WORLD->canAttackSameNation() && (pTarget->m_InfoBase.eNation == s_pPlayer->m_InfoBase.eNation))
-			return;
-		if (!ACT_WORLD->canAttackOtherNation() && (s_pPlayer->m_InfoBase.eNation == NATION_ELMORAD && pTarget->m_InfoBase.eNation == NATION_KARUS))
-			return;
-		if (!ACT_WORLD->canAttackOtherNation() && (s_pPlayer->m_InfoBase.eNation == NATION_KARUS && pTarget->m_InfoBase.eNation == NATION_ELMORAD))
-			return;
-		*/
-		//-------------------------------------------------------------------------
-	}
-	s_pPlayer->m_bAttackContinous = bEnable; // 상태를 기록하고..
-
-	if(bEnable)
-		SetGameCursor(s_hCursorAttack);
-	else
-	{
-		e_Nation eNation = s_pPlayer->m_InfoBase.eNation;
-		SetGameCursor(((NATION_ELMORAD == eNation) ? s_hCursorNormal1 : s_hCursorNormal));
+		StopAutoAttack(pTarget);
+		return;
 	}
 
-	if(m_pUICmd->m_pBtn_Act_Attack)
-	{
-		if(bEnable) m_pUICmd->m_pBtn_Act_Attack->SetState(UI_STATE_BUTTON_DOWN);
-		else m_pUICmd->m_pBtn_Act_Attack->SetState(UI_STATE_BUTTON_NORMAL);
-	}
-
-	// 자동 공격!
 	if (bEnable)
 	{
-		std::string szMsg;
-		GetTextF(IDS_MSG_ATTACK_START, &szMsg, pTarget->IDString().c_str());
-
-		this->PlayBGM_Battle();
-		
-		if(s_pPlayer->IsAttackableTarget(pTarget))
-			s_pPlayer->Action(PSA_BASIC, true, pTarget);
-
-		this->MsgOutput(szMsg, 0xff00ffff);
+		StartAutoAttack(pTarget);
 	}
-	else // 자동 공격 아님.
+	else
 	{
-		std::string szMsg;
-		GetText(IDS_MSG_ATTACK_STOP, &szMsg);
-		s_pPlayer->Action(PSA_BASIC, true, pTarget);
-		this->MsgOutput(szMsg, 0xff00ffff);
+		StopAutoAttack(pTarget);
 	}
+}
 
-	// 국가, 거리 및 각도 체크해서 공격 불가능하면 돌아가기..
-	if (bEnable
-		&& !s_pPlayer->IsAttackableTarget(pTarget))
+/// \brief contains the logic that should be executed whenever starting to auto-attack
+void CGameProcMain::StartAutoAttack(CPlayerBase* target)
+{
+	// already auto-attacking
+	if (s_pPlayer->m_bAttackContinous)
+		return;
+	
+	this->CloseUIs(); 
+	s_pUIMgr->UserMoveHideUIs();
+
+	if(s_pPlayer->m_bStun)
+		return;
+
+	s_pPlayer->RotateTo(target);
+	
+	// check if the target is attackable
+	// this can fail for several reasons:
+	// - invalid target
+	// - target not in front of attacker
+	// - target out of range
+	// doesn't really feel like it should be here, it's checked in so many other places
+	// and covers too many cases to be helpful
+	if (!s_pPlayer->IsAttackableTarget(target))
 	{
 		std::string szMsg;
 		GetText(IDS_MSG_ATTACK_DISABLE, &szMsg);
 		this->MsgOutput(szMsg, 0xffffff00);
+		// return;
+	}
+
+	//-------------------------------------------------------------------------
+	/*
+	// TODO(srmeier): need to use ZoneAbilityType here
+	// NOTE(srmeier): using zoneability information to determine if target is attackable
+	if (!ACT_WORLD->canAttackSameNation() && (pTarget->m_InfoBase.eNation == s_pPlayer->m_InfoBase.eNation))
+		return;
+	if (!ACT_WORLD->canAttackOtherNation() && (s_pPlayer->m_InfoBase.eNation == NATION_ELMORAD && pTarget->m_InfoBase.eNation == NATION_KARUS))
+		return;
+	if (!ACT_WORLD->canAttackOtherNation() && (s_pPlayer->m_InfoBase.eNation == NATION_KARUS && pTarget->m_InfoBase.eNation == NATION_ELMORAD))
+		return;
+	*/
+	//-------------------------------------------------------------------------
+	
+	s_pPlayer->m_bAttackContinous = true;
+	
+	SetGameCursor(s_hCursorAttack);
+		
+	// Print an info message for attack start
+	std::string szMsg;
+	GetTextF(IDS_MSG_ATTACK_START, &szMsg, target->IDString().c_str());
+	this->MsgOutput(szMsg, 0xff00ffff);
+	
+	// play combat music
+	this->PlayBGM_Battle();
+
+	// set auto-attack animation
+	s_pPlayer->Action(PSA_BASIC, true, target);
+	
+	if (m_pUICmd->m_pBtn_Act_Attack)
+	{
+		m_pUICmd->m_pBtn_Act_Attack->SetState(UI_STATE_BUTTON_DOWN);
+	}
+}
+
+/// \brief contains the logic that should be executed whenever auto-attacking is stopped
+void CGameProcMain::StopAutoAttack(CPlayerBase* target)
+{
+	// not auto-attacking
+	if (!s_pPlayer->m_bAttackContinous)
+		return;
+	
+	s_pPlayer->m_bAttackContinous = false;
+	
+	e_Nation eNation = s_pPlayer->m_InfoBase.eNation;
+	SetGameCursor(((NATION_ELMORAD == eNation) ? s_hCursorNormal1 : s_hCursorNormal));
+
+	std::string szMsg;
+	GetText(IDS_MSG_ATTACK_STOP, &szMsg);
+	s_pPlayer->Action(PSA_BASIC, true, target);
+	this->MsgOutput(szMsg, 0xff00ffff);
+
+	if (m_pUICmd->m_pBtn_Act_Attack)
+	{
+		m_pUICmd->m_pBtn_Act_Attack->SetState(UI_STATE_BUTTON_NORMAL);
 	}
 }
 
@@ -7402,24 +7451,34 @@ bool CGameProcMain::OnMouseMove(POINT ptCur, POINT ptPrev)
 // 왼쪽 더블 클릭
 bool CGameProcMain::OnMouseLDBtnPress(POINT ptCur, POINT ptPrev)
 {
-	if(s_pUIMgr->m_bDoneSomething) return false;
+	if(s_pUIMgr->m_bDoneSomething)
+		return false;
 
-	CPlayerNPC* pTarget = s_pOPMgr->CharacterGetByID(s_pPlayer->m_iIDTarget, true);
+	TryStartAttack();
+	
+	return true;
+}
 
-	if(pTarget && pTarget->m_InfoBase.iAuthority == AUTHORITY_MANAGER)
+/// \brief attempts to start the auto-attack process
+/// \returns true if auto-attack process started, false otherwise
+bool CGameProcMain::TryStartAttack()
+{
+	CPlayerNPC* target = s_pOPMgr->CharacterGetByID(s_pPlayer->m_iIDTarget, true);
+	if(target == nullptr || target->m_InfoBase.iAuthority == AUTHORITY_MANAGER)
 	{
 		s_pPlayer->m_iIDTarget = -1;
-		pTarget = NULL;
+		target = nullptr;
+		return false;
 	}
 
-	if(VP_THIRD_PERSON == s_pEng->ViewPoint())
+	if(s_pEng->ViewPoint() == VP_THIRD_PERSON)
 	{
-		if(s_pPlayer->IsAttackableTarget(pTarget, false))
+		if(s_pPlayer->IsAttackableTarget(target, false))
 		{
 			this->CommandMove(MD_STOP, true);
-			this->CommandEnableAttackContinous(true, pTarget); // 자동 공격
+			this->CommandEnableAttackContinous(true, target);
 		}
-		else if(pTarget && VP_THIRD_PERSON == s_pEng->ViewPoint())
+		else if(target && VP_THIRD_PERSON == s_pEng->ViewPoint())
 		{
 			this->CommandMove(MD_FOWARD, true);
 			s_pPlayer->SetMoveTargetID(s_pPlayer->m_iIDTarget);
@@ -7430,6 +7489,7 @@ bool CGameProcMain::OnMouseLDBtnPress(POINT ptCur, POINT ptPrev)
 		s_pPlayer->m_bAttackContinous = false;
 		CommandToggleAttackContinous();
 	}
+
 	return true;
 }
 

--- a/Client/WarFare/GameProcMain.h
+++ b/Client/WarFare/GameProcMain.h
@@ -213,6 +213,10 @@ public:
 	bool	OnMouseLBtnPressd(POINT ptCur, POINT ptPrev);
 	bool	OnMouseLBtnPress(POINT ptCur, POINT ptPrev);
 	bool	OnMouseLDBtnPress(POINT ptCur, POINT ptPrev);
+	
+	/// \brief attempts to start the auto-attack process
+    /// \returns true if auto-attack process started, false otherwise
+	bool	TryStartAttack();
 	bool	OnMouseRbtnDown(POINT ptCur, POINT ptPrev);
 	bool	OnMouseRBtnPressd(POINT ptCur, POINT ptPrev);
 	bool	OnMouseRBtnPress(POINT ptCur, POINT ptPrev);
@@ -227,7 +231,7 @@ public:
 	const __InfoPartyOrForce*	PartyOrForceConditionGet(bool& bIAmLeader, bool& bIAmMember, int& iMemberIndex, class CPlayerBase*& pTarget);
 	void						TargetSelect(int iID, bool bMustAlive);
 	void						TargetSelect(class CPlayerNPC* pTarget);
-
+	
 	void	CommandToggleUIChat();
 	void	CommandToggleUIMsgWnd();
 
@@ -244,6 +248,12 @@ public:
 
 	void	CommandMove(e_MoveDirection eMD, bool bStartOrEnd); // 움직이는 방향(전후진, 멈춤), 움직이기 시작하는가?
 	void	CommandEnableAttackContinous(bool bEnable, CPlayerBase* pTarget);
+
+	/// \brief contains the logic that should be executed whenever starting to auto-attack
+	void	StartAutoAttack(CPlayerBase* target);
+	/// \brief contains the logic that should be executed whenever auto-attacking is stopped
+	void	StopAutoAttack(CPlayerBase* target = nullptr);
+	
 	void	CommandCameraChange(); // 카메라 시점 바꾸기..
 	void	CommandSitDown(bool bLimitInterval, bool bSitDown, bool bImmediately = false);
 

--- a/Client/WarFare/GameProcMain.h
+++ b/Client/WarFare/GameProcMain.h
@@ -215,7 +215,7 @@ public:
 	bool	OnMouseLDBtnPress(POINT ptCur, POINT ptPrev);
 	
 	/// \brief attempts to start the auto-attack process
-    /// \returns true if auto-attack process started, false otherwise
+	/// \returns true if auto-attack process started, false otherwise
 	bool	TryStartAttack();
 	bool	OnMouseRbtnDown(POINT ptCur, POINT ptPrev);
 	bool	OnMouseRBtnPressd(POINT ptCur, POINT ptPrev);

--- a/Client/WarFare/PlayerBase.h
+++ b/Client/WarFare/PlayerBase.h
@@ -175,6 +175,9 @@ protected:
 
 	virtual bool	ProcessAttack(CPlayerBase* pTarget); // 공격 루틴 처리.. 타겟 포인터를 구하고 충돌체크까지 하며 충돌하면 참을 리턴..
 
+	/// \brief applies any on-hit elemental effects associated with a weapon
+	bool TryWeaponElementEffect(e_PlugPosition plugPosition, const CPlayerBase& target, __Vector3 collisionPosition);
+
 public:
 	const __Matrix44*	JointMatrixGet(int nJointIndex) { return m_Chr.MatrixGet( nJointIndex); }
 	bool 				JointPosGet(int iJointIdx, __Vector3& vPos);
@@ -253,7 +256,7 @@ public:
 	void			IDSet(int iID, const std::string& szID, D3DCOLOR crID);
 	virtual void	KnightsInfoSet(int iID, const std::string& szName, int iGrade, int iRank);
 	const std::string&	IDString() { return m_InfoBase.szID; } // ID 는 Character 포인터의 이름으로 대신한다.
-	int				IDNumber() { return m_InfoBase.iID; }
+	int				IDNumber() const { return m_InfoBase.iID; }
 	CPlayerBase*	TargetPointerCheck(bool bMustAlive);
 
 	////////////////////

--- a/Client/WarFare/PlayerMySelf.h
+++ b/Client/WarFare/PlayerMySelf.h
@@ -17,7 +17,9 @@ class CPlayerMySelf : public CPlayerBase
 {
 protected:
 	bool			m_bRunning; // 뛰는지..
-	float			m_fAttackTimeRecent;	// 최근에 공격한 시간..
+
+	/// \brief the last time an attack/skill message was sent to the server
+	float			m_fAttackTimeRecent;
 
 	__Vector3		m_vCollisionOffsets[3]; // 허리 부분 2개의 충돌 체크 + 머리 부분 1개의 충돌 체크..
 
@@ -60,7 +62,12 @@ public:
 
 	float			AttackableDistance(CPlayerBase* pTarget);
 	float			DistanceExceptRadius(CPlayerBase* pTarget);
-	bool			IsAttackableTarget(CPlayerBase* pTarget, bool bMesureAngle = true); // 공격 가능한 범위에 있는지..
+
+	/// \brief checks to see if an attack can be performed on the target
+	/// \param pTarget
+	/// \param bMeasureAngle does the target need to be in front of the attacker?
+	/// \returns true if attack would be valid, false otherwise
+	bool			IsAttackableTarget(CPlayerBase* pTarget, bool bMeasureAngle = true); // 공격 가능한 범위에 있는지..
 	bool			IsRunning() { return m_bRunning; }
 	bool			CheckCollision();		// 움직이는 처리와 충돌체크를 한다. 충돌되는게 있으면 움직이지 않는다.
 	//.. 


### PR DESCRIPTION
A few issues with auto-attack:

    Doesn't work most of the time with R. Not as bad with double-click but still not great
    Pressing R won't cause the player to run up to the target if out of range

This all works well on the goatcheez client, so it is a client problem.

## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)

## What is the new behaviour?
Auto-attack behaves as it does on the goatcheez client. R and double click function the same way.

## Why and how did I change this?
Auto-attack was a broken mess.  You had to be on top of the monster and double click for a chance to get an auto attack to proc.  Makes basic testing a hassle. 

## Checklist
- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
