### PR TITLE
Store and pass control tooltip colour to CN3UITooltip

### DIFF
--- a/Client/N3Base/N3UIBase.cpp
+++ b/Client/N3Base/N3UIBase.cpp
@@ -40,21 +40,23 @@ std::string CN3UIBase::s_szStringTmp; // 임시변수..
 CN3UIBase::CN3UIBase()
 {
 	m_eType = UI_TYPE_BASE;
-	m_pParent = NULL;
-	m_pChildUI	= NULL;
-	m_pParentUI = NULL;
+	m_pParent = nullptr;
+	m_pChildUI	= nullptr;
+	m_pParentUI = nullptr;
 
 	m_iChildID	= -1;
 
-	ZeroMemory(&m_rcRegion, sizeof(m_rcRegion));
-	ZeroMemory(&m_rcMovable, sizeof(m_rcMovable));
+	memset(&m_rcRegion, 0, sizeof(m_rcRegion));
+	memset(&m_rcMovable, 0, sizeof(m_rcMovable));
 	m_eState = UI_STATE_COMMON_NONE;
 	m_dwStyle = UISTYLE_NONE;
 
 	m_dwReserved = 0;
 	m_bVisible = true;
-	m_pSnd_OpenUI = NULL;
-	m_pSnd_CloseUI = NULL;
+	m_pSnd_OpenUI = nullptr;
+	m_pSnd_CloseUI = nullptr;
+
+	m_crTooltip = DefaultTooltipColor;
 }
 
 CN3UIBase::~CN3UIBase()
@@ -74,26 +76,28 @@ CN3UIBase::~CN3UIBase()
 
 void CN3UIBase::Release()
 {
-	if(m_pParent) m_pParent->RemoveChild(this);
+	if (m_pParent != nullptr)
+		m_pParent->RemoveChild(this);
 
-	ZeroMemory(&m_rcRegion, sizeof(m_rcRegion));
-	ZeroMemory(&m_rcMovable, sizeof(m_rcMovable));
+	memset(&m_rcRegion, 0, sizeof(m_rcRegion));
+	memset(&m_rcMovable, 0, sizeof(m_rcMovable));
 	
-	m_szID = "";
-	m_szToolTip = "";
+	m_szID.clear();
+	m_szToolTip.clear();
+	m_crTooltip = DefaultTooltipColor;
 
 	m_eState = UI_STATE_COMMON_NONE;
 	m_dwStyle = UISTYLE_NONE;
 	m_dwReserved = 0;
 	m_bVisible = true;
-	CN3Base::s_SndMgr.ReleaseObj(&m_pSnd_OpenUI);
-	CN3Base::s_SndMgr.ReleaseObj(&m_pSnd_CloseUI);
+	s_SndMgr.ReleaseObj(&m_pSnd_OpenUI);
+	s_SndMgr.ReleaseObj(&m_pSnd_CloseUI);
 
-	while(!m_Children.empty())
+	while (!m_Children.empty())
 	{
-		CN3UIBase* pChild = m_Children.front();
-		if (pChild) delete pChild;	// 자식이 delete되면서 부모의 list에서는 자동으로 제거된다.
-									// 따라서 리스트에서 따로 지우는 부분이 없어도 된다.
+		// 자식이 delete되면서 부모의 list에서는 자동으로 제거된다.
+		// 따라서 리스트에서 따로 지우는 부분이 없어도 된다.
+		delete m_Children.front();
 	}
 
 	CN3BaseFileAccess::Release();
@@ -395,8 +399,10 @@ uint32_t CN3UIBase::MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT&
 	else
 	{
 		// tool tip 관련
-		if (s_pTooltipCtrl) s_pTooltipCtrl->SetText(m_szToolTip);
+		if (s_pTooltipCtrl != nullptr)
+			s_pTooltipCtrl->SetText(m_szToolTip, m_crTooltip);
 	}
+
 	dwRet |= UI_MOUSEPROC_INREGION;	// 이번 좌표는 영역 안이다.
 
 

--- a/Client/N3Base/N3UIBase.cpp
+++ b/Client/N3Base/N3UIBase.cpp
@@ -56,7 +56,7 @@ CN3UIBase::CN3UIBase()
 	m_pSnd_OpenUI = nullptr;
 	m_pSnd_CloseUI = nullptr;
 
-	m_crTooltip = DefaultTooltipColor;
+	m_crToolTip = DefaultTooltipColor;
 }
 
 CN3UIBase::~CN3UIBase()
@@ -84,7 +84,7 @@ void CN3UIBase::Release()
 	
 	m_szID.clear();
 	m_szToolTip.clear();
-	m_crTooltip = DefaultTooltipColor;
+	m_crToolTip = DefaultTooltipColor;
 
 	m_eState = UI_STATE_COMMON_NONE;
 	m_dwStyle = UISTYLE_NONE;
@@ -400,7 +400,7 @@ uint32_t CN3UIBase::MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT&
 	{
 		// tool tip 관련
 		if (s_pTooltipCtrl != nullptr)
-			s_pTooltipCtrl->SetText(m_szToolTip, m_crTooltip);
+			s_pTooltipCtrl->SetText(m_szToolTip, m_crToolTip);
 	}
 
 	dwRet |= UI_MOUSEPROC_INREGION;	// 이번 좌표는 영역 안이다.

--- a/Client/N3Base/N3UIBase.h
+++ b/Client/N3Base/N3UIBase.h
@@ -59,7 +59,7 @@ public:
 
 	std::string m_szID;			// UI id
 	std::string	m_szToolTip;	// tooltip text
-	D3DCOLOR	m_crTooltip;
+	D3DCOLOR	m_crToolTip;
 
 	void SetID(const std::string& szID)
 	{
@@ -78,7 +78,7 @@ public:
 
 	void SetTooltipColor(D3DCOLOR crTooltip)
 	{
-		m_crTooltip = crTooltip;
+		m_crToolTip = crTooltip;
 	}
 
 	static CN3UITooltip*	s_pTooltipCtrl;		// tool tip

--- a/Client/N3Base/N3UIBase.h
+++ b/Client/N3Base/N3UIBase.h
@@ -51,15 +51,35 @@ friend class CUIEView;	// 툴에서 child list를 접근하기 위해서.
 #endif
 
 public:
+	static constexpr D3DCOLOR DefaultTooltipColor = D3DCOLOR_XRGB(255, 255, 255);
+
 #ifdef _N3GAME
 	static bool s_bWaitFromServer;
 #endif
 
 	std::string m_szID;			// UI id
 	std::string	m_szToolTip;	// tooltip text
-	void		SetID(LPCTSTR pszID) {m_szID = pszID;}
-	const std::string GetID() const {return m_szID;}
-	void		SetTooltipText(LPCTSTR pszTT) {m_szToolTip = pszTT;}
+	D3DCOLOR	m_crTooltip;
+
+	void SetID(const std::string& szID)
+	{
+		m_szID = szID;
+	}
+
+	const std::string& GetID() const
+	{
+		return m_szID;
+	}
+
+	void SetTooltipText(const std::string& szTooltipText)
+	{
+		m_szToolTip = szTooltipText;
+	}
+
+	void SetTooltipColor(D3DCOLOR crTooltip)
+	{
+		m_crTooltip = crTooltip;
+	}
 
 	static CN3UITooltip*	s_pTooltipCtrl;		// tool tip
 	

--- a/Client/N3Base/N3UITooltip.cpp
+++ b/Client/N3Base/N3UITooltip.cpp
@@ -79,7 +79,7 @@ void CN3UITooltip::Render()
 	else CN3UIStatic::Render();
 }
 
-void CN3UITooltip::SetText(const std::string& szText)
+void CN3UITooltip::SetText(const std::string& szText, D3DCOLOR crTooltip)
 {
 	if(!m_bVisible || m_bSetText) return;
 
@@ -119,7 +119,9 @@ void CN3UITooltip::SetText(const std::string& szText)
 		size.cy += 12;
 		SetSize(size.cx, size.cy);
 	}
+
 	m_pBuffOutRef->SetString(szText);
+	m_pBuffOutRef->SetColor(crTooltip);
 
 	// 위치 조정
 	POINT	ptNew = m_ptCursor;

--- a/Client/N3Base/N3UITooltip.h
+++ b/Client/N3Base/N3UITooltip.h
@@ -33,7 +33,7 @@ protected:
 
 // Operations
 public:
-	void			SetText(const std::string& szText);
+	void			SetText(const std::string& szText, D3DCOLOR crTooltip);
 	virtual void	Release();
 	virtual void	Tick();
 	virtual void	Render();

--- a/Client/WarFare/N3UIWndBase.cpp
+++ b/Client/WarFare/N3UIWndBase.cpp
@@ -154,8 +154,10 @@ uint32_t CN3UIWndBase::MouseProc(uint32_t dwFlags, const POINT& ptCur, const POI
 	else
 	{
 		// tool tip 관련
-		if (s_pTooltipCtrl) s_pTooltipCtrl->SetText(m_szToolTip);
+		if (s_pTooltipCtrl != nullptr)
+			s_pTooltipCtrl->SetText(m_szToolTip, m_crTooltip);
 	}
+
 	dwRet |= UI_MOUSEPROC_INREGION;	// 이번 좌표는 영역 안이다.
 
 	// child에게 메세지 전달

--- a/Client/WarFare/N3UIWndBase.cpp
+++ b/Client/WarFare/N3UIWndBase.cpp
@@ -155,7 +155,7 @@ uint32_t CN3UIWndBase::MouseProc(uint32_t dwFlags, const POINT& ptCur, const POI
 	{
 		// tool tip 관련
 		if (s_pTooltipCtrl != nullptr)
-			s_pTooltipCtrl->SetText(m_szToolTip, m_crTooltip);
+			s_pTooltipCtrl->SetText(m_szToolTip, m_crToolTip);
 	}
 
 	dwRet |= UI_MOUSEPROC_INREGION;	// 이번 좌표는 영역 안이다.

--- a/Client/WarFare/UICharacterSelect.cpp
+++ b/Client/WarFare/UICharacterSelect.cpp
@@ -225,7 +225,7 @@ uint32_t CUICharacterSelect::MouseProc(uint32_t dwFlags, const POINT &ptCur, con
 	{
 		// tool tip 관련
 		if (s_pTooltipCtrl != nullptr)
-			s_pTooltipCtrl->SetText(m_szToolTip, m_crTooltip);
+			s_pTooltipCtrl->SetText(m_szToolTip, m_crToolTip);
 	}
 
 	if(m_pChildUI && m_pChildUI->IsVisible())

--- a/Client/WarFare/UICharacterSelect.cpp
+++ b/Client/WarFare/UICharacterSelect.cpp
@@ -224,7 +224,8 @@ uint32_t CUICharacterSelect::MouseProc(uint32_t dwFlags, const POINT &ptCur, con
 	else
 	{
 		// tool tip 관련
-		if (s_pTooltipCtrl) s_pTooltipCtrl->SetText(m_szToolTip);
+		if (s_pTooltipCtrl != nullptr)
+			s_pTooltipCtrl->SetText(m_szToolTip, m_crTooltip);
 	}
 
 	if(m_pChildUI && m_pChildUI->IsVisible())

--- a/Client/WarFare/UIDead.cpp
+++ b/Client/WarFare/UIDead.cpp
@@ -169,8 +169,10 @@ uint32_t CUIDead::MouseProc(uint32_t dwFlags, const POINT &ptCur, const POINT &p
 	else
 	{
 		// tool tip 관련
-		if (s_pTooltipCtrl) s_pTooltipCtrl->SetText(m_szToolTip);
+		if (s_pTooltipCtrl != nullptr)
+			s_pTooltipCtrl->SetText(m_szToolTip, m_crTooltip);
 	}
+
 	dwRet |= UI_MOUSEPROC_INREGION;	// 이번 좌표는 영역 안이다.
 
 	if(m_pChildUI && m_pChildUI->IsVisible())

--- a/Client/WarFare/UIDead.cpp
+++ b/Client/WarFare/UIDead.cpp
@@ -170,7 +170,7 @@ uint32_t CUIDead::MouseProc(uint32_t dwFlags, const POINT &ptCur, const POINT &p
 	{
 		// tool tip 관련
 		if (s_pTooltipCtrl != nullptr)
-			s_pTooltipCtrl->SetText(m_szToolTip, m_crTooltip);
+			s_pTooltipCtrl->SetText(m_szToolTip, m_crToolTip);
 	}
 
 	dwRet |= UI_MOUSEPROC_INREGION;	// 이번 좌표는 영역 안이다.

--- a/UIE/PropertyView.cpp
+++ b/UIE/PropertyView.cpp
@@ -218,7 +218,9 @@ BOOL CPropertyView::OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult)
 				str += pItem->m_curValue;
 				pHView->GetTreeCtrl().SetItemText(hItem, str);
 			}
-			pUI->SetID(pItem->m_curValue);
+
+			const std::string szID(CT2A(pItem->m_curValue));
+			pUI->SetID(szID);
 		}
 		else if(pItem->m_propName == "Region left" || pItem->m_propName == "Region top" ||
 			pItem->m_propName == "Region right" || pItem->m_propName == "Region bottom")
@@ -232,7 +234,11 @@ BOOL CPropertyView::OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult)
 			// move rect 갱신하는 함수 만들어서 처리하기
 			pFrm->GetRightPane()->SelectRectType(CUIEView::RT_MOVE);
 		}
-		else if(pItem->m_propName == "Tooltip text") pUI->SetTooltipText(pItem->m_curValue);
+		else if(pItem->m_propName == "Tooltip text")
+		{
+			const std::string szToolTip(CT2A(pItem->m_curValue));
+			pUI->SetTooltipText(szToolTip);
+		}
 		else if(pItem->m_propName == "Open sound")
 		{
 			pUI->SetSndOpen((LPCTSTR)pItem->m_curValue);


### PR DESCRIPTION
Each control needs to store its own individual tooltip colour to be used when invoking a tooltip from that control.
As such, each place the tooltip needs to be invoked, we now pass its colour along as well to CN3UITooltip to modify the colour of the text.

Resolves #318