### PR TITLE
Wrap spdlog runner

### DIFF
--- a/Server/AIServer/Npc.cpp
+++ b/Server/AIServer/Npc.cpp
@@ -6,7 +6,6 @@
 #include "Region.h"
 #include "Party.h"
 #include "extern.h"
-#include <shared/logger.h>
 #include <spdlog/spdlog.h>
 
 //BOOL g_bDebug = TRUE;

--- a/Server/AIServer/ServerDlg.cpp
+++ b/Server/AIServer/ServerDlg.cpp
@@ -12,7 +12,6 @@
 #include <shared/lzf.h>
 #include <shared/globals.h>
 #include <shared/Ini.h>
-#include <shared/logger.h>
 
 #include <db-library/ConnectionManager.h>
 #include <spdlog/spdlog.h>
@@ -1106,8 +1105,6 @@ BOOL CServerDlg::DestroyWindow()
 	DeleteCriticalSection(&g_User_critical);
 	DeleteCriticalSection(&g_region_critical);
 
-	spdlog::shutdown();
-
 	s_pInstance = nullptr;
 
 	return CDialog::DestroyWindow();
@@ -2137,7 +2134,7 @@ void CServerDlg::GetServerInfoIni()
 	inifile.Load(iniPath);
 
 	// logger setup
-	logger::SetupLogger(inifile, logger::AIServer, exePathUtf8);
+	_logger.Setup(inifile, exePathUtf8);
 	
 	m_byZone = inifile.GetInt(_T("SERVER"), _T("ZONE"), 1);
 
@@ -2151,6 +2148,14 @@ void CServerDlg::GetServerInfoIni()
 
 	// Trigger a save to flush defaults to file.
 	inifile.Save();
+}
+
+void AIServerLogger::SetupExtraLoggers(CIni& ini,
+	std::shared_ptr<spdlog::details::thread_pool> threadPool,
+	const std::string& baseDir)
+{
+	SetupExtraLogger(ini, threadPool, baseDir, logger::AIServerItem, ini::ITEM_LOG_FILE);
+	SetupExtraLogger(ini, threadPool, baseDir, logger::AIServerUser, ini::USER_LOG_FILE);
 }
 
 void CServerDlg::SendSystemMsg(char* pMsg, int zone, int type, int who)

--- a/Server/AIServer/ServerDlg.h
+++ b/Server/AIServer/ServerDlg.h
@@ -24,7 +24,9 @@
 
 #include "resource.h"
 
+#include <shared/logger.h>
 #include <shared/STLMap.h>
+
 #include <vector>
 #include <list>
 
@@ -32,6 +34,19 @@ namespace recordset_loader
 {
 	struct Error;
 }
+
+class AIServerLogger : public logger::Logger
+{
+public:
+	AIServerLogger()
+		: Logger(logger::AIServer)
+	{
+	}
+
+	void SetupExtraLoggers(CIni& ini,
+		std::shared_ptr<spdlog::details::thread_pool> threadPool,
+		const std::string& baseDir) override;
+};
 
 /////////////////////////////////////////////////////////////////////////////
 // CServerDlg dialog
@@ -168,13 +183,9 @@ public:
 
 	static CServerDlg* s_pInstance;
 
-
 // Implementation
 protected:
 	void DefaultInit();
-
-
-//	CGameSocket m_GameSocket;
 
 	HICON m_hIcon;
 
@@ -203,6 +214,8 @@ private:
 	// ~패킷 압축에 필요 변수   -------------
 
 	BYTE				m_byZone;
+
+	AIServerLogger		_logger;
 	
 	/// \brief output message box for the application
 	CListBox _outputList;

--- a/Server/AIServer/User.cpp
+++ b/Server/AIServer/User.cpp
@@ -10,7 +10,6 @@
 #include "Region.h"
 #include "GameSocket.h"
 #include <spdlog/spdlog.h>
-#include <shared/logger.h>
 
 #ifdef _DEBUG
 #undef THIS_FILE

--- a/Server/Aujard/AujardDlg.cpp
+++ b/Server/Aujard/AujardDlg.cpp
@@ -7,7 +7,6 @@
 
 #include <process.h>
 #include <shared/Ini.h>
-#include <shared/logger.h>
 #include <shared/StringConversion.h>
 #include <db-library/ConnectionManager.h>
 
@@ -125,7 +124,8 @@ DWORD WINAPI ReadQueueThread(LPVOID lp)
 // CAujardDlg dialog
 
 CAujardDlg::CAujardDlg(CWnd* parent /*=nullptr*/)
-	: CDialog(IDD, parent)
+	: CDialog(IDD, parent),
+	_logger(logger::Aujard)
 {
 	//{{AFX_DATA_INIT(CAujardDlg)
 	//}}AFX_DATA_INIT
@@ -187,7 +187,7 @@ BOOL CAujardDlg::OnInitDialog()
 	CIni ini(iniPath);
 
 	// configure logger
-	logger::SetupLogger(ini, logger::Aujard, exePathUtf8);
+	_logger.Setup(ini, exePathUtf8);
 
 	LoggerRecvQueue.InitailizeMMF(MAX_PKTSIZE, MAX_COUNT, _T(SMQ_LOGGERSEND), FALSE);	// Dispatcher 의 Send Queue
 	LoggerSendQueue.InitailizeMMF(MAX_PKTSIZE, MAX_COUNT, _T(SMQ_LOGGERRECV), FALSE);	// Dispatcher 의 Read Queue
@@ -303,8 +303,6 @@ BOOL CAujardDlg::DestroyWindow()
 
 	if (!ItemArray.IsEmpty())
 		ItemArray.DeleteAllData();
-
-	spdlog::shutdown();
 	
 	_instance = nullptr;
 

--- a/Server/Aujard/AujardDlg.h
+++ b/Server/Aujard/AujardDlg.h
@@ -13,6 +13,7 @@
 #include "Define.h"
 #include "resource.h"
 
+#include <shared/logger.h>
 #include <shared/STLMap.h>
 
 using ItemtableArray = CSTLMap<model::Item>;
@@ -172,7 +173,6 @@ public:
 
 	ItemtableArray		ItemArray;
 
-
 	// Dialog Data
 	//{{AFX_DATA(CAujardDlg)
 	enum { IDD = IDD_AUJARD_DIALOG };
@@ -196,6 +196,8 @@ protected:
 	int					_recvPacketCount;	// packet의 수를 체크
 
 	HICON				_icon;
+
+	logger::Logger		_logger;
 
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAujardDlg)

--- a/Server/Ebenezer/AISocket.cpp
+++ b/Server/Ebenezer/AISocket.cpp
@@ -14,7 +14,6 @@
 #include <shared/crc32.h>
 #include <shared/lzf.h>
 #include <shared/packets.h>
-#include <shared/logger.h>
 #include <spdlog/spdlog.h>
 
 #ifdef _DEBUG

--- a/Server/Ebenezer/EbenezerDlg.cpp
+++ b/Server/Ebenezer/EbenezerDlg.cpp
@@ -11,7 +11,6 @@
 #include <shared/StringUtils.h>
 
 #include <db-library/ConnectionManager.h>
-#include <shared/logger.h>
 
 constexpr int GAME_TIME       	= 100;
 constexpr int SEND_TIME			= 200;
@@ -683,8 +682,6 @@ BOOL CEbenezerDlg::DestroyWindow()
 
 	DeleteCriticalSection(&g_serial_critical);
 	DeleteCriticalSection(&g_region_critical);
-
-	spdlog::shutdown();
 
 	return CDialog::DestroyWindow();
 }
@@ -1398,7 +1395,7 @@ void CEbenezerDlg::LoadConfig()
 
 	m_Ini.Load(iniPath);
 
-	logger::SetupLogger(m_Ini, logger::Ebenezer, exePathUtf8);
+	_logger.Setup(m_Ini, exePathUtf8);
 	
 	m_nYear = m_Ini.GetInt("TIMER", "YEAR", 1);
 	m_nMonth = m_Ini.GetInt("TIMER", "MONTH", 1);
@@ -1481,6 +1478,14 @@ void CEbenezerDlg::LoadConfig()
 	SetTimer(ALIVE_TIME, 34000, nullptr);
 	SetTimer(MARKET_BBS_TIME, 300000, nullptr);
 	SetTimer(PACKET_CHECK, 360000, nullptr);
+}
+
+void EbenezerLogger::SetupExtraLoggers(CIni& ini,
+	std::shared_ptr<spdlog::details::thread_pool> threadPool,
+	const std::string& baseDir)
+{
+	SetupExtraLogger(ini, threadPool, baseDir, logger::EbenezerEvent, ini::EVENT_LOG_FILE);
+	SetupExtraLogger(ini, threadPool, baseDir, logger::EbenezerRegion, ini::REGION_LOG_FILE);
 }
 
 void CEbenezerDlg::UpdateGameTime()

--- a/Server/Ebenezer/EbenezerDlg.h
+++ b/Server/Ebenezer/EbenezerDlg.h
@@ -21,7 +21,9 @@
 #include "UdpSocket.h"
 
 #include <shared/Ini.h>
+#include <shared/logger.h>
 #include <shared/STLMap.h>
+
 #include <vector>
 
 #include "resource.h"
@@ -30,6 +32,19 @@ namespace recordset_loader
 {
 	struct Error;
 }
+
+class EbenezerLogger : public logger::Logger
+{
+public:
+	EbenezerLogger()
+		: Logger(logger::Ebenezer)
+	{
+	}
+
+	void SetupExtraLoggers(CIni& ini,
+		std::shared_ptr<spdlog::details::thread_pool> threadPool,
+		const std::string& baseDir) override;
+};
 
 /////////////////////////////////////////////////////////////////////////////
 // CEbenezerDlg dialog
@@ -294,7 +309,8 @@ protected:
 	
 private:
 	CIni	m_Ini;
-	
+	EbenezerLogger _logger;
+
 	/// \brief output message box for the application
 	CListBox _outputList;
 };

--- a/Server/Ebenezer/MagicProcess.cpp
+++ b/Server/Ebenezer/MagicProcess.cpp
@@ -11,7 +11,6 @@
 #include "GameDefine.h"
 
 #include <shared/packets.h>
-#include <shared/logger.h>
 #include <spdlog/spdlog.h>
 
 #ifdef _DEBUG

--- a/Server/VersionManager/VersionManagerDlg.cpp
+++ b/Server/VersionManager/VersionManagerDlg.cpp
@@ -9,7 +9,6 @@
 #include "User.h"
 
 #include <shared/Ini.h>
-#include <shared/logger.h>
 
 #include <db-library/ConnectionManager.h>
 #include <spdlog/spdlog.h>
@@ -34,7 +33,8 @@ constexpr int DB_POOL_CHECK = 100;
 
 CVersionManagerDlg::CVersionManagerDlg(CWnd* parent)
 	: CDialog(IDD, parent),
-	DbProcess(this)
+	DbProcess(this),
+	_logger(logger::VersionManager)
 {
 	//{{AFX_DATA_INIT(CVersionManagerDlg)
 		// NOTE: the ClassWizard will add member initialization here
@@ -141,7 +141,7 @@ BOOL CVersionManagerDlg::GetInfoFromIni()
 	ini.GetString(ini::DOWNLOAD, ini::PATH, "/", _ftpPath, _countof(_ftpPath));
 
 	// configure logger
-	logger::SetupLogger(ini, logger::VersionManager, exePathUtf8);
+	_logger.Setup(ini, exePathUtf8);
 	
 	// TODO: KN_online should be Knight_Account
 	std::string datasourceName = ini.GetString(ini::ODBC, ini::DSN, "KN_online");
@@ -322,8 +322,6 @@ BOOL CVersionManagerDlg::DestroyWindow()
 	for (_SERVER_INFO* pInfo : ServerList)
 		delete pInfo;
 	ServerList.clear();
-
-	spdlog::shutdown();
 
 	return CDialog::DestroyWindow();
 }

--- a/Server/VersionManager/VersionManagerDlg.h
+++ b/Server/VersionManager/VersionManagerDlg.h
@@ -11,6 +11,9 @@
 #include "Define.h"
 #include "Iocport.h"
 #include "DBProcess.h"
+
+#include <shared/logger.h>
+
 #include <vector>
 #include <string>
 
@@ -97,6 +100,8 @@ protected:
 	/// \brief DefaultPath loaded from CONFIGURATION.DEFAULT_PATH
 	std::string		_defaultPath;
 	int				_lastVersion;
+
+	logger::Logger	_logger;
 
 	// Generated message map functions
 	//{{AFX_MSG(CVersionManagerDlg)

--- a/Server/shared/logger.cpp
+++ b/Server/shared/logger.cpp
@@ -19,7 +19,7 @@ logger::Logger::Logger(const std::string& appName)
 
 /// \brief Sets up spdlog from an ini file using standardized server settings
 /// \param ini server application's ini file (already loaded)
-/// \param baseDir base directory to store logs folder under. must end in a trailing slash.
+/// \param baseDir base directory to store logs folder under
 void logger::Logger::Setup(CIni& ini, const std::string& baseDir)
 {
 	// setup file logger

--- a/Server/shared/logger.cpp
+++ b/Server/shared/logger.cpp
@@ -9,6 +9,8 @@
 #include <spdlog/async.h>
 #include <spdlog/async_logger.h>
 
+#include <filesystem>
+
 logger::Logger::Logger(const std::string& appName)
 	: _appName(appName)
 {
@@ -22,7 +24,15 @@ void logger::Logger::Setup(CIni& ini, const std::string& baseDir)
 {
 	// setup file logger
 	std::string fileName = ini.GetString(ini::LOGGER, ini::FILE, _defaultLogPath);
-	auto fileLogger = std::make_shared<spdlog::sinks::daily_file_format_sink_mt>(baseDir + fileName, 0, 0);
+
+	std::filesystem::path configuredLogPath(fileName);
+	if (configuredLogPath.is_relative())
+		configuredLogPath = std::filesystem::path(baseDir) / fileName;
+
+	std::u8string utf8String = configuredLogPath.u8string();
+	fileName.assign(utf8String.begin(), utf8String.end());
+
+	auto fileLogger = std::make_shared<spdlog::sinks::daily_file_format_sink_mt>(fileName, 0, 0);
 
 	// setup console logger
 	auto consoleLogger = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
@@ -72,7 +82,15 @@ void logger::Logger::SetupExtraLogger(CIni& ini,
 {
 	// setup file logger
 	std::string fileName = ini.GetString(ini::LOGGER, logFileConfigProp, _defaultLogPath);
-	auto fileLogger = std::make_shared<spdlog::sinks::daily_file_format_sink_mt>(baseDir + fileName, 0, 0);
+
+	std::filesystem::path configuredLogPath(fileName);
+	if (configuredLogPath.is_relative())
+		configuredLogPath = std::filesystem::path(baseDir) / fileName;
+
+	std::u8string utf8String = configuredLogPath.u8string();
+	fileName.assign(utf8String.begin(), utf8String.end());
+
+	auto fileLogger = std::make_shared<spdlog::sinks::daily_file_format_sink_mt>(fileName, 0, 0);
 
 	// setup console logger
 	auto consoleLogger = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();

--- a/Server/shared/logger.cpp
+++ b/Server/shared/logger.cpp
@@ -9,23 +9,19 @@
 #include <spdlog/async.h>
 #include <spdlog/async_logger.h>
 
-namespace logger
+logger::Logger::Logger(const std::string& appName)
+	: _appName(appName)
 {
-	void SetupExtraLogger(CIni& ini,
-		const std::string& appName, const std::string& logFileConfigProp,
-		const std::string& exePath,
-		std::shared_ptr<spdlog::details::thread_pool> threadPool);
+	_defaultLogPath = std::format("logs/{}.log", appName);
 }
 
 /// \brief Sets up spdlog from an ini file using standardized server settings
 /// \param ini server application's ini file (already loaded)
-/// \param appName application name (VersionManager, Aujard, AIServer, Ebenezer)
 /// \param baseDir base directory to store logs folder under. must end in a trailing slash.
-void logger::SetupLogger(CIni& ini, const std::string& appName, const std::string& baseDir)
+void logger::Logger::Setup(CIni& ini, const std::string& baseDir)
 {
 	// setup file logger
-	std::string defaultLogPath = std::format("logs/{}.log", appName);
-	std::string fileName = ini.GetString(ini::LOGGER, ini::FILE, defaultLogPath);
+	std::string fileName = ini.GetString(ini::LOGGER, ini::FILE, _defaultLogPath);
 	auto fileLogger = std::make_shared<spdlog::sinks::daily_file_format_sink_mt>(baseDir + fileName, 0, 0);
 
 	// setup console logger
@@ -33,23 +29,16 @@ void logger::SetupLogger(CIni& ini, const std::string& appName, const std::strin
 
 	// setup multi-sink async logger as default (combines file+console logger)
 	spdlog::init_thread_pool(MessageQueueSize, ThreadPoolSize);
+
 	std::vector<spdlog::sink_ptr> sinks{fileLogger, consoleLogger};
+
 	auto threadPool = spdlog::thread_pool();
 	auto appLogger = std::make_shared<spdlog::async_logger>(
-		appName, sinks.begin(), sinks.end(), threadPool, spdlog::async_overflow_policy::block);
+		_appName, sinks.begin(), sinks.end(), threadPool, spdlog::async_overflow_policy::block);
 	spdlog::set_default_logger(appLogger);
 
 	// add any extra loggers
-	if (appName == AIServer)
-	{
-		SetupExtraLogger(ini, AIServerItem, ini::ITEM_LOG_FILE, baseDir, threadPool);
-		SetupExtraLogger(ini, AIServerUser, ini::USER_LOG_FILE, baseDir, threadPool);
-	}
-	else if (appName == Ebenezer)
-	{
-		SetupExtraLogger(ini, EbenezerEvent, ini::EVENT_LOG_FILE, baseDir, threadPool);
-		SetupExtraLogger(ini, EbenezerRegion, ini::REGION_LOG_FILE, baseDir, threadPool);
-	}
+	SetupExtraLoggers(ini, threadPool, baseDir);
 
 	// set default logger level and pattern
 	// we default to debug level logging
@@ -63,17 +52,26 @@ void logger::SetupLogger(CIni& ini, const std::string& appName, const std::strin
 	// warning: only use if all your loggers are thread-safe ("_mt" loggers)
 	spdlog::flush_every(std::chrono::seconds(3));
 
-	spdlog::info("{} logger configured", appName);
+	spdlog::info("{} logger configured", _appName);
 }
 
-void logger::SetupExtraLogger(CIni& ini,
-	const std::string& appName, const std::string& logFileConfigProp,
+void logger::Logger::SetupExtraLoggers(CIni& ini,
+	std::shared_ptr<spdlog::details::thread_pool> threadPool,
+	const std::string& baseDir)
+{
+	/* do nothing - consumers will implement this */
+	ini;
+	threadPool;
+	baseDir;
+}
+
+void logger::Logger::SetupExtraLogger(CIni& ini,
+	std::shared_ptr<spdlog::details::thread_pool> threadPool,
 	const std::string& baseDir,
-	std::shared_ptr<spdlog::details::thread_pool> threadPool)
+	const std::string& appName, const std::string& logFileConfigProp)
 {
 	// setup file logger
-	std::string defaultLogPath = std::format("logs/{}.log", appName);
-	std::string fileName = ini.GetString(ini::LOGGER, logFileConfigProp, defaultLogPath);
+	std::string fileName = ini.GetString(ini::LOGGER, logFileConfigProp, _defaultLogPath);
 	auto fileLogger = std::make_shared<spdlog::sinks::daily_file_format_sink_mt>(baseDir + fileName, 0, 0);
 
 	// setup console logger
@@ -95,4 +93,9 @@ void logger::SetupExtraLogger(CIni& ini,
 	// register the logger
 	spdlog::register_logger(extraLogger);
 	spdlog::get(appName)->info("{} logger configured", appName);
+}
+
+logger::Logger::~Logger()
+{
+	spdlog::shutdown();
 }

--- a/Server/shared/logger.h
+++ b/Server/shared/logger.h
@@ -16,6 +16,10 @@ namespace logger
 
 	class Logger
 	{
+		// setup defaults
+		static constexpr uint16_t MessageQueueSize = 8192;
+		static constexpr uint8_t ThreadPoolSize = 1;
+
 	public:
 		/// \param appName application name (VersionManager, Aujard, AIServer, Ebenezer)
 		Logger(const std::string& appName);
@@ -41,10 +45,6 @@ namespace logger
 		std::string _defaultLogPath;
 	};
 
-	// setup defaults
-	static constexpr uint16_t MessageQueueSize = 8192;
-	static constexpr uint8_t ThreadPoolSize = 1;
-	
 	// application names used by our loggers
 	static constexpr char AIServer[] = "AIServer";
 	static constexpr char AIServerItem[] = "AIServerItem";

--- a/Server/shared/logger.h
+++ b/Server/shared/logger.h
@@ -26,7 +26,7 @@ namespace logger
 
 		/// \brief Sets up spdlog from an ini file using standardized server settings
 		/// \param ini server application's ini file (already loaded)
-		/// \param baseDir base directory to store logs folder under. must end in a trailing slash.
+		/// \param baseDir base directory to store logs folder under
 		void Setup(CIni& ini, const std::string& baseDir);
 
 		virtual void SetupExtraLoggers(CIni& ini,

--- a/Server/shared/logger.h
+++ b/Server/shared/logger.h
@@ -1,17 +1,45 @@
 ﻿#pragma once
 
 #include <string>
+#include <memory>
 
 // forward declarations
 class CIni;
 
+namespace spdlog::details
+{
+	class thread_pool;
+}
+
 namespace logger
 {
-	/// \brief Sets up spdlog from an ini file using standardized server settings
-	/// \param ini server application's ini file (already loaded)
-	/// \param appName application name (VersionManager, Aujard, AIServer, Ebenezer)
-	/// \param baseDir base directory to store logs folder under. must end in a trailing slash.
-	void SetupLogger(CIni& ini, const std::string& appName, const std::string& baseDir);
+
+	class Logger
+	{
+	public:
+		/// \param appName application name (VersionManager, Aujard, AIServer, Ebenezer)
+		Logger(const std::string& appName);
+
+		/// \brief Sets up spdlog from an ini file using standardized server settings
+		/// \param ini server application's ini file (already loaded)
+		/// \param baseDir base directory to store logs folder under. must end in a trailing slash.
+		void Setup(CIni& ini, const std::string& baseDir);
+
+		virtual void SetupExtraLoggers(CIni& ini,
+			std::shared_ptr<spdlog::details::thread_pool> threadPool,
+			const std::string& baseDir);
+
+		void SetupExtraLogger(CIni& ini,
+			std::shared_ptr<spdlog::details::thread_pool> threadPool,
+			const std::string& baseDir,
+			const std::string& appName, const std::string& logFileConfigProp);
+
+		virtual ~Logger();
+
+	protected:
+		std::string _appName;
+		std::string _defaultLogPath;
+	};
 
 	// setup defaults
 	static constexpr uint16_t MessageQueueSize = 8192;


### PR DESCRIPTION
Very loosely wrap spdlog log runners for better RAII encapsulation, also allowing us to move consumer logic out of the shared library.

Additionally, make sure we're only appending the base directory to relative paths.