### PR TITLE
Add custom NANODBC_DISABLE_NULL_ACCESS_ERROR

### DIFF
--- a/props/nanodbc.props
+++ b/props/nanodbc.props
@@ -3,7 +3,7 @@
   <ImportGroup Label="PropertySheets" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>NANODBC_USE_UINT8_FOR_TINYINT;NANODBC_DISABLE_MSSQL_TVP;%(PreprocessorDefinitions);</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NANODBC_DISABLE_NULL_ACCESS_ERROR;NANODBC_USE_UINT8_FOR_TINYINT;NANODBC_DISABLE_MSSQL_TVP;%(PreprocessorDefinitions);</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(DependencyDir)nanodbc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>


### PR DESCRIPTION
For simplicity, when fetching, we should just initialize to defaults if a column is NULL, rather than throwing.
This way we don't have to strictly keep our database synced with user databases (at least, for this purpose).