### PR TITLE
Store logs under the executable's path

### DIFF
--- a/Server/AIServer/ServerDlg.cpp
+++ b/Server/AIServer/ServerDlg.cpp
@@ -2127,14 +2127,17 @@ void CServerDlg::CloseSocket(int zonenumber)
 
 void CServerDlg::GetServerInfoIni()
 {
-	std::filesystem::path iniPath(GetProgPath().GetString());
+	CString exePath = GetProgPath();
+	std::string exePathUtf8(CT2A(exePath, CP_UTF8));
+
+	std::filesystem::path iniPath(exePath.GetString());
 	iniPath /= L"server.ini";
 	
 	CIni inifile;
 	inifile.Load(iniPath);
 
 	// logger setup
-	logger::SetupLogger(inifile, logger::AIServer);
+	logger::SetupLogger(inifile, logger::AIServer, exePathUtf8);
 	
 	m_byZone = inifile.GetInt(_T("SERVER"), _T("ZONE"), 1);
 

--- a/Server/Aujard/AujardDlg.cpp
+++ b/Server/Aujard/AujardDlg.cpp
@@ -178,13 +178,16 @@ BOOL CAujardDlg::OnInitDialog()
 	SetIcon(_icon, TRUE);			// Set big icon
 	SetIcon(_icon, FALSE);		// Set small icon
 
-	std::filesystem::path iniPath(GetProgPath().GetString());
+	CString exePath(GetProgPath());
+	std::string exePathUtf8(CT2A(exePath, CP_UTF8));
+
+	std::filesystem::path iniPath(exePath.GetString());
 	iniPath /= L"Aujard.ini";
 
 	CIni ini(iniPath);
 
 	// configure logger
-	logger::SetupLogger(ini, logger::Aujard);
+	logger::SetupLogger(ini, logger::Aujard, exePathUtf8);
 
 	LoggerRecvQueue.InitailizeMMF(MAX_PKTSIZE, MAX_COUNT, _T(SMQ_LOGGERSEND), FALSE);	// Dispatcher 의 Send Queue
 	LoggerSendQueue.InitailizeMMF(MAX_PKTSIZE, MAX_COUNT, _T(SMQ_LOGGERRECV), FALSE);	// Dispatcher 의 Read Queue

--- a/Server/Ebenezer/EbenezerDlg.cpp
+++ b/Server/Ebenezer/EbenezerDlg.cpp
@@ -1390,12 +1390,15 @@ void CEbenezerDlg::LoadConfig()
 	int year = 0, month = 0, date = 0, hour = 0, serverCount = 0, sgroup_count = 0;
 	char ipkey[20] = {};
 
-	std::filesystem::path iniPath(GetProgPath().GetString());
+	CString exePath(GetProgPath());
+	std::string exePathUtf8(CT2A(exePath, CP_UTF8));
+
+	std::filesystem::path iniPath(exePath.GetString());
 	iniPath /= L"gameserver.ini";
 
 	m_Ini.Load(iniPath);
 
-	logger::SetupLogger(m_Ini, logger::Ebenezer);
+	logger::SetupLogger(m_Ini, logger::Ebenezer, exePathUtf8);
 	
 	m_nYear = m_Ini.GetInt("TIMER", "YEAR", 1);
 	m_nMonth = m_Ini.GetInt("TIMER", "MONTH", 1);

--- a/Server/VersionManager/VersionManagerDlg.cpp
+++ b/Server/VersionManager/VersionManagerDlg.cpp
@@ -128,7 +128,10 @@ BOOL CVersionManagerDlg::OnInitDialog()
 
 BOOL CVersionManagerDlg::GetInfoFromIni()
 {
-	std::filesystem::path iniPath(GetProgPath().GetString());
+	CString exePath = GetProgPath();
+	std::string exePathUtf8(CT2A(exePath, CP_UTF8));
+
+	std::filesystem::path iniPath(exePath.GetString());
 	iniPath /= L"Version.ini";
 
 	CIni ini(iniPath);
@@ -138,7 +141,7 @@ BOOL CVersionManagerDlg::GetInfoFromIni()
 	ini.GetString(ini::DOWNLOAD, ini::PATH, "/", _ftpPath, _countof(_ftpPath));
 
 	// configure logger
-	logger::SetupLogger(ini, logger::VersionManager);
+	logger::SetupLogger(ini, logger::VersionManager, exePathUtf8);
 	
 	// TODO: KN_online should be Knight_Account
 	std::string datasourceName = ini.GetString(ini::ODBC, ini::DSN, "KN_online");

--- a/Server/shared/logger.cpp
+++ b/Server/shared/logger.cpp
@@ -9,43 +9,53 @@
 #include <spdlog/async.h>
 #include <spdlog/async_logger.h>
 
+namespace logger
+{
+	void SetupExtraLogger(CIni& ini,
+		const std::string& appName, const std::string& logFileConfigProp,
+		const std::string& exePath,
+		std::shared_ptr<spdlog::details::thread_pool> threadPool);
+}
+
 /// \brief Sets up spdlog from an ini file using standardized server settings
 /// \param ini server application's ini file (already loaded)
-/// \param name application name (VersionManager, Aujard, AIServer, Ebenezer)
-void logger::SetupLogger(CIni& ini, const std::string& name)
+/// \param appName application name (VersionManager, Aujard, AIServer, Ebenezer)
+/// \param baseDir base directory to store logs folder under. must end in a trailing slash.
+void logger::SetupLogger(CIni& ini, const std::string& appName, const std::string& baseDir)
 {
 	// setup file logger
-	std::string defaultLogPath = std::format("logs/{}.log", name);
+	std::string defaultLogPath = std::format("logs/{}.log", appName);
 	std::string fileName = ini.GetString(ini::LOGGER, ini::FILE, defaultLogPath);
-	auto fileLogger = std::make_shared<spdlog::sinks::daily_file_format_sink_mt>(fileName, 0, 0);
+	auto fileLogger = std::make_shared<spdlog::sinks::daily_file_format_sink_mt>(baseDir + fileName, 0, 0);
 
 	// setup console logger
 	auto consoleLogger = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
 
 	// setup multi-sink async logger as default (combines file+console logger)
-	spdlog::init_thread_pool(messageQueueSize, threadPoolSize);
+	spdlog::init_thread_pool(MessageQueueSize, ThreadPoolSize);
 	std::vector<spdlog::sink_ptr> sinks{fileLogger, consoleLogger};
 	auto threadPool = spdlog::thread_pool();
-	std::shared_ptr<spdlog::async_logger> appLogger = std::make_shared<spdlog::async_logger>(
-		name, sinks.begin(), sinks.end(), threadPool, spdlog::async_overflow_policy::block);
+	auto appLogger = std::make_shared<spdlog::async_logger>(
+		appName, sinks.begin(), sinks.end(), threadPool, spdlog::async_overflow_policy::block);
 	spdlog::set_default_logger(appLogger);
 
 	// add any extra loggers
-	if (name == AIServer)
+	if (appName == AIServer)
 	{
-		SetupExtraLogger(ini, AIServerItem, ini::ITEM_LOG_FILE, threadPool);
-		SetupExtraLogger(ini, AIServerUser, ini::USER_LOG_FILE, threadPool);
+		SetupExtraLogger(ini, AIServerItem, ini::ITEM_LOG_FILE, baseDir, threadPool);
+		SetupExtraLogger(ini, AIServerUser, ini::USER_LOG_FILE, baseDir, threadPool);
 	}
-	else if (name == Ebenezer)
+	else if (appName == Ebenezer)
 	{
-		SetupExtraLogger(ini, EbenezerEvent, ini::EVENT_LOG_FILE, threadPool);
-		SetupExtraLogger(ini, EbenezerRegion, ini::REGION_LOG_FILE, threadPool);
+		SetupExtraLogger(ini, EbenezerEvent, ini::EVENT_LOG_FILE, baseDir, threadPool);
+		SetupExtraLogger(ini, EbenezerRegion, ini::REGION_LOG_FILE, baseDir, threadPool);
 	}
 
 	// set default logger level and pattern
 	// we default to debug level logging
 	int logLevel = ini.GetInt(ini::LOGGER, ini::LEVEL, spdlog::level::debug);
 	spdlog::set_level(static_cast<spdlog::level::level_enum>(logLevel));
+
 	std::string logPattern = ini.GetString(ini::LOGGER, ini::PATTERN, ini::DEFAULT_LOG_PATTERN);
 	spdlog::set_pattern(logPattern);
 
@@ -53,30 +63,32 @@ void logger::SetupLogger(CIni& ini, const std::string& name)
 	// warning: only use if all your loggers are thread-safe ("_mt" loggers)
 	spdlog::flush_every(std::chrono::seconds(3));
 
-	spdlog::info("{} logger configured", name);
+	spdlog::info("{} logger configured", appName);
 }
 
-void logger::SetupExtraLogger(CIni& ini, const std::string& appName,
-	const std::string& logFileConfigProp,
+void logger::SetupExtraLogger(CIni& ini,
+	const std::string& appName, const std::string& logFileConfigProp,
+	const std::string& baseDir,
 	std::shared_ptr<spdlog::details::thread_pool> threadPool)
 {
 	// setup file logger
 	std::string defaultLogPath = std::format("logs/{}.log", appName);
 	std::string fileName = ini.GetString(ini::LOGGER, logFileConfigProp, defaultLogPath);
-	auto fileLogger = std::make_shared<spdlog::sinks::daily_file_format_sink_mt>(fileName, 0, 0);
+	auto fileLogger = std::make_shared<spdlog::sinks::daily_file_format_sink_mt>(baseDir + fileName, 0, 0);
 
 	// setup console logger
 	auto consoleLogger = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
 
 	// setup multi-sink async logger as default (combines file+console logger)
 	std::vector<spdlog::sink_ptr> sinks{fileLogger, consoleLogger};
-	std::shared_ptr<spdlog::async_logger> extraLogger = std::make_shared<spdlog::async_logger>(
+	auto extraLogger = std::make_shared<spdlog::async_logger>(
 		appName, sinks.begin(), sinks.end(), threadPool, spdlog::async_overflow_policy::block);
 
 	// set default logger level and pattern
 	// we default to debug level logging
 	int logLevel = ini.GetInt(ini::LOGGER, ini::LEVEL, spdlog::level::debug);
 	extraLogger->set_level(static_cast<spdlog::level::level_enum>(logLevel));
+
 	std::string logPattern = ini.GetString(ini::LOGGER, ini::PATTERN, ini::DEFAULT_LOG_PATTERN);
 	extraLogger->set_pattern(logPattern);
 

--- a/Server/shared/logger.h
+++ b/Server/shared/logger.h
@@ -1,28 +1,21 @@
 ﻿#pragma once
+
 #include <string>
-#include <memory>
 
 // forward declarations
 class CIni;
-namespace spdlog::details
-{
-	class thread_pool;
-}
 
 namespace logger
 {
 	/// \brief Sets up spdlog from an ini file using standardized server settings
 	/// \param ini server application's ini file (already loaded)
-	/// \param name application name (VersionManager, Aujard, AIServer, Ebenezer)
-	void SetupLogger(CIni& ini, const std::string& name);
-
-	void SetupExtraLogger(CIni& ini, const std::string& appName,
-		const std::string& logFileConfigProp,
-		std::shared_ptr<spdlog::details::thread_pool> threadPool);
+	/// \param appName application name (VersionManager, Aujard, AIServer, Ebenezer)
+	/// \param baseDir base directory to store logs folder under. must end in a trailing slash.
+	void SetupLogger(CIni& ini, const std::string& appName, const std::string& baseDir);
 
 	// setup defaults
-	static constexpr uint16_t messageQueueSize = 8196;
-	static constexpr uint8_t threadPoolSize = 1;
+	static constexpr uint16_t MessageQueueSize = 8192;
+	static constexpr uint8_t ThreadPoolSize = 1;
 	
 	// application names used by our loggers
 	static constexpr char AIServer[] = "AIServer";


### PR DESCRIPTION
Everything else is loaded relative to the executable, so we should be sure to store logs there too. Otherwise they end up in the working dir which won't be the same when running under a debugger with default config.