### PR TITLE
replacing pipelines with newlines in quest_talk

### DIFF
--- a/Client/WarFare/GameBase.cpp
+++ b/Client/WarFare/GameBase.cpp
@@ -648,3 +648,30 @@ std::string CGameBase::FormatNumber(int iNumber)
 
 	return szFormattedNum;
 }
+
+void CGameBase::ConvertPipesToNewlines(std::string* pString){
+	
+	if (pString == nullptr)
+		return;
+	
+	for (size_t i = 0; i < pString->length();)
+	{
+		if ((*pString)[i] == '|')
+		{
+			if (i + 1 < pString->length() && (*pString)[i + 1] == '|')
+			{
+				pString->replace(i, 2, "\n\n");
+				i += 2;
+			}
+			else
+			{
+				pString->replace(i, 1, "\n");
+				i += 1;
+			}
+		}
+		else
+		{
+			i++;
+		}
+	}
+}

--- a/Client/WarFare/GameBase.cpp
+++ b/Client/WarFare/GameBase.cpp
@@ -658,16 +658,8 @@ void CGameBase::ConvertPipesToNewlines(std::string* pString){
 	{
 		if ((*pString)[i] == '|')
 		{
-			if (i + 1 < pString->length() && (*pString)[i + 1] == '|')
-			{
-				pString->replace(i, 2, "\n\n");
-				i += 2;
-			}
-			else
-			{
-				pString->replace(i, 1, "\n");
-				i += 1;
-			}
+			pString->replace(i, 1, "\n");
+			i++;
 		}
 		else
 		{

--- a/Client/WarFare/GameBase.h
+++ b/Client/WarFare/GameBase.h
@@ -62,6 +62,7 @@ public:
 	class CPlayerBase*	CharacterGetByID(int iID, bool bFromAlive);
 	bool				IsValidCharacter(CPlayerBase* pCharacter);
 	static std::string FormatNumber(int iNumber);
+	static void ConvertPipesToNewlines(std::string* pString); //replace | with \n in quest_talk, quest_content
 
 	CGameBase();
 	virtual ~CGameBase();

--- a/Client/WarFare/UIQuestMenu.cpp
+++ b/Client/WarFare/UIQuestMenu.cpp
@@ -164,6 +164,7 @@ void CUIQuestMenu::Open(Packet& pkt)
 	if(pTbl_Quest_Talk == NULL) return;
 
 	szTitle = pTbl_Quest_Talk->szTalk;
+	CGameBase::ConvertPipesToNewlines(&szTitle);
 	m_pTextTitle->SetString(szTitle);
 
 	m_iMenuCnt = 0;

--- a/Client/WarFare/UIQuestTalk.cpp
+++ b/Client/WarFare/UIQuestTalk.cpp
@@ -57,10 +57,10 @@ void CUIQuestTalk::Open(Packet& pkt)
 		if(pTbl_Quest_Talk)
 		{
 			m_szTalk[i] = pTbl_Quest_Talk->szTalk;
+			CGameBase::ConvertPipesToNewlines(&m_szTalk[i]);
 			m_iNumTalk++;
 		}
 	}
-	CGameBase::ConvertPipesToNewlines(&m_szTalk[m_iCurTalk]);
 
 	m_pTextTalk->SetString(m_szTalk[m_iCurTalk]);
 	SetVisible(true);
@@ -80,6 +80,7 @@ bool CUIQuestTalk::ReceiveMessage(CN3UIBase *pSender, uint32_t dwMsg)
 			}
 			else
 			{
+				CGameBase::ConvertPipesToNewlines(&m_szTalk[m_iCurTalk]);
 				m_pTextTalk->SetString(m_szTalk[m_iCurTalk]);
 			}
 		}

--- a/Client/WarFare/UIQuestTalk.cpp
+++ b/Client/WarFare/UIQuestTalk.cpp
@@ -60,6 +60,7 @@ void CUIQuestTalk::Open(Packet& pkt)
 			m_iNumTalk++;
 		}
 	}
+	CGameBase::ConvertPipesToNewlines(&m_szTalk[m_iCurTalk]);
 
 	m_pTextTalk->SetString(m_szTalk[m_iCurTalk]);
 	SetVisible(true);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
quest texts include pipelines ( | ).

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
pipelines has been changed into newlines (\n) as in official client.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
Increase readability on quest texts.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
