### PR TITLE
Implement START_POSITION for /TOWN

### DIFF
--- a/Server/Ebenezer/EbenezerDlg.cpp
+++ b/Server/Ebenezer/EbenezerDlg.cpp
@@ -493,6 +493,14 @@ BOOL CEbenezerDlg::OnInitDialog()
 		return FALSE;
 	}
 
+	LogFileWrite(_T("before item LoadStartPositionTable table\r\n"));
+	if (!LoadStartPositionTable())
+	{
+		AfxMessageBox(_T("LoadStartPositionTable Load Fail"));
+		AfxPostQuitMessage(0);
+		return FALSE;
+	}
+
 	LogFileWrite(_T("before battle\r\n"));
 	if (!LoadBattleTable())
 	{
@@ -651,6 +659,9 @@ BOOL CEbenezerDlg::DestroyWindow()
 
 	if (!m_HomeArray.IsEmpty())
 		m_HomeArray.DeleteAllData();
+
+	if (!m_StartPositionMap.IsEmpty())
+		m_StartPositionMap.DeleteAllData();
 
 	for (C3DMap* pMap : m_ZoneArray)
 		delete pMap;
@@ -3074,6 +3085,18 @@ void CEbenezerDlg::Announcement(BYTE type, int nation, int chat_type)
 				pUser->Send(send_buff, send_index);
 		}
 	}
+}
+
+BOOL CEbenezerDlg::LoadStartPositionTable()
+{
+	recordset_loader::STLMap loader(m_StartPositionMap);
+	if (!loader.Load_ForbidEmpty())
+	{
+		ReportTableLoadError(loader.GetError(), __func__);
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 BOOL CEbenezerDlg::LoadHomeTable()

--- a/Server/Ebenezer/EbenezerDlg.h
+++ b/Server/Ebenezer/EbenezerDlg.h
@@ -51,6 +51,7 @@ typedef CSTLMap <_PARTY_GROUP>				PartyArray;
 typedef CSTLMap <CKnights>					KnightsArray;
 typedef CSTLMap <_ZONE_SERVERINFO>			ServerArray;
 typedef CSTLMap <model::Home>				HomeArray;
+typedef CSTLMap <model::StartPosition>		StartPositionMap;
 typedef	CSTLMap	<EVENT>						QuestArray;
 
 enum class NameType
@@ -89,6 +90,7 @@ public:
 	int  GetKnightsAllMembers(int knightsindex, char* temp_buff, int& buff_index, int type = 0);
 	BOOL LoadAllKnightsUserData();
 	BOOL LoadAllKnights();
+	BOOL LoadStartPositionTable();
 	BOOL LoadHomeTable();
 	void Announcement(BYTE type, int nation = 0, int chat_type = 8);
 	void ResetBattleZone();
@@ -182,6 +184,7 @@ public:
 	PartyArray				m_PartyArray;
 	KnightsArray			m_KnightsArray;
 	HomeArray				m_HomeArray;
+	StartPositionMap		m_StartPositionMap;
 	QuestArray				m_Event;
 
 	CKnightsManager			m_KnightsManager;

--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -8696,87 +8696,34 @@ void CUser::Home()
 	char send_buff[128] = {};
 
 	short x = 0, z = 0;		// The point where you will be warped to.
-
-	model::Home* pHomeInfo = m_pMain->m_HomeArray.GetData(m_pUserData->m_bNation);
-	if (pHomeInfo == nullptr)
+	if (!GetStartPosition(&x, &z))
 		return;
-
-	// Frontier Zone...
-	if (m_pUserData->m_bNation != m_pUserData->m_bZone
-		&& m_pUserData->m_bZone > 200)
-	{
-		x = pHomeInfo->FreeZoneX + myrand(0, pHomeInfo->FreeZoneLX);
-		z = pHomeInfo->FreeZoneZ + myrand(0, pHomeInfo->FreeZoneLZ);
-	}
-	// Battle Zone...
-	else if (m_pUserData->m_bNation != m_pUserData->m_bZone
-		&& m_pUserData->m_bZone > 100
-		&& m_pUserData->m_bZone < 200)
-	{
-		x = pHomeInfo->BattleZoneX + myrand(0, pHomeInfo->BattleZoneLX);
-		z = pHomeInfo->BattleZoneZ + myrand(0, pHomeInfo->BattleZoneLZ);
-
-// 비러머글 개척지대 바꿔치기 --;
-		if (m_pUserData->m_bZone == ZONE_SNOW_BATTLE)
-		{
-			x = pHomeInfo->FreeZoneX + myrand(0, pHomeInfo->FreeZoneLX);
-			z = pHomeInfo->FreeZoneZ + myrand(0, pHomeInfo->FreeZoneLZ);
-		}
-//
-
-/*
-		KickOutZoneUser();
-		return;
-*/
-	}
-	// Specific Lands...
-	else if (m_pUserData->m_bNation != m_pUserData->m_bZone
-		&& m_pUserData->m_bZone < 3)
-	{
-		if (m_pUserData->m_bNation == KARUS)
-		{
-			x = pHomeInfo->ElmoZoneX + myrand(0, pHomeInfo->ElmoZoneLX);
-			z = pHomeInfo->ElmoZoneZ + myrand(0, pHomeInfo->ElmoZoneLZ);
-		}
-		else if (m_pUserData->m_bNation == ELMORAD)
-		{
-			x = pHomeInfo->KarusZoneX + myrand(0, pHomeInfo->KarusZoneLX);
-			z = pHomeInfo->KarusZoneZ + myrand(0, pHomeInfo->KarusZoneLZ);
-		}
-		else
-		{
-			return;
-		}
-	}
-// 비러머글 뉴존 >.<
-	else if (m_pUserData->m_bZone > 10
-		&& m_pUserData->m_bZone < 20)
-	{
-		x = 527 + myrand(0, 10);
-		z = 543 + myrand(0, 10);
-	}
-//
-	else
-	{	// Your own nation...
-		if (m_pUserData->m_bNation == KARUS)
-		{
-			x = pHomeInfo->KarusZoneX + myrand(0, pHomeInfo->KarusZoneLX);
-			z = pHomeInfo->KarusZoneZ + myrand(0, pHomeInfo->KarusZoneLZ);
-		}
-		else if (m_pUserData->m_bNation == ELMORAD)
-		{
-			x = pHomeInfo->ElmoZoneX + myrand(0, pHomeInfo->ElmoZoneLX);
-			z = pHomeInfo->ElmoZoneZ + myrand(0, pHomeInfo->ElmoZoneLZ);
-		}
-		else
-		{
-			return;
-		}
-	}
 
 	SetShort(send_buff, (WORD) (x * 10), send_index);
 	SetShort(send_buff, (WORD) (z * 10), send_index);
 	Warp(send_buff);
+}
+
+bool CUser::GetStartPosition(short* x, short* z)
+{
+	model::StartPosition* startPosition = m_pMain->m_StartPositionMap.GetData(m_pUserData->m_bZone);
+	if (startPosition == nullptr)
+		return false;
+
+	if (m_pUserData->m_bNation == KARUS)
+	{
+		*x = startPosition->KarusX + myrand(0, startPosition->RangeX);
+		*z = startPosition->KarusZ + myrand(0, startPosition->RangeZ);
+		return true;
+	}
+	else if (m_pUserData->m_bNation == ELMORAD)
+	{
+		*x = startPosition->ElmoX + myrand(0, startPosition->RangeX);
+		*z = startPosition->ElmoZ + myrand(0, startPosition->RangeZ);
+		return true;
+	}
+
+	return false;
 }
 
 CUser* CUser::GetItemRoutingUser(int itemid, short itemcount)

--- a/Server/Ebenezer/User.h
+++ b/Server/Ebenezer/User.h
@@ -276,6 +276,7 @@ public:
 	void ClassChangeReq();
 	void FriendReport(char* pBuf);
 	CUser* GetItemRoutingUser(int itemid, short itemcount);
+	bool GetStartPosition(short* x, short* z);
 	void Home();
 	void ReportBug(char* pBuf);
 	int GetEmptySlot(int itemid, int bCountable);


### PR DESCRIPTION
For now this is just /town (WIZ_HOME / CUser::Home()). Officially it'd extend to respawning, warping, etc too.

It should also handle things like CSW overrides, but we don't implement this yet.

Resolves #319

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?

Since START_POSITION isn't loaded, the server only uses HOME for /town.
This is exclusively used during war invasions, so the /town coordinates are wrong for the only zones it supports (1 & 2).
Since other zones don't exist in it, naturally /town doesn't behave either.

## What is the new behaviour?

We load up START_POSITION (again). For /town specifically (though more should be added, like respawning), we now use it to fetch the appropriate /town coordinates per nation.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
