### PR TITLE
Find VS preview builds if no other VS instance is installed

### DIFF
--- a/build_scripts/env_find_msbuild.cmd
+++ b/build_scripts/env_find_msbuild.cmd
@@ -16,9 +16,16 @@ FOR /f "usebackq tokens=*" %%i IN (`"%VSWHERE%" -latest -products * -requires Mi
 	SET "MSBUILD=%%i"
 )
 
-IF  "%MSBUILD%"=="" (
-	ECHO ERROR: MSBuild.exe not found! Please ensure that Visual Studio 2022 or later is installed.
-	EXIT /B 1
+REM Search for preview builds as a fallback only, for cases where only preview is installed (we don't want to use it by default)
+IF "%MSBUILD%"=="" (
+	FOR /f "usebackq tokens=*" %%i IN (`"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
+		SET "MSBUILD=%%i"
+	)
+
+	IF "%MSBUILD%"=="" (
+		ECHO ERROR: MSBuild.exe not found! Please ensure that Visual Studio 2022 or later is installed.
+		EXIT /B 1
+	)
 )
 
 REM Export MSBUILD environment variable for caller

--- a/build_scripts/env_find_msbuild.cmd
+++ b/build_scripts/env_find_msbuild.cmd
@@ -12,20 +12,24 @@ IF NOT EXIST "%VSWHERE%" (
 
 REM Find latest MSBuild.exe path
 SET "MSBUILD="
+SET "MSBUILD_PREVIEW="
+
 FOR /f "usebackq tokens=*" %%i IN (`"%VSWHERE%" -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
 	SET "MSBUILD=%%i"
 )
 
+FOR /f "usebackq tokens=*" %%i IN (`"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
+	SET "MSBUILD_PREVIEW=%%i"
+)
+
 REM Search for preview builds as a fallback only, for cases where only preview is installed (we don't want to use it by default)
 IF "%MSBUILD%"=="" (
-	FOR /f "usebackq tokens=*" %%i IN (`"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) DO (
-		SET "MSBUILD=%%i"
-	)
-
-	IF "%MSBUILD%"=="" (
+	IF "%MSBUILD_PREVIEW%"=="" (
 		ECHO ERROR: MSBuild.exe not found! Please ensure that Visual Studio 2022 or later is installed.
 		EXIT /B 1
 	)
+	
+	SET "MSBUILD=%MSBUILD_PREVIEW%"
 )
 
 REM Export MSBUILD environment variable for caller


### PR DESCRIPTION
For users that install VS preview only, the existing script would not find their install.

To ensure we still primarily use latest stable for building, we still prioritise using this install first.
If it cannot be found, we search for the prerelease (preview) build.