### PR TITLE
Charfps

### DIFF
--- a/Client/N3Base/N3Base.vcxproj
+++ b/Client/N3Base/N3Base.vcxproj
@@ -43,6 +43,10 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\deps\mpg123\include\fmt123.h" />
+    <ClInclude Include="..\..\deps\mpg123\include\mpg123.h" />
+    <ClInclude Include="..\..\deps\mpg123\include\out123.h" />
+    <ClInclude Include="..\..\deps\mpg123\include\syn123.h" />
     <ClInclude Include="AVIPlayer.h" />
     <ClInclude Include="BitMapFile.h" />
     <ClInclude Include="DFont.h" />

--- a/Client/N3Base/N3Base.vcxproj.filters
+++ b/Client/N3Base/N3Base.vcxproj.filters
@@ -270,6 +270,18 @@
     <ClInclude Include="N3GlobalEffectMng.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\deps\mpg123\include\fmt123.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\deps\mpg123\include\mpg123.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\deps\mpg123\include\out123.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\deps\mpg123\include\syn123.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="N3Eng.cpp">

--- a/Client/N3Base/N3SndMgr.h
+++ b/Client/N3Base/N3SndMgr.h
@@ -13,6 +13,7 @@
 
 #include "N3SndDef.h"
 #include "N3TableBase.h"
+#include "..\deps\mpg123\include\mpg123.h"
 
 #include <list>
 #include <map>
@@ -36,7 +37,10 @@ protected:
 	std::list<CN3SndObjStream*>			m_SndObjStreams;	// 스트리밍 사운드..
 	std::list<CN3SndObj*>				m_SndObjs_Duplicated;
 	std::list<CN3SndObj*>				m_SndObjs_PlayOnceAndRelease;	// 한번만 플레이 하고 릴리즈 해야 하는 사운드들
-	
+	std::vector<std::string>			m_TempFilePaths; // For MP3 decoding
+
+	void CleanupTempFiles(); // For MP3 decoding
+
 public:
 	void		ReleaseObj(CN3SndObj** ppObj);
 	void		ReleaseStreamObj(CN3SndObjStream** ppObj);

--- a/Client/WarFare/GameProcCharacterSelect.cpp
+++ b/Client/WarFare/GameProcCharacterSelect.cpp
@@ -218,7 +218,10 @@ void CGameProcCharacterSelect::Init()
 	if (s_bIsRestarting)
 		MsgSend_VersionCheck();
 	else
+	{
 		MsgSend_RequestAllCharacterInfo(); // 캐릭터 정보 요청..
+		m_pSnd_Rotate->Play(); m_pSnd_Rotate->Stop();
+	}
 }
 
 void CGameProcCharacterSelect::Tick()

--- a/Client/WarFare/GameProcCharacterSelect.cpp
+++ b/Client/WarFare/GameProcCharacterSelect.cpp
@@ -107,6 +107,7 @@ void CGameProcCharacterSelect::Init()
 
 	CN3Base::s_SndMgr.ReleaseObj(&m_pSnd_Rotate);
 	m_pSnd_Rotate = CN3Base::s_SndMgr.CreateObj(ID_SOUND_CHR_SELECT_ROTATE);
+	m_pSnd_Rotate->Play(); m_pSnd_Rotate->Stop();
 	s_pUIMgr->EnableOperationSet(false); // 기존의 캐릭터 정보 패킷이 들어올때까지 UI 를 Disable 시킨다...
 
 	m_pCamera = new CN3Camera();
@@ -218,10 +219,7 @@ void CGameProcCharacterSelect::Init()
 	if (s_bIsRestarting)
 		MsgSend_VersionCheck();
 	else
-	{
 		MsgSend_RequestAllCharacterInfo(); // 캐릭터 정보 요청..
-		m_pSnd_Rotate->Play(); m_pSnd_Rotate->Stop();
-	}
 }
 
 void CGameProcCharacterSelect::Tick()

--- a/Client/WarFare/GameProcLogIn_1298.cpp
+++ b/Client/WarFare/GameProcLogIn_1298.cpp
@@ -74,9 +74,9 @@ void CGameProcLogIn_1298::Init()
 	m_pUILogIn->PositionGroups();
 
 	s_SndMgr.ReleaseStreamObj(&s_pSnd_BGM);
-
-	std::string szFN = "Snd\\Intro_Sound.mp3";
-	s_pSnd_BGM = s_SndMgr.CreateStreamObj(szFN);
+	s_pSnd_BGM = s_SndMgr.CreateStreamObj("snd\\intro_sound.mp3");
+	s_pSnd_BGM->Looping(true);
+	fTmp = 0; // enabling/play the bgm music
 
 	s_pUIMgr->SetFocusedUI(m_pUILogIn);
 
@@ -139,20 +139,32 @@ void CGameProcLogIn_1298::Tick() // 프로시져 인덱스를 리턴한다. 0 �
 {
 	CGameProcedure::Tick();	// 키, 마우스 입력 등등..
 
-	static float fTmp = 0;
+
 	if (fTmp == 0)
 	{
 		if (s_pSnd_BGM != nullptr)
-			s_pSnd_BGM->Play(); // 음악 시작..
+		{
+			s_pSnd_BGM->Play(0,0,2.5F,false); // 음악 시작.. // did 2.5F fade in some realtek or audio chips have crackling at the start
+		}
+		fTmp = 1.0f;
 	}
 
-	fTmp += CN3Base::s_fSecPerFrm;
-	if(fTmp > 191.0f)
-	{
-		fTmp = 0;
-		if (s_pSnd_BGM != nullptr)
-			s_pSnd_BGM->Stop();
-	}
+	// TODO: Remove this code if not needed
+	
+	//static float fTmp = 0;
+	//if (fTmp == 0)
+	//{
+	//	if (s_pSnd_BGM != nullptr)
+	//		s_pSnd_BGM->Play(); // 음악 시작..
+	//}
+
+	//fTmp += CN3Base::s_fSecPerFrm;
+	//if(fTmp > 191.0f)
+	//{
+	//	fTmp = 0;
+	//	if (s_pSnd_BGM != nullptr)
+	//		s_pSnd_BGM->Stop();
+	//}
 }
 
 void CGameProcLogIn_1298::Render()

--- a/Client/WarFare/GameProcLogIn_1298.h
+++ b/Client/WarFare/GameProcLogIn_1298.h
@@ -11,6 +11,7 @@ public:
 	
 	bool			m_bLogIn; // 로그인 중복 방지..
 	std::string		m_szRegistrationSite;
+	float fTmp; // Temp for bgm kicking in // TODO some realistic implementation
 
 public:
 	void	MsgRecv_GameServerGroupList(Packet& pkt);

--- a/Client/WarFare/WarFare.vcxproj
+++ b/Client/WarFare/WarFare.vcxproj
@@ -52,13 +52,13 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
-      <AdditionalIncludeDirectories>.;..;..\..\Server;$(DependencyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Server;$(DependencyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>shared.lib;ws2_32.lib;winmm.lib;imm32.lib;wsock32.lib;DInput8.lib;N3Base_client.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\Server\shared\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>shared.lib;ws2_32.lib;winmm.lib;imm32.lib;wsock32.lib;DInput8.lib;N3Base_client.lib;mpg123.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\Server\shared\$(Configuration);$(DependencyDir)mpg123\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/deps/mpg123/include/fmt123.h
+++ b/deps/mpg123/include/fmt123.h
@@ -1,0 +1,159 @@
+/*
+	libmpg123: MPEG Audio Decoder library
+
+	separate header just for audio format definitions not tied to
+	library code
+
+	copyright 1995-2020 by the mpg123 project
+	free software under the terms of the LGPL 2.1
+	see COPYING and AUTHORS files in distribution or http://mpg123.org
+*/
+
+#ifndef MPG123_ENC_H
+#define MPG123_ENC_H
+
+/** \file fmt123.h Audio format definitions. */
+
+/** \defgroup mpg123_enc mpg123 PCM sample encodings
+ *  These are definitions for audio formats used by libmpg123 and
+ *  libout123.
+ *
+ * @{
+ */
+
+/** An enum over all sample types possibly known to mpg123.
+ *  The values are designed as bit flags to allow bitmasking for encoding
+ *  families.
+ *  This is also why the enum is not used as type for actual encoding variables,
+ *  plain integers (at least 16 bit, 15 bit being used) cover the possible
+ *  combinations of these flags.
+ *
+ *  Note that (your build of) libmpg123 does not necessarily support all these.
+ *  Usually, you can expect the 8bit encodings and signed 16 bit.
+ *  Also 32bit float will be usual beginning with mpg123-1.7.0 .
+ *  What you should bear in mind is that (SSE, etc) optimized routines may be
+ *  absent for some formats. We do have SSE for 16, 32 bit and float, though.
+ *  24 bit integer is done via postprocessing of 32 bit output -- just cutting
+ *  the last byte, no rounding, even. If you want better, do it yourself.
+ *
+ *  All formats are in native byte order. If you need different endinaness, you
+ *  can simply postprocess the output buffers (libmpg123 wouldn't do anything
+ * else). The macro MPG123_SAMPLESIZE() can be helpful there.
+ */
+enum mpg123_enc_enum
+{
+/* 0000 0000 0000 1111 Some 8 bit  integer encoding. */
+	MPG123_ENC_8      = 0x00f
+/* 0000 0000 0100 0000 Some 16 bit integer encoding. */
+,	MPG123_ENC_16     = 0x040
+/* 0100 0000 0000 0000 Some 24 bit integer encoding. */
+,	MPG123_ENC_24     = 0x4000 
+/* 0000 0001 0000 0000 Some 32 bit integer encoding. */
+,	MPG123_ENC_32     = 0x100  
+/* 0000 0000 1000 0000 Some signed integer encoding. */
+,	MPG123_ENC_SIGNED = 0x080  
+/* 0000 1110 0000 0000 Some float encoding. */
+,	MPG123_ENC_FLOAT  = 0xe00  
+/* 0000 0000 1101 0000 signed 16 bit */
+,	MPG123_ENC_SIGNED_16   = (MPG123_ENC_16|MPG123_ENC_SIGNED|0x10)
+/* 0000 0000 0110 0000 unsigned 16 bit */
+,	MPG123_ENC_UNSIGNED_16 = (MPG123_ENC_16|0x20)
+/* 0000 0000 0000 0001 unsigned 8 bit */
+,	MPG123_ENC_UNSIGNED_8  = 0x01
+/* 0000 0000 1000 0010 signed 8 bit */
+,	MPG123_ENC_SIGNED_8    = (MPG123_ENC_SIGNED|0x02)
+/* 0000 0000 0000 0100 ulaw 8 bit */
+,	MPG123_ENC_ULAW_8      = 0x04
+/* 0000 0000 0000 1000 alaw 8 bit */
+,	MPG123_ENC_ALAW_8      = 0x08
+/* 0001 0001 1000 0000 signed 32 bit */
+,	MPG123_ENC_SIGNED_32   = MPG123_ENC_32|MPG123_ENC_SIGNED|0x1000
+/* 0010 0001 0000 0000 unsigned 32 bit */
+,	MPG123_ENC_UNSIGNED_32 = MPG123_ENC_32|0x2000
+/* 0101 0000 1000 0000 signed 24 bit */
+,	MPG123_ENC_SIGNED_24   = MPG123_ENC_24|MPG123_ENC_SIGNED|0x1000
+/* 0110 0000 0000 0000 unsigned 24 bit */
+,	MPG123_ENC_UNSIGNED_24 = MPG123_ENC_24|0x2000
+/* 0000 0010 0000 0000 32bit float */
+,	MPG123_ENC_FLOAT_32    = 0x200
+/* 0000 0100 0000 0000 64bit float */
+,	MPG123_ENC_FLOAT_64    = 0x400
+/* Any possibly known encoding from the list above. */
+,	MPG123_ENC_ANY = ( MPG123_ENC_SIGNED_16  | MPG123_ENC_UNSIGNED_16
+	                 | MPG123_ENC_UNSIGNED_8 | MPG123_ENC_SIGNED_8
+	                 | MPG123_ENC_ULAW_8     | MPG123_ENC_ALAW_8
+	                 | MPG123_ENC_SIGNED_32  | MPG123_ENC_UNSIGNED_32
+	                 | MPG123_ENC_SIGNED_24  | MPG123_ENC_UNSIGNED_24
+	                 | MPG123_ENC_FLOAT_32   | MPG123_ENC_FLOAT_64    )
+};
+
+/** Get size of one PCM sample with given encoding.
+ *  This is included both in libmpg123 and libout123. Both offer
+ *  an API function to provide the macro results from library
+ *  compile-time, not that of you application. This most likely
+ *  does not matter as I do not expect any fresh PCM sample
+ *  encoding to appear. But who knows? Perhaps the encoding type
+ *  will be abused for funny things in future, not even plain PCM.
+ *  And, by the way: Thomas really likes the ?: operator.
+ * \param enc the encoding (mpg123_enc_enum value)
+ * \return size of one sample in bytes
+ */
+#define MPG123_SAMPLESIZE(enc) ( \
+	(enc) < 1 \
+	?	0 \
+	:	( (enc) & MPG123_ENC_8 \
+		?	1 \
+		:	( (enc) & MPG123_ENC_16 \
+			?	2 \
+			:	( (enc) & MPG123_ENC_24 \
+				?	3 \
+				:	( (  (enc) & MPG123_ENC_32 \
+					  || (enc) == MPG123_ENC_FLOAT_32 ) \
+					?	4 \
+					:	( (enc) == MPG123_ENC_FLOAT_64 \
+						?	8 \
+						:	0 \
+)	)	)	)	)	)
+
+/** Representation of zero in differing encodings.
+ *  This exists to define proper silence in various encodings without
+ *  having to link to libsyn123 to do actual conversions at runtime.
+ *  You have to handle big/little endian order yourself, though.
+ *  This takes the shortcut that any signed encoding has a zero with
+ *  all-zero bits. Unsigned linear encodings just have the highest bit set
+ *  (2^(n-1) for n bits), while the nonlinear 8-bit ones are special.
+ *  \param enc the encoding (mpg123_enc_enum value)
+ *  \param siz bytes per sample (return value of MPG123_SAMPLESIZE(enc))
+ *  \param off byte (octet) offset counted from LSB
+ *  \return unsigned byte value for the designated octet
+ */
+#define MPG123_ZEROSAMPLE(enc, siz, off) ( \
+	(enc) == MPG123_ENC_ULAW_8 \
+	?	(off == 0 ? 0xff : 0x00) \
+	:	( (enc) == MPG123_ENC_ALAW_8 \
+		?	(off == 0 ? 0xd5 : 0x00) \
+		:	( (((enc) & (MPG123_ENC_SIGNED|MPG123_ENC_FLOAT)) || (siz) != ((off)+1)) \
+			?	0x00 \
+			:	0x80 \
+	)	)	)
+
+/** Structure defining an audio format.
+ *  Providing the members as individual function arguments to define a certain
+ *  output format is easy enough. This struct makes is more comfortable to deal
+ *  with a list of formats.
+ *  Negative values for the members might be used to communicate use of default
+ *  values.
+ */
+struct mpg123_fmt
+{
+	long rate;    /**< sampling rate in Hz  */
+	int channels; /**< channel count */
+	/** encoding code, can be single value or bitwise or of members of
+	 *  mpg123_enc_enum */
+	int encoding;
+};
+
+/** @} */
+
+#endif
+

--- a/deps/mpg123/include/mpg123.h
+++ b/deps/mpg123/include/mpg123.h
@@ -1,0 +1,2352 @@
+/*
+	libmpg123: MPEG Audio Decoder library
+
+	copyright 1995-2023 by the mpg123 project
+	free software under the terms of the LGPL 2.1
+	see COPYING and AUTHORS files in distribution or http://mpg123.org
+*/
+
+#ifndef MPG123_LIB_H
+#define MPG123_LIB_H
+
+#include "fmt123.h"
+
+/** \file mpg123.h The header file for the libmpg123 MPEG Audio decoder */
+
+/** \defgroup mpg123_h mpg123 header general settings and notes
+ * @{
+ */
+
+/** A macro to check at compile time which set of API functions to expect.
+ * This must be incremented at least each time a new symbol is added
+ * to the header.
+ */
+#define MPG123_API_VERSION 49
+/** library patch level at client build time */
+#define MPG123_PATCHLEVEL  3
+
+#ifndef MPG123_EXPORT
+/** Defines needed for MS Visual Studio(tm) DLL builds.
+ * Every public function must be prefixed with MPG123_EXPORT. When building 
+ * the DLL ensure to define BUILD_MPG123_DLL. This makes the function accessible
+ * for clients and includes it in the import library which is created together
+ * with the DLL. When consuming the DLL ensure to define LINK_MPG123_DLL which
+ * imports the functions from the DLL. 
+ */
+#ifdef BUILD_MPG123_DLL
+/* The dll exports. */
+#define MPG123_EXPORT __declspec(dllexport)
+#else
+#ifdef LINK_MPG123_DLL
+/* The exe imports. */
+#define MPG123_EXPORT __declspec(dllimport)
+#else
+/* Nothing on normal/UNIX builds */
+#define MPG123_EXPORT
+#endif
+#endif
+#endif
+
+/** \page enumapi About enum API
+ *
+ * Earlier versions of libmpg123 put enums into public API calls,
+ * which is not exactly safe. There are ABI rules, but you can use
+ * compiler switches to change the sizes of enums. It is safer not
+ * to have them in API calls. Thus, the default is to remap calls and
+ * structs to variants that use plain ints. Define MPG123_ENUM_API to
+ * prevent that remapping.
+ *
+ * You might want to define this to increase the chance of your binary
+ * working with an older version of the library. But if that is your goal,
+ * you should better build with an older version to begin with.
+ *
+ * You can avoid renamed symbols by using the non-enum names directly:
+ *
+ * - mpg123_param2()
+ * - mpg123_getparam2()
+ * - mpg123_feature2()
+ * - mpg123_eq2()
+ * - mpg123_geteq2()
+ * - mpg123_frameinfo2()
+ * - mpg123_info2()
+ * - mpg123_getstate2()
+ * - mpg123_enc_from_id3_2()
+ * - mpg123_store_utf8_2()
+ * - mpg123_par2()
+ * - mpg123_getpar2()
+ */
+#ifndef MPG123_ENUM_API
+
+#define mpg123_param        mpg123_param2
+#define mpg123_getparam     mpg123_getparam2
+#define mpg123_feature      mpg123_feature2
+#define mpg123_eq           mpg123_eq2
+#define mpg123_geteq        mpg123_geteq2
+#define mpg123_frameinfo    mpg123_frameinfo2
+#define mpg123_info         mpg123_info2
+#define mpg123_getstate     mpg123_getstate2
+#define mpg123_enc_from_id3 mpg123_enc_from_id3_2
+#define mpg123_store_utf8   mpg123_store_utf8_2
+#define mpg123_par          mpg123_par2
+#define mpg123_getpar       mpg123_getpar2
+
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef MPG123_PORTABLE_API
+#include <sys/types.h>
+/** A little hack to help MSVC not having ssize_t. */
+#ifdef _MSC_VER
+typedef ptrdiff_t mpg123_ssize_t;
+#else
+typedef ssize_t mpg123_ssize_t;
+#endif
+#endif
+
+
+/** \page lfs Handling of large file offsets
+ *
+ * When client code defines _FILE_OFFSET_BITS, it wants non-default large file
+ * support, and thus functions with added suffix (mpg123_open_64). The default
+ * library build provides wrapper and alias functions to accomodate client code
+ * variations (dual-mode library like glibc).
+ *
+ * Client code can definie MPG123_NO_LARGENAME and MPG123_LARGESUFFIX,
+ * respectively, for disabling or enforcing the suffixes. You should *not* do
+ * this, though, unless you *really* want to deal with symbol ABI yourself.
+ * If explicit usage of 64 bit offsets is desired, the int64_t API
+ * consisting of functions with 64 suffix without underscore, notably
+ * mpg123_reader64(), can be used since API version 48 (mpg123 1.32). A matching
+ * mpg123_open64(), stripped-down mpg123_open_handle_64() is present since API
+ * version 49 (mpg123 1.33). 
+ *
+ * When in doubt, use the explicit 64 bit functions and avoid off_t in the API.
+ * You can define MPG123_PORTABLE_API to ensure that. That being said, if you
+ * and your compiler do not have problems with the	concept of off_t, just use
+ * the normal AP like the I/O API of the standard C library. Both 32 and 64 bit
+ * versions of functions will be present where appropriate.
+ *
+ * If your toolchain enforces _FILE_OFFSET_BITS also during build of libmpg123,
+ * only that setting will be supported for client code.
+ */
+
+#ifndef MPG123_PORTABLE_API
+/** \page lfs_names Renaming of functions for largefile support
+ *
+ * Now, the renaming of large file aware functions.
+ * By default, it appends underscore _FILE_OFFSET_BITS (so, mpg123_seek_64() for mpg123_seek()),
+ * if _FILE_OFFSET_BITS is defined. These are the affected API functions:
+ *
+ * - mpg123_open_fixed()
+ * - mpg123_open()
+ * - mpg123_open_fd()
+ * - mpg123_open_handle()
+ * - mpg123_framebyframe_decode()
+ * - mpg123_decode_frame()
+ * - mpg123_tell()
+ * - mpg123_tellframe()
+ * - mpg123_tell_stream()
+ * - mpg123_seek()
+ * - mpg123_feedseek()
+ * - mpg123_seek_frame()
+ * - mpg123_timeframe()
+ * - mpg123_index()
+ * - mpg123_set_index()
+ * - mpg123_position()
+ * - mpg123_length()
+ * - mpg123_framelength()
+ * - mpg123_set_filesize()
+ * - mpg123_replace_reader()
+ * - mpg123_replace_reader_handle()
+ * - mpg123_framepos()
+*/
+#if (!defined MPG123_NO_LARGENAME) && ((defined _FILE_OFFSET_BITS) || (defined MPG123_LARGESUFFIX))
+
+/* Need some trickery to concatenate the value(s) of the given macro(s). */
+#define MPG123_MACROCAT_REALLY(a, b) a ## b
+#define MPG123_MACROCAT(a, b) MPG123_MACROCAT_REALLY(a, b)
+#ifndef MPG123_LARGESUFFIX
+#define MPG123_LARGESUFFIX MPG123_MACROCAT(_, _FILE_OFFSET_BITS)
+#endif
+#define MPG123_LARGENAME(func) MPG123_MACROCAT(func, MPG123_LARGESUFFIX)
+
+#define mpg123_open_fixed   MPG123_LARGENAME(mpg123_open_fixed)
+#define mpg123_open         MPG123_LARGENAME(mpg123_open)
+#define mpg123_open_fd      MPG123_LARGENAME(mpg123_open_fd)
+#define mpg123_open_handle  MPG123_LARGENAME(mpg123_open_handle)
+#define mpg123_framebyframe_decode MPG123_LARGENAME(mpg123_framebyframe_decode)
+#define mpg123_decode_frame MPG123_LARGENAME(mpg123_decode_frame)
+#define mpg123_tell         MPG123_LARGENAME(mpg123_tell)
+#define mpg123_tellframe    MPG123_LARGENAME(mpg123_tellframe)
+#define mpg123_tell_stream  MPG123_LARGENAME(mpg123_tell_stream)
+#define mpg123_seek         MPG123_LARGENAME(mpg123_seek)
+#define mpg123_feedseek     MPG123_LARGENAME(mpg123_feedseek)
+#define mpg123_seek_frame   MPG123_LARGENAME(mpg123_seek_frame)
+#define mpg123_timeframe    MPG123_LARGENAME(mpg123_timeframe)
+#define mpg123_index        MPG123_LARGENAME(mpg123_index)
+#define mpg123_set_index    MPG123_LARGENAME(mpg123_set_index)
+#define mpg123_position     MPG123_LARGENAME(mpg123_position)
+#define mpg123_length       MPG123_LARGENAME(mpg123_length)
+#define mpg123_framelength  MPG123_LARGENAME(mpg123_framelength)
+#define mpg123_set_filesize MPG123_LARGENAME(mpg123_set_filesize)
+#define mpg123_replace_reader MPG123_LARGENAME(mpg123_replace_reader)
+#define mpg123_replace_reader_handle MPG123_LARGENAME(mpg123_replace_reader_handle)
+#define mpg123_framepos MPG123_LARGENAME(mpg123_framepos)
+
+#endif /* largefile hackery */
+#endif
+
+/** @} */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \defgroup mpg123_init mpg123 library and handle setup
+ *
+ * Functions to initialise and shutdown the mpg123 library and handles.
+ * The parameters of handles have workable defaults, you only have to tune them when you want to tune something;-)
+ * Tip: Use a RVA setting...
+ *
+ * @{
+ */
+
+/** Opaque structure for the libmpg123 decoder handle. */
+struct mpg123_handle_struct;
+
+/** Opaque structure for the libmpg123 decoder handle.
+ *  Most functions take a pointer to a mpg123_handle as first argument and operate on its data in an object-oriented manner.
+ */
+typedef struct mpg123_handle_struct mpg123_handle;
+
+/** Get version of the mpg123 distribution this library build came with.
+ * (optional means non-NULL)
+ * \param major optional address to store major version number
+ * \param minor optional address to store minor version number
+ * \param patch optional address to store patchlevel version number
+ * \return full version string (like "1.2.3-beta4 (experimental)")
+ */
+const char *mpg123_distversion(unsigned int *major, unsigned int *minor, unsigned int *patch);
+
+/** Get API version of library build.
+ * \param patch optional address to store patchlevel
+ * \return API version of library
+ */
+unsigned int mpg123_libversion(unsigned int *patch);
+
+/** Useless no-op that used to do initialization work.
+ *
+ * For API version before 46 (mpg123 1.27.0), you had to ensure to have
+ * this called once before creating a handle. To be pure, this had to
+ * happen in a single-threaded context, too (while in practice, there was no
+ * harm done possibly racing to compute the same numbers again).
+ *
+ * Now this function really does nothing anymore. The only reason to call
+ * it is to be compatible with old versions of the library that still require
+ * it.
+ *
+ *	\return MPG123_OK if successful, otherwise an error number.
+ */
+MPG123_EXPORT int mpg123_init(void);
+
+/** Superfluous Function to close down the mpg123 library.
+ * This was created with the thought that there sometime will be cleanup code
+ * to be run after library use. This never materialized. You can forget about
+ * this function and it is only here for old programs that do call it.
+ */
+MPG123_EXPORT void mpg123_exit(void);
+
+/** Create a handle with optional choice of decoder (named by a string, see mpg123_decoders() or mpg123_supported_decoders()).
+ *  and optional retrieval of an error code to feed to mpg123_plain_strerror().
+ *  Optional means: Any of or both the parameters may be NULL.
+ *
+ *  \param decoder optional choice of decoder variant (NULL for default)
+ *  \param error optional address to store error codes
+ *  \return Non-NULL pointer to fresh handle when successful.
+ */
+MPG123_EXPORT mpg123_handle *mpg123_new(const char* decoder, int *error);
+
+/** Delete handle, mh is either a valid mpg123 handle or NULL.
+ *  \param mh handle
+ */
+MPG123_EXPORT void mpg123_delete(mpg123_handle *mh);
+
+/** Free plain memory allocated within libmpg123.
+ *  This is for library users that are not sure to use the same underlying
+ *  memory allocator as libmpg123. It is just a wrapper over free() in
+ *  the underlying C library.
+ */
+MPG123_EXPORT void mpg123_free(void *ptr);
+
+/** Enumeration of the parameters types that it is possible to set/get. */
+enum mpg123_parms
+{
+	MPG123_VERBOSE = 0,        /**< set verbosity value for enabling messages to stderr, >= 0 makes sense (integer) */
+	MPG123_FLAGS,          /**< set all flags, p.ex val = MPG123_GAPLESS|MPG123_MONO_MIX (integer) */
+	MPG123_ADD_FLAGS,      /**< add some flags (integer) */
+	MPG123_FORCE_RATE,     /**< when value > 0, force output rate to that value (integer) */
+	MPG123_DOWN_SAMPLE,    /**< 0=native rate, 1=half rate, 2=quarter rate (integer) */
+	MPG123_RVA,            /**< one of the RVA choices above (integer) */
+	MPG123_DOWNSPEED,      /**< play a frame N times (integer) */
+	MPG123_UPSPEED,        /**< play every Nth frame (integer) */
+	MPG123_START_FRAME,    /**< start with this frame (skip frames before that, integer) */ 
+	MPG123_DECODE_FRAMES,  /**< decode only this number of frames (integer) */
+	MPG123_ICY_INTERVAL,   /**< Stream contains ICY metadata with this interval (integer).
+	                            Make sure to set this _before_ opening a stream.*/
+	MPG123_OUTSCALE,       /**< the scale for output samples (amplitude - integer or float according to mpg123 output format, normally integer) */
+	MPG123_TIMEOUT,        /**< timeout for reading from a stream (not supported on win32, integer) */
+	MPG123_REMOVE_FLAGS,   /**< remove some flags (inverse of MPG123_ADD_FLAGS, integer) */
+	MPG123_RESYNC_LIMIT,   /**< Try resync on frame parsing for that many bytes or until end of stream (<0 ... integer). This can enlarge the limit for skipping junk on beginning, too (but not reduce it).  */
+	MPG123_INDEX_SIZE      /**< Set the frame index size (if supported). Values <0 mean that the index is allowed to grow dynamically in these steps (in positive direction, of course) -- Use this when you really want a full index with every individual frame. */
+	,MPG123_PREFRAMES /**< Decode/ignore that many frames in advance for layer 3. This is needed to fill bit reservoir after seeking, for example (but also at least one frame in advance is needed to have all "normal" data for layer 3). Give a positive integer value, please.*/
+	,MPG123_FEEDPOOL  /**< For feeder mode, keep that many buffers in a pool to avoid frequent malloc/free. The pool is allocated on mpg123_open_feed(). If you change this parameter afterwards, you can trigger growth and shrinkage during decoding. The default value could change any time. If you care about this, then set it. (integer) */
+	,MPG123_FEEDBUFFER /**< Minimal size of one internal feeder buffer, again, the default value is subject to change. (integer) */
+	,MPG123_FREEFORMAT_SIZE /**< Tell the parser a free-format frame size to
+	 * avoid read-ahead to get it. A value of -1 (default) means that the parser
+	 * will determine it. The parameter value is applied during decoder setup
+	 * for a freshly opened stream only.
+	 */
+};
+
+/** Flag bits for MPG123_FLAGS, use the usual binary or to combine. */
+enum mpg123_param_flags
+{
+	 MPG123_FORCE_MONO   = 0x7  /**<     0111 Force some mono mode: This is a test bitmask for seeing if any mono forcing is active. */
+	,MPG123_MONO_LEFT    = 0x1  /**<     0001 Force playback of left channel only.  */
+	,MPG123_MONO_RIGHT   = 0x2  /**<     0010 Force playback of right channel only. */
+	,MPG123_MONO_MIX     = 0x4  /**<     0100 Force playback of mixed mono.         */
+	,MPG123_FORCE_STEREO = 0x8  /**<     1000 Force stereo output.                  */
+	,MPG123_FORCE_8BIT   = 0x10 /**< 00010000 Force 8bit formats.                   */
+	,MPG123_QUIET        = 0x20 /**< 00100000 Suppress any printouts (overrules verbose).                    */
+	,MPG123_GAPLESS      = 0x40 /**< 01000000 Enable gapless decoding (default on if libmpg123 has support). */
+	,MPG123_NO_RESYNC    = 0x80 /**< 10000000 Disable resync stream after error.                             */
+	,MPG123_SEEKBUFFER   = 0x100 /**< 000100000000 Enable small buffer on non-seekable streams to allow some peek-ahead (for better MPEG sync). */
+	,MPG123_FUZZY        = 0x200 /**< 001000000000 Enable fuzzy seeks (guessing byte offsets or using approximate seek points from Xing TOC) */
+	,MPG123_FORCE_FLOAT  = 0x400 /**< 010000000000 Force floating point output (32 or 64 bits depends on mpg123 internal precision). */
+	,MPG123_PLAIN_ID3TEXT = 0x800 /**< 100000000000 Do not translate ID3 text data to UTF-8. ID3 strings will contain the raw text data, with the first byte containing the ID3 encoding code. */
+	,MPG123_IGNORE_STREAMLENGTH = 0x1000 /**< 1000000000000 Ignore any stream length information contained in the stream, which can be contained in a 'TLEN' frame of an ID3v2 tag or a Xing tag */
+	,MPG123_SKIP_ID3V2 = 0x2000 /**< 10 0000 0000 0000 Do not parse ID3v2 tags, just skip them. */
+	,MPG123_IGNORE_INFOFRAME = 0x4000 /**< 100 0000 0000 0000 Do not parse the LAME/Xing info frame, treat it as normal MPEG data. */
+	,MPG123_AUTO_RESAMPLE = 0x8000 /**< 1000 0000 0000 0000 Allow automatic internal resampling of any kind (default on if supported). Especially when going lowlevel with replacing output buffer, you might want to unset this flag. Setting MPG123_DOWNSAMPLE or MPG123_FORCE_RATE will override this. */
+	,MPG123_PICTURE = 0x10000 /**< 17th bit: Enable storage of pictures from tags (ID3v2 APIC). */
+	,MPG123_NO_PEEK_END    = 0x20000 /**< 18th bit: Do not seek to the end of
+	 *  the stream in order to probe
+	 *  the stream length and search for the id3v1 field. This also means
+	 *  the file size is unknown unless set using mpg123_set_filesize() and
+	 *  the stream is assumed as non-seekable unless overridden.
+	 */
+	,MPG123_FORCE_SEEKABLE = 0x40000 /**< 19th bit: Force the stream to be seekable. */
+	,MPG123_STORE_RAW_ID3  = 0x80000 /**< store raw ID3 data (even if skipping) */
+	,MPG123_FORCE_ENDIAN   = 0x100000 /**< Enforce endianess of output samples.
+	 *  This is not reflected in the format codes. If this flag is set along with
+	 *  MPG123_BIG_ENDIAN, MPG123_ENC_SIGNED16 means s16be, without
+	 *  MPG123_BIG_ENDIAN, it means s16le. Normal operation without
+	 *  MPG123_FORCE_ENDIAN produces output in native byte order.
+	 */
+	,MPG123_BIG_ENDIAN     = 0x200000 /**< Choose big endian instead of little. */
+	,MPG123_NO_READAHEAD   = 0x400000 /**< Disable read-ahead in parser. If
+	 * you know you provide full frames to the feeder API, this enables
+	 * decoder output from the first one on, instead of having to wait for
+	 * the next frame to confirm that the stream is healthy. It also disables
+	 * free format support unless you provide a frame size using
+	 * MPG123_FREEFORMAT_SIZE.
+	 */
+	,MPG123_FLOAT_FALLBACK = 0x800000 /**< Consider floating point output encoding only after
+	 * trying other (possibly downsampled) rates and encodings first. This is to
+	 * support efficient playback where floating point output is only configured for
+	 * an external resampler, bypassing that resampler when the desired rate can
+	 * be produced directly. This is enabled by default to be closer to older versions
+	 * of libmpg123 which did not enable float automatically at all. If disabled,
+	 * float is considered after the 16 bit default and higher-bit integer encodings
+	 * for any rate. */
+	,MPG123_NO_FRANKENSTEIN = 0x1000000 /**< Disable support for Frankenstein streams
+	 * (different MPEG streams stiched together). Do not accept serious change of MPEG
+	 * header inside a single stream. With this flag, the audio output format cannot
+	 * change during decoding unless you open a new stream. This also stops decoding
+	 * after an announced end of stream (Info header contained a number of frames
+	 * and this number has been reached). This makes your MP3 files behave more like
+	 * ordinary media files with defined structure, rather than stream dumps with
+	 * some sugar. */
+};
+
+/** choices for MPG123_RVA */
+enum mpg123_param_rva
+{
+	 MPG123_RVA_OFF   = 0 /**< RVA disabled (default).   */
+	,MPG123_RVA_MIX   = 1 /**< Use mix/track/radio gain. */
+	,MPG123_RVA_ALBUM = 2 /**< Use album/audiophile gain */
+	,MPG123_RVA_MAX   = MPG123_RVA_ALBUM /**< The maximum RVA code, may increase in future. */
+};
+
+#ifdef MPG123_ENUM_API
+/** Set a specific parameter on a handle.
+ *
+ *  Note that this name is mapped to mpg123_param2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  \param mh handle
+ *  \param type parameter choice
+ *  \param value integer value
+ *  \param fvalue floating point value
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_param( mpg123_handle *mh
+,	enum mpg123_parms type, long value, double fvalue );
+#endif
+
+/** Set a specific parameter on a handle. No enums.
+ *
+ *  This is actually called instead of mpg123_param()
+ *  unless MPG123_ENUM_API is defined.
+ *
+ *  \param mh handle
+ *  \param type parameter choice (from enum #mpg123_parms)
+ *  \param value integer value
+ *  \param fvalue floating point value
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_param2( mpg123_handle *mh
+,	int type, long value, double fvalue );
+
+#ifdef MPG123_ENUM_API
+/** Get a specific parameter from a handle.
+ *
+ *  Note that this name is mapped to mpg123_getparam2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  \param mh handle
+ *  \param type parameter choice
+ *  \param value integer value return address
+ *  \param fvalue floating point value return address
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_getparam( mpg123_handle *mh
+,	enum mpg123_parms type, long *value, double *fvalue );
+#endif
+
+/** Get a specific parameter from a handle. No enums.
+ *
+ *  This is actually called instead of mpg123_getparam() unless MPG123_ENUM_API
+ *  is defined.
+ *
+ *  \param mh handle
+ *  \param type parameter choice (from enum #mpg123_parms)
+ *  \param value integer value return address
+ *  \param fvalue floating point value return address
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_getparam2( mpg123_handle *mh
+,	int type, long *value, double *fvalue );
+
+/** Feature set available for query with mpg123_feature. */
+enum mpg123_feature_set
+{
+	 MPG123_FEATURE_ABI_UTF8OPEN = 0     /**< mpg123 expects path names to be given in UTF-8 encoding instead of plain native. */
+	,MPG123_FEATURE_OUTPUT_8BIT          /**< 8bit output   */
+	,MPG123_FEATURE_OUTPUT_16BIT         /**< 16bit output  */
+	,MPG123_FEATURE_OUTPUT_32BIT         /**< 32bit output  */
+	,MPG123_FEATURE_INDEX                /**< support for building a frame index for accurate seeking */
+	,MPG123_FEATURE_PARSE_ID3V2          /**< id3v2 parsing */
+	,MPG123_FEATURE_DECODE_LAYER1        /**< mpeg layer-1 decoder enabled */
+	,MPG123_FEATURE_DECODE_LAYER2        /**< mpeg layer-2 decoder enabled */
+	,MPG123_FEATURE_DECODE_LAYER3        /**< mpeg layer-3 decoder enabled */
+	,MPG123_FEATURE_DECODE_ACCURATE      /**< accurate decoder rounding    */
+	,MPG123_FEATURE_DECODE_DOWNSAMPLE    /**< downsample (sample omit)     */
+	,MPG123_FEATURE_DECODE_NTOM          /**< flexible rate decoding       */
+	,MPG123_FEATURE_PARSE_ICY            /**< ICY support                  */
+	,MPG123_FEATURE_TIMEOUT_READ         /**< Reader with timeout (network). */
+	,MPG123_FEATURE_EQUALIZER            /**< tunable equalizer */
+	,MPG123_FEATURE_MOREINFO             /**< more info extraction (for frame analyzer) */
+	,MPG123_FEATURE_OUTPUT_FLOAT32      /**< 32 bit float output */
+	,MPG123_FEATURE_OUTPUT_FLOAT64      /**< 64 bit float output (as of now: never!) */
+};
+
+#ifdef MPG123_ENUM_API
+/** Query libmpg123 features.
+ *
+ *  Note that this name is mapped to mpg123_feature2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  \param key feature selection
+ *  \return 1 for success, 0 for unimplemented functions
+ */
+MPG123_EXPORT int mpg123_feature(const enum mpg123_feature_set key);
+#endif
+
+/** Query libmpg123 features. No enums.
+ *
+ *  This is actually called instead of mpg123_feature() unless MPG123_ENUM_API
+ *  is defined.
+ *
+ *  \param key feature selection (from enum #mpg123_feature_set)
+ *  \return 1 for success, 0 for unimplemented functions
+ */
+MPG123_EXPORT int mpg123_feature2(int key);
+
+/** @} */
+
+
+/** \defgroup mpg123_error mpg123 error handling
+ *
+ * Functions to get text version of the error numbers and an enumeration
+ * of the error codes returned by libmpg123.
+ *
+ * Most functions operating on a mpg123_handle simply return MPG123_OK (0)
+ * on success and MPG123_ERR (-1) on failure, setting the internal error
+ * variable of the handle to the specific error code. If there was not a valid
+ * (non-NULL) handle provided to a function operating on one, MPG123_BAD_HANDLE
+ * may be returned if this can not be confused with a valid positive return
+ * value.
+ * Meaning: A function expected to return positive integers on success will
+ * always indicate error or a special condition by returning a negative one.
+ *
+ * Decoding/seek functions may also return message codes MPG123_DONE,
+ * MPG123_NEW_FORMAT and MPG123_NEED_MORE (all negative, see below on how to
+ * react). Note that calls to those can be nested, so generally watch out
+ * for these codes after initial handle setup.
+ * Especially any function that needs information about the current stream
+ * to work will try to at least parse the beginning if that did not happen
+ * yet.
+ *
+ * On a function that is supposed to return MPG123_OK on success and
+ * MPG123_ERR on failure, make sure you check for != MPG123_OK, not
+ * == MPG123_ERR, as the error code could get more specific in future,
+ * or there is just a special message from a decoding routine as indicated
+ * above.
+ *
+ * @{
+ */
+
+/** Enumeration of the message and error codes and returned by libmpg123 functions. */
+enum mpg123_errors
+{
+	MPG123_DONE=-12,	/**< Message: Track ended. Stop decoding. */
+	MPG123_NEW_FORMAT=-11,	/**< Message: Output format will be different on next call. Note that some libmpg123 versions between 1.4.3 and 1.8.0 insist on you calling mpg123_getformat() after getting this message code. Newer verisons behave like advertised: You have the chance to call mpg123_getformat(), but you can also just continue decoding and get your data. */
+	MPG123_NEED_MORE=-10,	/**< Message: For feed reader: "Feed me more!" (call mpg123_feed() or mpg123_decode() with some new input data). */
+	MPG123_ERR=-1,			/**< Generic Error */
+	MPG123_OK=0, 			/**< Success */
+	MPG123_BAD_OUTFORMAT, 	/**< Unable to set up output format! */
+	MPG123_BAD_CHANNEL,		/**< Invalid channel number specified. */
+	MPG123_BAD_RATE,		/**< Invalid sample rate specified.  */
+	MPG123_ERR_16TO8TABLE,	/**< Unable to allocate memory for 16 to 8 converter table! */
+	MPG123_BAD_PARAM,		/**< Bad parameter id! */
+	MPG123_BAD_BUFFER,		/**< Bad buffer given -- invalid pointer or too small size. */
+	MPG123_OUT_OF_MEM,		/**< Out of memory -- some malloc() failed. */
+	MPG123_NOT_INITIALIZED,	/**< You didn't initialize the library! */
+	MPG123_BAD_DECODER,		/**< Invalid decoder choice. */
+	MPG123_BAD_HANDLE,		/**< Invalid mpg123 handle. */
+	MPG123_NO_BUFFERS,		/**< Unable to initialize frame buffers (out of memory?). */
+	MPG123_BAD_RVA,			/**< Invalid RVA mode. */
+	MPG123_NO_GAPLESS,		/**< This build doesn't support gapless decoding. */
+	MPG123_NO_SPACE,		/**< Not enough buffer space. */
+	MPG123_BAD_TYPES,		/**< Incompatible numeric data types. */
+	MPG123_BAD_BAND,		/**< Bad equalizer band. */
+	MPG123_ERR_NULL,		/**< Null pointer given where valid storage address needed. */
+	MPG123_ERR_READER,		/**< Error reading the stream. */
+	MPG123_NO_SEEK_FROM_END,/**< Cannot seek from end (end is not known). */
+	MPG123_BAD_WHENCE,		/**< Invalid 'whence' for seek function.*/
+	MPG123_NO_TIMEOUT,		/**< Build does not support stream timeouts. */
+	MPG123_BAD_FILE,		/**< File access error. */
+	MPG123_NO_SEEK,			/**< Seek not supported by stream. */
+	MPG123_NO_READER,		/**< No stream opened or no reader callback setup. */
+	MPG123_BAD_PARS,		/**< Bad parameter handle. */
+	MPG123_BAD_INDEX_PAR,	/**< Bad parameters to mpg123_index() and mpg123_set_index() */
+	MPG123_OUT_OF_SYNC,	/**< Lost track in bytestream and did not try to resync. */
+	MPG123_RESYNC_FAIL,	/**< Resync failed to find valid MPEG data. */
+	MPG123_NO_8BIT,	/**< No 8bit encoding possible. */
+	MPG123_BAD_ALIGN,	/**< Stack aligmnent error */
+	MPG123_NULL_BUFFER,	/**< NULL input buffer with non-zero size... */
+	MPG123_NO_RELSEEK,	/**< Relative seek not possible (screwed up file offset) */
+	MPG123_NULL_POINTER, /**< You gave a null pointer somewhere where you shouldn't have. */
+	MPG123_BAD_KEY,	/**< Bad key value given. */
+	MPG123_NO_INDEX,	/**< No frame index in this build. */
+	MPG123_INDEX_FAIL,	/**< Something with frame index went wrong. */
+	MPG123_BAD_DECODER_SETUP,	/**< Something prevents a proper decoder setup */
+	MPG123_MISSING_FEATURE  /**< This feature has not been built into libmpg123. */
+	,MPG123_BAD_VALUE /**< A bad value has been given, somewhere. */
+	,MPG123_LSEEK_FAILED /**< Low-level seek failed. */
+	,MPG123_BAD_CUSTOM_IO /**< Custom I/O not prepared. */
+	,MPG123_LFS_OVERFLOW /**< Offset value overflow during translation of large file API calls -- your client program cannot handle that large file. */
+	,MPG123_INT_OVERFLOW /**< Some integer overflow. */
+	,MPG123_BAD_FLOAT /**< Floating-point computations work not as expected. */
+};
+
+/** Look up error strings given integer code.
+ *  \param errcode integer error code
+ *  \return string describing what that error error code means
+ */
+MPG123_EXPORT const char* mpg123_plain_strerror(int errcode);
+
+/** Give string describing what error has occured in the context of handle mh.
+ *  When a function operating on an mpg123 handle returns MPG123_ERR, you should check for the actual reason via
+ *  char *errmsg = mpg123_strerror(mh)
+ *  This function will catch mh == NULL and return the message for MPG123_BAD_HANDLE.
+ *  \param mh handle
+ *  \return error message
+ */
+MPG123_EXPORT const char* mpg123_strerror(mpg123_handle *mh);
+
+/** Return the plain errcode intead of a string.
+ *  \param mh handle
+ *  \return error code recorded in handle or MPG123_BAD_HANDLE
+ */
+MPG123_EXPORT int mpg123_errcode(mpg123_handle *mh);
+
+/** @} */
+
+
+/** \defgroup mpg123_decoder mpg123 decoder selection
+ *
+ * Functions to list and select the available decoders.
+ * Perhaps the most prominent feature of mpg123: You have several (optimized) decoders to choose from (on x86 and PPC (MacOS) systems, that is).
+ *
+ * @{
+ */
+
+/** Get available decoder list.
+ *  \return NULL-terminated array of generally available decoder names (plain 8bit ASCII)
+ */
+MPG123_EXPORT const char **mpg123_decoders(void);
+
+/** Get supported decoder list.
+ *
+ * This possibly writes to static storage in the library, so avoid
+ * calling concurrently, please.
+ *
+ *  \return NULL-terminated array of the decoders supported by the CPU (plain 8bit ASCII)
+ */
+MPG123_EXPORT const char **mpg123_supported_decoders(void);
+
+/** Set the active decoder.
+ *  \param mh handle
+ *  \param decoder_name name of decoder
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_decoder(mpg123_handle *mh, const char* decoder_name);
+
+/** Get the currently active decoder name.
+ *  The active decoder engine can vary depening on output constraints,
+ *  mostly non-resampling, integer output is accelerated via 3DNow & Co. but for
+ *  other modes a fallback engine kicks in.
+ *  Note that this can return a decoder that is only active in the hidden and not
+ *  available as decoder choice from the outside.
+ *  \param mh handle
+ *  \return The decoder name or NULL on error.
+ */
+MPG123_EXPORT const char* mpg123_current_decoder(mpg123_handle *mh);
+
+/** @} */
+
+
+/** \defgroup mpg123_output mpg123 output audio format 
+ *
+ * Functions to get and select the format of the decoded audio.
+ *
+ * Before you dive in, please be warned that you might get confused by this.
+ * This seems to happen a lot, therefore I am trying to explain in advance.
+ * If you do feel confused and just want to decode your normal MPEG audio files that
+ * don't alter properties in the middle, just use mpg123_open_fixed() with a fixed encoding
+ * and channel count and forget about a matrix of audio formats. If you want to get funky,
+ * read ahead ...
+ *
+ * The mpg123 library decides what output format to use when encountering the first frame in a stream, or actually any frame that is still valid but differs from the frames before in the prompted output format. At such a deciding point, an internal table of allowed encodings, sampling rates and channel setups is consulted. According to this table, an output format is chosen and the decoding engine set up accordingly (including optimized routines for different output formats). This might seem unusual but it just follows from the non-existence of "MPEG audio files" with defined overall properties. There are streams, streams are concatenations of (semi) independent frames. We store streams on disk and call them "MPEG audio files", but that does not change their nature as the decoder is concerned (the LAME/Xing header for gapless decoding makes things interesting again).
+ *
+ * To get to the point: What you do with mpg123_format() and friends is to fill the internal table of allowed formats before it is used. That includes removing support for some formats or adding your forced sample rate (see MPG123_FORCE_RATE) that will be used with the crude internal resampler. Also keep in mind that the sample encoding is just a question of choice -- the MPEG frames do only indicate their native sampling rate and channel count. If you want to decode to integer or float samples, 8 or 16 bit ... that is your decision. In a "clean" world, libmpg123 would always decode to 32 bit float and let you handle any sample conversion. But there are optimized routines that work faster by directly decoding to the desired encoding / accuracy. We prefer efficiency over conceptual tidyness.
+ *
+ * People often start out thinking that mpg123_format() should change the actual decoding format on the fly. That is wrong. It only has effect on the next natural change of output format, when libmpg123 will consult its format table again. To make life easier, you might want to call mpg123_format_none() before any thing else and then just allow one desired encoding and a limited set of sample rates / channel choices that you actually intend to deal with. You can force libmpg123 to decode everything to 44100 KHz, stereo, 16 bit integer ... it will duplicate mono channels and even do resampling if needed (unless that feature is disabled in the build, same with some encodings). But I have to stress that the resampling of libmpg123 is very crude and doesn't even contain any kind of "proper" interpolation.
+ *
+ * In any case, watch out for MPG123_NEW_FORMAT as return message from decoding routines and call mpg123_getformat() to get the currently active output format.
+ *
+ * @{
+ */
+
+/** They can be combined into one number (3) to indicate mono and stereo... */
+enum mpg123_channelcount
+{
+	 MPG123_MONO   = 1 /**< mono */
+	,MPG123_STEREO = 2 /**< stereo */
+};
+
+/** An array of supported standard sample rates
+ *  These are possible native sample rates of MPEG audio files.
+ *  You can still force mpg123 to resample to a different one, but by
+ *  default you will only get audio in one of these samplings.
+ *  This list is in ascending order.
+ *  \param list Store a pointer to the sample rates array there.
+ *  \param number Store the number of sample rates there. */
+MPG123_EXPORT void mpg123_rates(const long **list, size_t *number);
+
+/** An array of supported audio encodings.
+ *  An audio encoding is one of the fully qualified members of mpg123_enc_enum (MPG123_ENC_SIGNED_16, not MPG123_SIGNED).
+ *  \param list Store a pointer to the encodings array there.
+ *  \param number Store the number of encodings there. */
+MPG123_EXPORT void mpg123_encodings(const int **list, size_t *number);
+
+/** Return the size (in bytes) of one mono sample of the named encoding.
+ * \param encoding The encoding value to analyze.
+ * \return positive size of encoding in bytes, 0 on invalid encoding. */
+MPG123_EXPORT int mpg123_encsize(int encoding);
+
+/** Configure a mpg123 handle to accept no output format at all, 
+ *  use before specifying supported formats with mpg123_format
+ *  \param mh handle
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_format_none(mpg123_handle *mh);
+
+/** Configure mpg123 handle to accept all formats 
+ *  (also any custom rate you may set) -- this is default.
+ *  \param mh handle
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_format_all(mpg123_handle *mh);
+
+/** Set the audio format support of a mpg123_handle in detail:
+ *  \param mh handle
+ *  \param rate The sample rate value (in Hertz).
+ *  \param channels A combination of MPG123_STEREO and MPG123_MONO.
+ *  \param encodings A combination of accepted encodings for rate and channels, p.ex MPG123_ENC_SIGNED16 | MPG123_ENC_ULAW_8 (or 0 for no support). Please note that some encodings may not be supported in the library build and thus will be ignored here.
+ *  \return MPG123_OK on success, MPG123_ERR if there was an error. */
+MPG123_EXPORT int mpg123_format( mpg123_handle *mh
+,	long rate, int channels, int encodings );
+
+/** Set the audio format support of a mpg123_handle in detail:
+ *  \param mh handle
+ *  \param rate The sample rate value (in Hertz). Special value 0 means
+ *     all rates (the reason for this variant of mpg123_format()).
+ *  \param channels A combination of MPG123_STEREO and MPG123_MONO.
+ *  \param encodings A combination of accepted encodings for rate and channels,
+ *     p.ex MPG123_ENC_SIGNED16 | MPG123_ENC_ULAW_8 (or 0 for no support).
+ *     Please note that some encodings may not be supported in the library build
+ *     and thus will be ignored here.
+ *  \return MPG123_OK on success, MPG123_ERR if there was an error. */
+MPG123_EXPORT int mpg123_format2( mpg123_handle *mh
+,	long rate, int channels, int encodings );
+
+/** Check to see if a specific format at a specific rate is supported 
+ *  by mpg123_handle.
+ *  \param mh handle
+ *  \param rate sampling rate
+ *  \param encoding encoding
+ *  \return 0 for no support (that includes invalid parameters), MPG123_STEREO, 
+ *          MPG123_MONO or MPG123_STEREO|MPG123_MONO. */
+MPG123_EXPORT int mpg123_format_support( mpg123_handle *mh
+,	long rate, int encoding );
+
+/** Get the current output format written to the addresses given.
+ *  If the stream is freshly loaded, this will try to parse enough
+ *  of it to give you the format to come. This clears the flag that
+ *  would otherwise make the first decoding call return
+ *  MPG123_NEW_FORMAT.
+ *  \param mh handle
+ *  \param rate sampling rate return address
+ *  \param channels channel count return address
+ *  \param encoding encoding return address
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_getformat( mpg123_handle *mh
+,	long *rate, int *channels, int *encoding );
+
+/** Get the current output format written to the addresses given.
+ *  This differs from plain mpg123_getformat() in that you can choose
+ *  _not_ to clear the flag that would trigger the next decoding call
+ *  to return MPG123_NEW_FORMAT in case of a new format arriving.
+ *  \param mh handle
+ *  \param rate sampling rate return address
+ *  \param channels channel count return address
+ *  \param encoding encoding return address
+ *  \param clear_flag if true, clear internal format flag
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_getformat2( mpg123_handle *mh
+,	long *rate, int *channels, int *encoding, int clear_flag );
+
+/** @} */
+
+
+/** \defgroup mpg123_input mpg123 file input and decoding
+ *
+ * Functions for input bitstream and decoding operations.
+ * Decoding/seek functions may also return message codes MPG123_DONE, MPG123_NEW_FORMAT and MPG123_NEED_MORE (please read up on these on how to react!).
+ * @{
+ */
+
+#ifndef MPG123_PORTABLE_API
+/** Open a simple MPEG file with fixed properties.
+ *
+ *  This function shall simplify the common use case of a plain MPEG
+ *  file on disk that you want to decode, with one fixed sample
+ *  rate and channel count, and usually a length defined by a Lame/Info/Xing
+ *  tag. It will:
+ *
+ *  - set the MPG123_NO_FRANKENSTEIN flag
+ *  - set up format support according to given parameters,
+ *  - open the file,
+ *  - query audio format,
+ *  - fix the audio format support table to ensure the format stays the same,
+ *  - call mpg123_scan() if there is no header frame to tell the track length.
+ *
+ *  From that on, you can call mpg123_getformat() for querying the sample
+ *  rate (and channel count in case you allowed both) and mpg123_length()
+ *  to get a pretty safe number for the duration.
+ *  Only the sample rate is left open as that indeed is a fixed property of
+ *  MPEG files. You could set MPG123_FORCE_RATE beforehand, but that may trigger
+ *  low-quality resampling in the decoder, only do so if in dire need.
+ *  The library will convert mono files to stereo for you, and vice versa.
+ *  If any constraint cannot be satisified (most likely because of a non-default
+ *  build of libmpg123), you get MPG123_ERR returned and can query the detailed
+ *  cause from the handle. Only on MPG123_OK there will an open file that you
+ *  then close using mpg123_close(), or implicitly on mpg123_delete() or the next
+ *  call to open another file.
+ *
+ *  So, for your usual CD rip collection, you could use
+ *
+ *    mpg123_open_fixed(mh, path, MPG123_STEREO, MPG123_ENC_SIGNED_16)
+ *
+ *  and be happy calling mpg123_getformat() to verify 44100 Hz rate, then just
+ *  playing away with mpg123_read(). The occasional mono file, or MP2 file,
+ *  will also be decoded without you really noticing. Just the speed could be
+ *  wrong if you do not care about sample rate at all.
+ *  \param mh handle
+ *  \param path filesystem path (see mpg123_open())
+ *  \param channels allowed channel count, either 1 (MPG123_MONO) or
+ *    2 (MPG123_STEREO), or bitwise or of them, but then you're halfway back to
+ *    calling mpg123_format() again;-)
+ *  \param encoding a definite encoding from enum mpg123_enc_enum
+ *    or a bitmask like for mpg123_format(), defeating the purpose somewhat
+ */
+MPG123_EXPORT int mpg123_open_fixed(mpg123_handle *mh, const char *path
+,	int channels, int encoding);
+
+/** Open and prepare to decode the specified file by filesystem path.
+ *  This does not open HTTP urls; libmpg123 contains no networking code.
+ *  If you want to decode internet streams, use mpg123_open_fd() or mpg123_open_feed().
+ *
+ *  The path parameter usually is just a string that is handed to the underlying
+ *  OS routine for opening, treated as a blob of binary data. On platforms
+ *  where encoding needs to be involved, something like _wopen() is called
+ *  underneath and the path argument to libmpg123 is assumed to be encoded in UTF-8.
+ *  So, if you have to ask yourself which encoding is needed, the answer is
+ *  UTF-8, which also fits any sane modern install of Unix-like systems.
+ *
+ *  \param mh handle
+ *  \param path filesystem path
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_open(mpg123_handle *mh, const char *path);
+
+/** Use an already opened file descriptor as the bitstream input
+ *  mpg123_close() will _not_ close the file descriptor.
+ *  \param mh handle
+ *  \param fd file descriptor
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_open_fd(mpg123_handle *mh, int fd);
+
+/** Use an opaque handle as bitstream input. This works only with the
+ *  replaced I/O from mpg123_replace_reader_handle() or mpg123_reader64()!
+ *  mpg123_close() will call the cleanup callback for your non-NULL
+ *  handle (if you gave one).
+ *  Note that this used to be usable with MPG123_PORTABLE_API defined in
+ *  mpg123 1.32.x and was in fact the only entry point for handle I/O.
+ *  Since mpg123 1.33.0 and API version 49, there is
+ *  mpg123_open_handle64() for the portable case and has to be used
+ *  instead of this function here, even if it _would_ work just fine,
+ *  the inclusion of a largefile-renamed symbol in the portable set was wrong.
+ *
+ *  \param mh handle
+ *  \param iohandle your handle
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_open_handle(mpg123_handle *mh, void *iohandle);
+#endif
+
+/** Open and prepare to decode the specified file by filesystem path.
+ *  This works exactly like mpg123_open() in modern libmpg123, see there
+ *  for more description. This name is not subject to largefile symbol renaming.
+ *  You can also use it with MPG123_PORTABLE_API.
+ *
+ *  \param mh handle
+ *  \param path filesystem path of your resource
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_open64(mpg123_handle *mh, const char *path);
+
+/** Open a simple MPEG file with fixed properties.
+ *  This is the same as mpg123_open_fixed(), just with a stable
+ *  symbol name for int64_t portable API.
+ *
+ *  \param mh handle
+ *  \param path filesystem path (see mpg123_open())
+ *  \param channels allowed channel count, either 1 (MPG123_MONO) or
+ *    2 (MPG123_STEREO), or bitwise or of them, but then you're halfway back to
+ *    calling mpg123_format() again;-)
+ *  \param encoding a definite encoding from enum mpg123_enc_enum
+ *    or a bitmask like for mpg123_format(), defeating the purpose somewhat
+ */
+MPG123_EXPORT int mpg123_open_fixed64(mpg123_handle *mh, const char *path
+,	int channels, int encoding);
+
+/** Use an opaque handle as bitstream input. This works only with the
+ *  replaced I/O from mpg123_reader64()!
+ *  mpg123_close() will call the cleanup callback for your non-NULL
+ *  handle (if you gave one).
+ *  This is a simplified variant of mpg123_open_handle() that only
+ *  supports the int64_t API, available with MPG123_PORTABLE_API.
+ *
+ *  \param mh handle
+ *  \param iohandle your handle
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_open_handle64(mpg123_handle *mh, void *iohandle);
+
+/** Open a new bitstream and prepare for direct feeding
+ *  This works together with mpg123_decode(); you are responsible for reading and feeding the input bitstream.
+ *  Also, you are expected to handle ICY metadata extraction yourself. This
+ *  input method does not handle MPG123_ICY_INTERVAL. It does parse ID3 frames, though.
+ *  \param mh handle
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_open_feed(mpg123_handle *mh);
+
+/** Closes the source, if libmpg123 opened it.
+ *  \param mh handle
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_close(mpg123_handle *mh);
+
+/** Read from stream and decode up to outmemsize bytes.
+ *
+ *  Note: The type of outmemory changed to a void pointer in mpg123 1.26.0
+ *  (API version 45).
+ *
+ *  \param mh handle
+ *  \param outmemory address of output buffer to write to
+ *  \param outmemsize maximum number of bytes to write
+ *  \param done address to store the number of actually decoded bytes to
+ *  \return MPG123_OK or error/message code
+ */
+MPG123_EXPORT int mpg123_read(mpg123_handle *mh
+,	void *outmemory, size_t outmemsize, size_t *done );
+
+/** Feed data for a stream that has been opened with mpg123_open_feed().
+ *  It's give and take: You provide the bytestream, mpg123 gives you the decoded samples.
+ *  \param mh handle
+ *  \param in input buffer
+ *  \param size number of input bytes
+ *  \return MPG123_OK or error/message code.
+ */
+MPG123_EXPORT int mpg123_feed( mpg123_handle *mh
+,	const unsigned char *in, size_t size );
+
+/** Decode MPEG Audio from inmemory to outmemory. 
+ *  This is very close to a drop-in replacement for old mpglib.
+ *  When you give zero-sized output buffer the input will be parsed until 
+ *  decoded data is available. This enables you to get MPG123_NEW_FORMAT (and query it) 
+ *  without taking decoded data.
+ *  Think of this function being the union of mpg123_read() and mpg123_feed() (which it actually is, sort of;-).
+ *  You can actually always decide if you want those specialized functions in separate steps or one call this one here.
+ *
+ *  Note: The type of outmemory changed to a void pointer in mpg123 1.26.0
+ *  (API version 45).
+ *
+ *  \param mh handle
+ *  \param inmemory input buffer
+ *  \param inmemsize number of input bytes
+ *  \param outmemory output buffer
+ *  \param outmemsize maximum number of output bytes
+ *  \param done address to store the number of actually decoded bytes to
+ *  \return error/message code (watch out especially for MPG123_NEED_MORE)
+ */
+MPG123_EXPORT int mpg123_decode( mpg123_handle *mh
+,	const unsigned char *inmemory, size_t inmemsize
+,	void *outmemory, size_t outmemsize, size_t *done );
+
+#ifndef MPG123_PORTABLE_API
+/** Decode next MPEG frame to internal buffer
+ *  or read a frame and return after setting a new format.
+ *  \param mh handle
+ *  \param num current frame offset gets stored there
+ *  \param audio This pointer is set to the internal buffer to read the decoded audio from.
+ *  \param bytes number of output bytes ready in the buffer
+ *  \return MPG123_OK or error/message code
+ */
+MPG123_EXPORT int mpg123_decode_frame( mpg123_handle *mh
+,	off_t *num, unsigned char **audio, size_t *bytes );
+
+/** Decode current MPEG frame to internal buffer.
+ * Warning: This is experimental API that might change in future releases!
+ * Please watch mpg123 development closely when using it.
+ *  \param mh handle
+ *  \param num last frame offset gets stored there
+ *  \param audio this pointer is set to the internal buffer to read the decoded audio from.
+ *  \param bytes number of output bytes ready in the buffer
+ *  \return MPG123_OK or error/message code
+ */
+MPG123_EXPORT int mpg123_framebyframe_decode( mpg123_handle *mh
+,	off_t *num, unsigned char **audio, size_t *bytes );
+#endif /* un-portable API */
+
+/** Decode next MPEG frame to internal buffer
+ *  or read a frame and return after setting a new format.
+ *  \param mh handle
+ *  \param num current frame offset gets stored there
+ *  \param audio This pointer is set to the internal buffer to read the decoded audio from.
+ *  \param bytes number of output bytes ready in the buffer
+ *  \return MPG123_OK or error/message code
+ */
+MPG123_EXPORT int mpg123_decode_frame64( mpg123_handle *mh
+,	int64_t *num, unsigned char **audio, size_t *bytes );
+
+/** Decode current MPEG frame to internal buffer.
+ * Warning: This is experimental API that might change in future releases!
+ * Please watch mpg123 development closely when using it.
+ *  \param mh handle
+ *  \param num last frame offset gets stored there
+ *  \param audio this pointer is set to the internal buffer to read the decoded audio from.
+ *  \param bytes number of output bytes ready in the buffer
+ *  \return MPG123_OK or error/message code
+ */
+MPG123_EXPORT int mpg123_framebyframe_decode64( mpg123_handle *mh
+,	int64_t *num, unsigned char **audio, size_t *bytes );
+
+/** Find, read and parse the next mp3 frame
+ * Warning: This is experimental API that might change in future releases!
+ * Please watch mpg123 development closely when using it.
+ *  \param mh handle
+ *  \return MPG123_OK or error/message code
+ */
+MPG123_EXPORT int mpg123_framebyframe_next(mpg123_handle *mh);
+
+/** Get access to the raw input data for the last parsed frame.
+ * This gives you a direct look (and write access) to the frame body data.
+ * Together with the raw header, you can reconstruct the whole raw MPEG stream without junk and meta data, or play games by actually modifying the frame body data before decoding this frame (mpg123_framebyframe_decode()).
+ * A more sane use would be to use this for CRC checking (see mpg123_info() and MPG123_CRC), the first two bytes of the body make up the CRC16 checksum, if present.
+ * You can provide NULL for a parameter pointer when you are not interested in the value.
+ *
+ * \param mh handle
+ * \param header the 4-byte MPEG header
+ * \param bodydata pointer to the frame body stored in the handle (without the header)
+ * \param bodybytes size of frame body in bytes (without the header)
+ * \return MPG123_OK if there was a yet un-decoded frame to get the
+ *    data from, MPG123_BAD_HANDLE or MPG123_ERR otherwise (without further
+ *    explanation, the error state of the mpg123_handle is not modified by
+ *    this function).
+ */
+MPG123_EXPORT int mpg123_framedata( mpg123_handle *mh
+,	unsigned long *header, unsigned char **bodydata, size_t *bodybytes );
+
+#ifndef MPG123_PORTABLE_API
+/** Get the input position (byte offset in stream) of the last parsed frame.
+ *  This can be used for external seek index building, for example.
+ *  It just returns the internally stored offset, regardless of validity --
+ *  you ensure that a valid frame has been parsed before!
+ * \param mh handle
+ * \return byte offset in stream
+ */
+MPG123_EXPORT off_t mpg123_framepos(mpg123_handle *mh);
+#endif
+
+/** Get the 64 bit input position (byte offset in stream) of the last parsed frame.
+ *  This can be used for external seek index building, for example.
+ *  It just returns the internally stored offset, regardless of validity --
+ *  you ensure that a valid frame has been parsed before!
+ * \param mh handle
+ * \return byte offset in stream
+ */
+MPG123_EXPORT int64_t mpg123_framepos64(mpg123_handle *mh);
+
+/** @} */
+
+
+/** \defgroup mpg123_seek mpg123 position and seeking
+ *
+ * Functions querying and manipulating position in the decoded audio bitstream.
+ * The position is measured in decoded audio samples or MPEG frame offset for
+ * the specific functions. The term sample refers to a group of samples for
+ * multiple channels, normally dubbed PCM frames. The latter term is
+ * avoided here because frame means something different in the context of MPEG
+ * audio. Since all samples of a PCM frame occur at the same time, there is only
+ * very limited ambiguity when talking about playback offset, as counting each
+ * channel sample individually does not make sense.
+ *
+ * If gapless code is in effect, the positions are adjusted to compensate the
+ * skipped padding/delay - meaning, you should not care about that at all and
+ * just use the position defined for the samples you get out of the decoder;-)
+ * The general usage is modelled after stdlib's ftell() and fseek().
+ * Especially, the whence parameter for the seek functions has the same meaning
+ * as the one for fseek() and needs the same constants from stdlib.h: 
+ *
+ * - SEEK_SET: set position to (or near to) specified offset
+ * - SEEK_CUR: change position by offset from now
+ * - SEEK_END: set position to offset from end
+ *
+ * Since API version 48 (mpg123 1.32), the offset given with SEEK_END is always
+ * taken to be  negative in the terms of standard lseek(). You can only seek from
+ * the end towards the beginning. All earlier versions had the sign wrong, positive
+ * was towards the beginning, negative past the end (which results in error,
+ * anyway).
+ *
+ * Note that sample-accurate seek only works when gapless support has been
+ * enabled at compile time; seek is frame-accurate otherwise.
+ * Also, really sample-accurate seeking (meaning that you get the identical
+ * sample value after seeking compared to plain decoding up to the position)
+ * is only guaranteed when you do not mess with the position code by using
+ * #MPG123_UPSPEED, #MPG123_DOWNSPEED or #MPG123_START_FRAME. The first two mainly
+ * should cause trouble with NtoM resampling, but in any case with these options
+ * in effect, you have to keep in mind that the sample offset is not the same
+ * as counting the samples you get from decoding since mpg123 counts the skipped
+ * samples, too (or the samples played twice only once)!
+ *
+ * Short: When you care about the sample position, don't mess with those
+ * parameters;-)
+ *
+ * Streams may be openend in ways that do not support seeking. Also, consider
+ * the effect of #MPG123_FUZZY.
+ *
+ * @{
+ */
+
+#ifndef MPG123_PORTABLE_API
+/** Returns the current position in samples.
+ *  On the next successful read, you'd get audio data with that offset.
+ *  \param mh handle
+ *  \return sample (PCM frame) offset or MPG123_ERR (null handle)
+ */
+MPG123_EXPORT off_t mpg123_tell(mpg123_handle *mh);
+#endif
+
+/** Returns the current 64 bit position in samples.
+ *  On the next successful read, you'd get audio data with that offset.
+ *  \param mh handle
+ *  \return sample (PCM frame) offset or MPG123_ERR (null handle)
+ */
+MPG123_EXPORT int64_t mpg123_tell64(mpg123_handle *mh);
+
+#ifndef MPG123_PORTABLE_API
+/** Returns the frame number that the next read will give you data from.
+ *  \param mh handle
+ *  \return frame offset or MPG123_ERR (null handle)
+ */
+MPG123_EXPORT off_t mpg123_tellframe(mpg123_handle *mh);
+#endif
+
+/** Returns the 64 bit frame number that the next read will give you data from.
+ *  \param mh handle
+ *  \return frame offset or MPG123_ERR (null handle)
+ */
+MPG123_EXPORT int64_t mpg123_tellframe64(mpg123_handle *mh);
+
+#ifndef MPG123_PORTABLE_API
+/** Returns the current byte offset in the input stream.
+ *  \param mh handle
+ *  \return byte offset or MPG123_ERR (null handle)
+ */
+MPG123_EXPORT off_t mpg123_tell_stream(mpg123_handle *mh);
+#endif
+
+/** Returns the current 64 bit byte offset in the input stream.
+ *  \param mh handle
+ *  \return byte offset or MPG123_ERR (null handle)
+ */
+MPG123_EXPORT int64_t mpg123_tell_stream64(mpg123_handle *mh);
+
+
+#ifndef MPG123_PORTABLE_API
+/** Seek to a desired sample offset.
+ *  Usage is modelled afer the standard lseek().
+ * \param mh handle
+ * \param sampleoff offset in samples (PCM frames)
+ * \param whence one of SEEK_SET, SEEK_CUR or SEEK_END
+ *        (Offset for SEEK_END is always effectively negative since API
+ *        version 48, was inverted from lseek() usage since ever before.)
+ * \return The resulting offset >= 0 or error/message code
+ */
+MPG123_EXPORT off_t mpg123_seek( mpg123_handle *mh
+,	off_t sampleoff, int whence );
+#endif
+
+/** Seek to a desired 64 bit sample offset.
+ *  Usage is modelled afer the standard lseek().
+ * \param mh handle
+ * \param sampleoff offset in samples (PCM frames)
+ * \param whence one of SEEK_SET, SEEK_CUR or SEEK_END
+ *        (Offset for SEEK_END is always effectively negative.)
+ * \return The resulting offset >= 0 or error/message code
+ */
+MPG123_EXPORT int64_t mpg123_seek64( mpg123_handle *mh
+,	int64_t sampleoff, int whence );
+
+#ifndef MPG123_PORTABLE_API
+/** Seek to a desired sample offset in data feeding mode.
+ *  This just prepares things to be right only if you ensure that the next chunk
+ *  of input data will be from input_offset byte position.
+ * \param mh handle
+ * \param sampleoff offset in samples (PCM frames)
+ * \param whence one of SEEK_SET, SEEK_CUR or SEEK_END
+ *        (Offset for SEEK_END is always effectively negative since API
+ *        version 48, was inverted from lseek() usage since ever before.)
+ * \param input_offset The position it expects to be at the 
+ *                     next time data is fed to mpg123_decode().
+ * \return The resulting offset >= 0 or error/message code
+ */
+MPG123_EXPORT off_t mpg123_feedseek( mpg123_handle *mh
+,	off_t sampleoff, int whence, off_t *input_offset );
+#endif
+
+/** Seek to a desired 64 bit sample offset in data feeding mode.
+ *  This just prepares things to be right only if you ensure that the next chunk
+ *  of input data will be from input_offset byte position.
+ * \param mh handle
+ * \param sampleoff offset in samples (PCM frames)
+ * \param whence one of SEEK_SET, SEEK_CUR or SEEK_END
+ *        (Offset for SEEK_END is always effectively negative.)
+ * \param input_offset The position it expects to be at the 
+ *                     next time data is fed to mpg123_decode().
+ * \return The resulting offset >= 0 or error/message code
+ */
+MPG123_EXPORT int64_t mpg123_feedseek64( mpg123_handle *mh
+,	int64_t sampleoff, int whence, int64_t *input_offset );
+
+#ifndef MPG123_PORTABLE_API
+/** Seek to a desired MPEG frame offset.
+ *  Usage is modelled afer the standard lseek().
+ * \param mh handle
+ * \param frameoff offset in MPEG frames
+ * \param whence one of SEEK_SET, SEEK_CUR or SEEK_END
+ *        (Offset for SEEK_END is always effectively negative since API
+ *        version 48, was inverted from lseek() usage since ever before.)
+ * \return The resulting offset >= 0 or error/message code */
+MPG123_EXPORT off_t mpg123_seek_frame( mpg123_handle *mh
+,	off_t frameoff, int whence );
+#endif
+
+/** Seek to a desired 64 bit MPEG frame offset.
+ *  Usage is modelled afer the standard lseek().
+ * \param mh handle
+ * \param frameoff offset in MPEG frames
+ * \param whence one of SEEK_SET, SEEK_CUR or SEEK_END
+ *        (Offset for SEEK_END is always effectively negative.)
+ * \return The resulting offset >= 0 or error/message code */
+MPG123_EXPORT int64_t mpg123_seek_frame64( mpg123_handle *mh
+,	int64_t frameoff, int whence );
+
+#ifndef MPG123_PORTABLE_API
+/** Return a MPEG frame offset corresponding to an offset in seconds.
+ *  This assumes that the samples per frame do not change in the file/stream, which is a good assumption for any sane file/stream only.
+ *  \return frame offset >= 0 or error/message code */
+MPG123_EXPORT off_t mpg123_timeframe(mpg123_handle *mh, double sec);
+
+/** Give access to the frame index table that is managed for seeking.
+ *  You are asked not to modify the values... Use mpg123_set_index to set the
+ *  seek index.
+ *  Note: This can be just a copy of the data in case a conversion is done
+ *  from the internal 64 bit values.
+ *  \param mh handle
+ *  \param offsets pointer to the index array
+ *  \param step one index byte offset advances this many MPEG frames
+ *  \param fill number of recorded index offsets; size of the array
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_index( mpg123_handle *mh
+,	off_t **offsets, off_t *step, size_t *fill );
+#endif
+
+/** Return a 64 bit MPEG frame offset corresponding to an offset in seconds.
+ *  This assumes that the samples per frame do not change in the file/stream, which is a good assumption for any sane file/stream only.
+ *  \return frame offset >= 0 or error/message code */
+MPG123_EXPORT int64_t mpg123_timeframe64(mpg123_handle *mh, double sec);
+
+/** Give access to the 64 bit frame index table that is managed for seeking.
+ *  You are asked not to modify the values... Use mpg123_set_index to set the
+ *  seek index.
+ *  \param mh handle
+ *  \param offsets pointer to the index array
+ *  \param step one index byte offset advances this many MPEG frames
+ *  \param fill number of recorded index offsets; size of the array
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_index64( mpg123_handle *mh
+,	int64_t **offsets, int64_t *step, size_t *fill );
+
+#ifndef MPG123_PORTABLE_API
+/** Set the frame index table
+ *  Setting offsets to NULL and fill > 0 will allocate fill entries. Setting offsets
+ *  to NULL and fill to 0 will clear the index and free the allocated memory used by the index.
+ *  Note that this function might involve conversion/copying of data because of
+ *  the varying nature of off_t. Better use mpg123_set_index64().
+ *  \param mh handle
+ *  \param offsets pointer to the index array
+ *  \param step    one index byte offset advances this many MPEG frames
+ *  \param fill    number of recorded index offsets; size of the array
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_set_index( mpg123_handle *mh
+,	off_t *offsets, off_t step, size_t fill );
+#endif
+
+/** Set the 64 bit frame index table
+ *  Setting offsets to NULL and fill > 0 will allocate fill entries. Setting offsets
+ *  to NULL and fill to 0 will clear the index and free the allocated memory used by the index.
+ *  \param mh handle
+ *  \param offsets pointer to the index array
+ *  \param step    one index byte offset advances this many MPEG frames
+ *  \param fill    number of recorded index offsets; size of the array
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_set_index64( mpg123_handle *mh
+,	int64_t *offsets, int64_t step, size_t fill );
+
+
+#ifndef MPG123_PORTABLE_API
+/** An old crutch to keep old mpg123 binaries happy.
+ *  WARNING: This function is there only to avoid runtime linking errors with
+ *  standalone mpg123 before version 1.32.0 (if you strangely update the
+ *  library but not the end-user program) and actually is broken
+ *  for various cases (p.ex. 24 bit output). Do never use. It might eventually
+ *  be purged from the library.
+ */
+MPG123_EXPORT int mpg123_position( mpg123_handle *mh, off_t INT123_frame_offset, off_t buffered_bytes, off_t *current_frame, off_t *frames_left, double *current_seconds, double *seconds_left);
+#endif
+
+/** @} */
+
+
+/** \defgroup mpg123_voleq mpg123 volume and equalizer
+ *
+ * @{
+ */
+
+/** another channel enumeration, for left/right choice */
+enum mpg123_channels
+{
+	 MPG123_LEFT=0x1	/**< The Left Channel. */
+	,MPG123_RIGHT=0x2	/**< The Right Channel. */
+	,MPG123_LR=0x3	/**< Both left and right channel; same as MPG123_LEFT|MPG123_RIGHT */
+};
+
+#ifdef MPG123_ENUM_API
+/** Set the 32 Band Audio Equalizer settings.
+ *
+ *  Note that this name is mapped to mpg123_eq2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  \param mh handle
+ *  \param channel Can be #MPG123_LEFT, #MPG123_RIGHT or
+ *    #MPG123_LEFT|#MPG123_RIGHT for both.
+ *  \param band The equaliser band to change (from 0 to 31)
+ *  \param val The (linear) adjustment factor.
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_eq( mpg123_handle *mh
+,	enum mpg123_channels channel, int band, double val );
+#endif
+
+/** Set the 32 Band Audio Equalizer settings. No enums.
+ *
+ *  This is actually called instead of mpg123_eq() unless MPG123_ENUM_API
+ *  is defined.
+ *
+ *  \param mh handle
+ *  \param channel Can be #MPG123_LEFT, #MPG123_RIGHT or
+ *    #MPG123_LEFT|#MPG123_RIGHT for both.
+ *  \param band The equaliser band to change (from 0 to 31)
+ *  \param val The (linear) adjustment factor.
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_eq2( mpg123_handle *mh
+,	int channel, int band, double val );
+
+/** Set a range of equalizer bands
+ *  \param channel Can be #MPG123_LEFT, #MPG123_RIGHT or
+ *    #MPG123_LEFT|#MPG123_RIGHT for both.
+ *  \param mh handle
+ *  \param a The first equalizer band to set (from 0 to 31)
+ *  \param b The last equalizer band to set (from 0 to 31)
+ *  \param factor The (linear) adjustment factor, 1 being neutral.
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_eq_bands( mpg123_handle *mh
+,	int channel, int a, int b, double factor );
+
+/** Change a range of equalizer bands
+ *  \param mh handle
+ *  \param channel Can be #MPG123_LEFT, #MPG123_RIGHT or
+ *    #MPG123_LEFT|#MPG123_RIGHT for both.
+ *  \param a The first equalizer band to change (from 0 to 31)
+ *  \param b The last equalizer band to change (from 0 to 31)
+ *  \param db The adjustment in dB (limited to +/- 60 dB).
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_eq_change( mpg123_handle *mh
+,	int channel, int a, int b, double db );
+
+#ifdef MPG123_ENUM_API
+/** Get the 32 Band Audio Equalizer settings.
+ *
+ *  Note that this name is mapped to mpg123_geteq2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  \param mh handle
+ *  \param channel Can be #MPG123_LEFT, #MPG123_RIGHT or
+ *     #MPG123_LEFT|MPG123_RIGHT for (arithmetic mean of) both.
+ *  \param band The equaliser band to change (from 0 to 31)
+ *  \return The (linear) adjustment factor (zero for pad parameters) */
+MPG123_EXPORT double mpg123_geteq(mpg123_handle *mh
+                                 , enum mpg123_channels channel, int band);
+#endif
+
+/** Get the 32 Band Audio Equalizer settings.
+ *
+ *  This is actually called instead of mpg123_geteq() unless MPG123_ENUM_API
+ *  is defined.
+ *
+ *  \param mh handle
+ *  \param channel Can be #MPG123_LEFT, #MPG123_RIGHT or
+ *     #MPG123_LEFT|MPG123_RIGHT for (arithmetic mean of) both.
+ *  \param band The equaliser band to change (from 0 to 31)
+ *  \return The (linear) adjustment factor (zero for pad parameters) */
+MPG123_EXPORT double mpg123_geteq2(mpg123_handle *mh, int channel, int band);
+
+/** Reset the 32 Band Audio Equalizer settings to flat
+ *  \param mh handle
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_reset_eq(mpg123_handle *mh);
+
+/** Set the absolute output volume including the RVA setting, 
+ *  vol<0 just applies (a possibly changed) RVA setting.
+ *  \param mh handle
+ *  \param vol volume value (linear factor)
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_volume(mpg123_handle *mh, double vol);
+
+/** Adjust output volume including the RVA setting by chosen amount
+ *  \param mh handle
+ *  \param change volume value (linear factor increment)
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_volume_change(mpg123_handle *mh, double change);
+
+/** Adjust output volume including the RVA setting by chosen amount
+ *  \param mh handle
+ *  \param db volume adjustment in decibels (limited to +/- 60 dB)
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_volume_change_db(mpg123_handle *mh, double db);
+
+/** Return current volume setting, the actual value due to RVA, and the RVA 
+ *  adjustment itself. It's all as double float value to abstract the sample 
+ *  format. The volume values are linear factors / amplitudes (not percent) 
+ *  and the RVA value is in decibels.
+ *  \param mh handle
+ *  \param base return address for base volume (linear factor)
+ *  \param really return address for actual volume (linear factor)
+ *  \param rva_db return address for RVA value (decibels)
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_getvolume(mpg123_handle *mh, double *base, double *really, double *rva_db);
+
+/* TODO: Set some preamp in addition / to replace internal RVA handling? */
+
+/** @} */
+
+
+/** \defgroup mpg123_status mpg123 status and information
+ *
+ * @{
+ */
+
+/** Enumeration of the mode types of Variable Bitrate */
+enum mpg123_vbr {
+	MPG123_CBR=0,	/**< Constant Bitrate Mode (default) */
+	MPG123_VBR,		/**< Variable Bitrate Mode */
+	MPG123_ABR		/**< Average Bitrate Mode */
+};
+
+/** Enumeration of the MPEG Versions */
+enum mpg123_version {
+	MPG123_1_0=0,	/**< MPEG Version 1.0 */
+	MPG123_2_0,		/**< MPEG Version 2.0 */
+	MPG123_2_5		/**< MPEG Version 2.5 */
+};
+
+
+/** Enumeration of the MPEG Audio mode.
+ *  Only the mono mode has 1 channel, the others have 2 channels. */
+enum mpg123_mode {
+	MPG123_M_STEREO=0,	/**< Standard Stereo. */
+	MPG123_M_JOINT,		/**< Joint Stereo. */
+	MPG123_M_DUAL,		/**< Dual Channel. */
+	MPG123_M_MONO		/**< Single Channel. */
+};
+
+
+/** Enumeration of the MPEG Audio flag bits */
+enum mpg123_flags {
+	MPG123_CRC=0x1,			/**< The bitstream is error protected using 16-bit CRC. */
+	MPG123_COPYRIGHT=0x2,	/**< The bitstream is copyrighted. */
+	MPG123_PRIVATE=0x4,		/**< The private bit has been set. */
+	MPG123_ORIGINAL=0x8	/**< The bitstream is an original, not a copy. */
+};
+
+#ifdef MPG123_ENUM_API
+/** Data structure for storing information about a frame of MPEG Audio */
+struct mpg123_frameinfo
+{
+	enum mpg123_version version;	/**< The MPEG version (1.0/2.0/2.5). */
+	int layer;						/**< The MPEG Audio Layer (MP1/MP2/MP3). */
+	long rate; 						/**< The sampling rate in Hz. */
+	enum mpg123_mode mode;			/**< The audio mode (Mono, Stereo, Joint-stero, Dual Channel). */
+	int mode_ext;					/**< The mode extension bit flag. */
+	int framesize;					/**< The size of the frame (in bytes, including header). */
+	enum mpg123_flags flags;		/**< MPEG Audio flag bits. Just now I realize that it should be declared as int, not enum. It's a bitwise combination of the enum values. */
+	int emphasis;					/**< The emphasis type. */
+	int bitrate;					/**< Bitrate of the frame (kbps). */
+	int abr_rate;					/**< The target average bitrate. */
+	enum mpg123_vbr vbr;			/**< The VBR mode. */
+};
+#endif
+
+/** Data structure for storing information about a frame of MPEG Audio without enums */
+struct mpg123_frameinfo2
+{
+	int version;   /**< The MPEG version (1.0/2.0/2.5), enum mpg123_version. */
+	int layer;     /**< The MPEG Audio Layer (MP1/MP2/MP3). */
+	long rate;     /**< The sampling rate in Hz. */
+	int mode;      /**< The audio mode (enum mpg123_mode, Mono, Stereo, Joint-stero, Dual Channel). */
+	int mode_ext;  /**< The mode extension bit flag. */
+	int framesize; /**< The size of the frame (in bytes, including header). */
+	int flags;     /**< MPEG Audio flag bits. Bitwise combination of enum mpg123_flags values. */
+	int emphasis;  /**< The emphasis type. */
+	int bitrate;   /**< Bitrate of the frame (kbps). */
+	int abr_rate;  /**< The target average bitrate. */
+	int vbr;       /**< The VBR mode, enum mpg123_vbr. */
+};
+
+/** Data structure for even more detailed information out of the decoder,
+  * for MPEG layer III only.
+  * This was added to support the frame analyzer by the Lame project and
+  * just follows what was used there before. You know what the fields mean
+  * if you want use this structure. */
+struct mpg123_moreinfo
+{
+	double xr[2][2][576];  /**< internal data */
+	double sfb[2][2][22];  /**< [2][2][SBMAX_l] */
+	double sfb_s[2][2][3*13]; /**< [2][2][3*SBMAX_s] */
+	int qss[2][2];  /**< internal data */
+	int big_values[2][2]; /**< internal data */
+	int sub_gain[2][2][3]; /**< internal data */
+	int scalefac_scale[2][2]; /**< internal data */
+	int preflag[2][2]; /**< internal data */
+	int blocktype[2][2]; /**< internal data */
+	int mixed[2][2]; /**< internal data */
+	int mainbits[2][2]; /**< internal data */
+	int sfbits[2][2]; /**< internal data */
+	int scfsi[2]; /**< internal data */
+	int maindata; /**< internal data */
+	int padding; /**< internal data */
+};
+
+#ifdef MPG123_ENUM_API
+/** Get frame information about the MPEG audio bitstream and store
+ *  it in a mpg123_frameinfo structure.
+ *
+ *  Note that this name is mapped to mpg123_info2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  \param mh handle
+ *  \param mi address of existing frameinfo structure to write to
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_info(mpg123_handle *mh, struct mpg123_frameinfo *mi);
+#endif
+
+/** Get frame information about the MPEG audio bitstream and store
+ *  it in a mpg123_frameinfo2 structure.
+ *
+ *  This is actually called instead of mpg123_info()
+ *  unless MPG123_ENUM_API is defined.
+ *
+ *  \param mh handle
+ *  \param mi address of existing frameinfo structure to write to
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_info2(mpg123_handle *mh, struct mpg123_frameinfo2 *mi);
+
+/** Trigger collection of additional decoder information while decoding.
+ *  \param mh handle
+ *  \param mi pointer to data storage (NULL to disable collection)
+ *  \return MPG123_OK if the collection was enabled/disabled as desired, MPG123_ERR
+ *    otherwise (e.g. if the feature is disabled)
+ */
+MPG123_EXPORT int mpg123_set_moreinfo( mpg123_handle *mh
+,	struct mpg123_moreinfo *mi );
+
+/** Get the safe output buffer size for all cases
+ *  (when you want to replace the internal buffer)
+ *  \return safe buffer size
+ */
+MPG123_EXPORT size_t mpg123_safe_buffer(void);
+
+/** Make a full parsing scan of each frame in the file. ID3 tags are found. An
+ *  accurate length value is stored. Seek index will be filled. A seek back to
+ *  current position is performed. At all, this function refuses work when
+ *  stream is not seekable.
+ *  \param mh handle
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_scan(mpg123_handle *mh);
+
+#ifndef MPG123_PORTABLE_API
+/** Return, if possible, the full (expected) length of current track in
+ *  MPEG frames.
+ * \param mh handle
+ * \return length >= 0 or MPG123_ERR if there is no length guess possible.
+ */
+MPG123_EXPORT off_t mpg123_framelength(mpg123_handle *mh);
+
+/** Return, if possible, the full (expected) length of current
+ *  track in samples (PCM frames).
+ *
+ *  This relies either on an Info frame at the beginning or a previous
+ *  call to mpg123_scan() to get the real number of MPEG frames in a
+ *  file. It will guess based on file size if neither Info frame nor
+ *  scan data are present. In any case, there is no guarantee that the
+ *  decoder will not give you more data, for example in case the open
+ *  file gets appended to during decoding.
+ * \param mh handle
+ * \return length >= 0 or MPG123_ERR if there is no length guess possible.
+ */
+MPG123_EXPORT off_t mpg123_length(mpg123_handle *mh);
+
+/** Override the value for file size in bytes.
+ *  Useful for getting sensible track length values in feed mode or for HTTP streams.
+ *  \param mh handle
+ *  \param size file size in bytes
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_set_filesize(mpg123_handle *mh, off_t size);
+#endif
+
+/** Return, if possible, the full (expected) length of current track in
+ *  MPEG frames as 64 bit number.
+ * \param mh handle
+ * \return length >= 0 or MPG123_ERR if there is no length guess possible.
+ */
+MPG123_EXPORT int64_t mpg123_framelength64(mpg123_handle *mh);
+
+/** Return, if possible, the full (expected) length of current
+ *  track in samples (PCM frames) as 64 bit value.
+ *
+ *  This relies either on an Info frame at the beginning or a previous
+ *  call to mpg123_scan() to get the real number of MPEG frames in a
+ *  file. It will guess based on file size if neither Info frame nor
+ *  scan data are present. In any case, there is no guarantee that the
+ *  decoder will not give you more data, for example in case the open
+ *  file gets appended to during decoding.
+ * \param mh handle
+ * \return length >= 0 or MPG123_ERR if there is no length guess possible.
+ */
+MPG123_EXPORT int64_t mpg123_length64(mpg123_handle *mh);
+
+/** Override the 64 bit value for file size in bytes.
+ *  Useful for getting sensible track length values in feed mode or for HTTP streams.
+ *  \param mh handle
+ *  \param size file size in bytes
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_set_filesize64(mpg123_handle *mh, int64_t size);
+
+/** Get MPEG frame duration in seconds.
+ *  \param mh handle
+ *  \return frame duration in seconds, <0 on error
+ */
+MPG123_EXPORT double mpg123_tpf(mpg123_handle *mh);
+
+/** Get MPEG frame duration in samples.
+ *  \param mh handle
+ *  \return samples per frame for the most recently parsed frame; <0 on errors
+ */
+MPG123_EXPORT int mpg123_spf(mpg123_handle *mh);
+
+/** Get and reset the clip count.
+ *  \param mh handle
+ *  \return count of clipped samples
+ */
+MPG123_EXPORT long mpg123_clip(mpg123_handle *mh);
+
+
+/** The key values for state information from mpg123_getstate(). */
+enum mpg123_state
+{
+	 MPG123_ACCURATE = 1 /**< Query if positons are currently accurate (integer value, 0 if false, 1 if true). */
+	,MPG123_BUFFERFILL   /**< Get fill of internal (feed) input buffer as integer byte count returned as long and as double. An error is returned on integer overflow while converting to (signed) long, but the returned floating point value shold still be fine. */
+	,MPG123_FRANKENSTEIN /**< Stream consists of carelessly stitched together files. Seeking may yield unexpected results (also with MPG123_ACCURATE, it may be confused). */
+	,MPG123_FRESH_DECODER /**< Decoder structure has been updated, possibly indicating changed stream (integer value, 0 if false, 1 if true). Flag is cleared after retrieval. */
+	,MPG123_ENC_DELAY /** Encoder delay read from Info tag (layer III, -1 if unknown). */
+	,MPG123_ENC_PADDING /** Encoder padding read from Info tag (layer III, -1 if unknown). */
+	,MPG123_DEC_DELAY /** Decoder delay (for layer III only, -1 otherwise). */
+};
+
+#ifdef MPG123_ENUM_API
+/** Get various current decoder/stream state information.
+ *
+ *  Note that this name is mapped to mpg123_getstate2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  \param mh handle
+ *  \param key the key to identify the information to give.
+ *  \param val the address to return (long) integer values to
+ *  \param fval the address to return floating point values to
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_getstate( mpg123_handle *mh
+,	enum mpg123_state key, long *val, double *fval );
+#endif
+
+/** Get various current decoder/stream state information. No enums.
+ *
+ *  This is actually called instead of mpg123_getstate()
+ *  unless MPG123_ENUM_API is defined.
+ *
+ *  \param mh handle
+ *  \param key the key to identify the information to give (enum mpg123_state)
+ *  \param val the address to return (long) integer values to
+ *  \param fval the address to return floating point values to
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_getstate2( mpg123_handle *mh
+,	int key, long *val, double *fval );
+
+/** @} */
+
+
+/** \defgroup mpg123_metadata mpg123 metadata handling
+ *
+ * Functions to retrieve the metadata from MPEG Audio files and streams.
+ * Also includes string handling functions.
+ *
+ * @{
+ */
+
+/** Data structure for storing strings in a safer way than a standard C-String.
+ *  Can also hold a number of null-terminated strings. */
+typedef struct 
+{
+	char* p;     /**< pointer to the string data */
+	size_t size; /**< raw number of bytes allocated */
+	size_t fill; /**< number of used bytes (including closing zero byte) */
+} mpg123_string;
+
+/** Allocate and intialize a new string.
+ *  \param val optional initial string value (can be NULL)
+ */
+MPG123_EXPORT mpg123_string* mpg123_new_string(const char* val);
+
+/** Free memory of contents and the string structure itself.
+ *  \param sb string handle
+ */
+MPG123_EXPORT void mpg123_delete_string(mpg123_string* sb);
+
+/** Initialize an existing mpg123_string structure to {NULL, 0, 0}.
+ *  If you hand in a NULL pointer here, your program should crash. The other
+ *  string functions are more forgiving, but this one here is too basic.
+ *  \param sb string handle (address of existing structure on your side)
+ */
+MPG123_EXPORT void mpg123_init_string(mpg123_string* sb);
+
+/** Free-up memory of the contents of an mpg123_string (not the struct itself).
+ *  This also calls mpg123_init_string() and hence is safe to be called
+ *  repeatedly.
+ *  \param sb string handle
+ */
+MPG123_EXPORT void mpg123_free_string(mpg123_string* sb);
+
+/** Change the size of a mpg123_string
+ *  \param sb string handle
+ *  \param news new size in bytes
+ *  \return 0 on error, 1 on success
+ */
+MPG123_EXPORT int mpg123_resize_string(mpg123_string* sb, size_t news);
+
+/** Increase size of a mpg123_string if necessary (it may stay larger).
+ *  Note that the functions for adding and setting in current libmpg123
+ *  use this instead of mpg123_resize_string().
+ *  That way, you can preallocate memory and safely work afterwards with
+ *  pieces.
+ *  \param sb string handle
+ *  \param news new minimum size
+ *  \return 0 on error, 1 on success
+ */
+MPG123_EXPORT int mpg123_grow_string(mpg123_string* sb, size_t news);
+
+/** Copy the contents of one mpg123_string string to another.
+ *  Yes the order of arguments is reversed compated to memcpy().
+ *  \param from string handle
+ *  \param to string handle
+ *  \return 0 on error, 1 on success
+ */
+MPG123_EXPORT int mpg123_copy_string(mpg123_string* from, mpg123_string* to);
+
+/** Move the contents of one mpg123_string string to another.
+ *  This frees any memory associated with the target and moves over the
+ *  pointers from the source, leaving the source without content after
+ *  that. The only possible error is that you hand in NULL pointers.
+ *  If you handed in a valid source, its contents will be gone, even if
+ *  there was no target to move to. If you hand in a valid target, its
+ *  original contents will also always be gone, to be replaced with the
+ *  source's contents if there was some.
+ *  \param from source string handle
+ *  \param to   target string handle
+ *  \return 0 on error, 1 on success
+ */
+MPG123_EXPORT int mpg123_move_string(mpg123_string* from, mpg123_string* to);
+
+/** Append a C-String to an mpg123_string
+ *  \param sb string handle
+ *  \param stuff to append
+ *  \return 0 on error, 1 on success
+ */
+MPG123_EXPORT int mpg123_add_string(mpg123_string* sb, const char* stuff);
+
+/** Append a C-substring to an mpg123 string
+ *  \param sb string handle
+ *  \param stuff content to copy
+ *  \param from offset to copy from
+ *  \param count number of characters to copy (a null-byte is always appended)
+ *  \return 0 on error, 1 on success
+ */
+MPG123_EXPORT int mpg123_add_substring( mpg123_string *sb
+,	const char *stuff, size_t from, size_t count );
+
+/** Set the content of a mpg123_string to a C-string
+ *  \param sb string handle
+ *  \param stuff content to copy
+ *  \return 0 on error, 1 on success
+ */
+MPG123_EXPORT int mpg123_set_string(mpg123_string* sb, const char* stuff);
+
+/** Set the content of a mpg123_string to a C-substring
+ *  \param sb string handle
+ *  \param stuff the future content
+ *  \param from offset to copy from
+ *  \param count number of characters to copy (a null-byte is always appended)
+ *  \return 0 on error, 1 on success
+ */
+MPG123_EXPORT int mpg123_set_substring( mpg123_string *sb
+,	const char *stuff, size_t from, size_t count );
+
+/** Count characters in a mpg123 string (non-null bytes or Unicode points).
+ *  This function is of limited use, as it does just count code points
+ *  encoded in an UTF-8 string, only loosely related to the count of visible
+ *  characters. Get your full Unicode handling support elsewhere.
+ *  \param sb string handle
+ *  \param utf8 a flag to tell if the string is in utf8 encoding
+ *  \return character count
+*/
+MPG123_EXPORT size_t mpg123_strlen(mpg123_string *sb, int utf8);
+
+/** Remove trailing \\r and \\n, if present.
+ *  \param sb string handle
+ *  \return 0 on error, 1 on success
+ */
+MPG123_EXPORT int mpg123_chomp_string(mpg123_string *sb);
+
+/** Determine if two strings contain the same data.
+ *  This only returns 1 if both given handles are non-NULL and
+ *  if they are filled with the same bytes.
+ *  \param a first string handle
+ *  \param b second string handle
+ *  \return 0 for different strings, 1 for identical
+ */
+MPG123_EXPORT int mpg123_same_string(mpg123_string *a, mpg123_string *b);
+
+/** The mpg123 text encodings. This contains encodings we encounter in ID3 tags or ICY meta info. */
+enum mpg123_text_encoding
+{
+	 mpg123_text_unknown  = 0 /**< Unkown encoding... mpg123_id3_encoding can return that on invalid codes. */
+	,mpg123_text_utf8     = 1 /**< UTF-8 */
+	,mpg123_text_latin1   = 2 /**< ISO-8859-1. Note that sometimes latin1 in ID3 is abused for totally different encodings. */
+	,mpg123_text_icy      = 3 /**< ICY metadata encoding, usually CP-1252 but we take it as UTF-8 if it qualifies as such. */
+	,mpg123_text_cp1252   = 4 /**< Really CP-1252 without any guessing. */
+	,mpg123_text_utf16    = 5 /**< Some UTF-16 encoding. The last of a set of leading BOMs (byte order mark) rules.
+	                           *   When there is no BOM, big endian ordering is used. Note that UCS-2 qualifies as UTF-8 when
+	                           *   you don't mess with the reserved code points. If you want to decode little endian data
+	                           *   without BOM you need to prepend 0xff 0xfe yourself. */
+	,mpg123_text_utf16bom = 6 /**< Just an alias for UTF-16, ID3v2 has this as distinct code. */
+	,mpg123_text_utf16be  = 7 /**< Another alias for UTF16 from ID3v2. Note, that, because of the mess that is reality,
+	                           *   BOMs are used if encountered. There really is not much distinction between the UTF16 types for mpg123
+	                           *   One exception: Since this is seen in ID3v2 tags, leading null bytes are skipped for all other UTF16
+	                           *   types (we expect a BOM before real data there), not so for utf16be!*/
+	,mpg123_text_max      = 7 /**< Placeholder for the maximum encoding value. */
+};
+
+/** The encoding byte values from ID3v2. */
+enum mpg123_id3_enc
+{
+	 mpg123_id3_latin1   = 0 /**< Note: This sometimes can mean anything in practice... */
+	,mpg123_id3_utf16bom = 1 /**< UTF16, UCS-2 ... it's all the same for practical purposes. */
+	,mpg123_id3_utf16be  = 2 /**< Big-endian UTF-16, BOM see note for mpg123_text_utf16be. */
+	,mpg123_id3_utf8     = 3 /**< Our lovely overly ASCII-compatible 8 byte encoding for the world. */
+	,mpg123_id3_enc_max  = 3 /**< Placeholder to check valid range of encoding byte. */
+};
+
+#ifdef MPG123_ENUM_API
+/** Convert ID3 encoding byte to mpg123 encoding index.
+ *
+ *  Note that this name is mapped to mpg123_enc_from_id3_2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  \param id3_enc_byte the ID3 encoding code
+ *  \return the mpg123 encoding index
+ */
+MPG123_EXPORT enum mpg123_text_encoding mpg123_enc_from_id3(unsigned char id3_enc_byte);
+#endif
+
+/** Convert ID3 encoding byte to mpg123 encoding index. No enums.
+ *
+ *  This is actually called instead of mpg123_enc_from_id3()
+ *  unless MPG123_ENUM_API is defined.
+ *
+ *  \param id3_enc_byte the ID3 encoding code
+ *  \return the mpg123 encoding index
+ */
+MPG123_EXPORT int mpg123_enc_from_id3_2(unsigned char id3_enc_byte);
+
+#ifdef MPG123_ENUM_API
+/** Store text data in string, after converting to UTF-8 from indicated encoding.
+ *
+ *  Note that this name is mapped to mpg123_store_utf8_2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  A prominent error can be that you provided an unknown encoding value, or this build of libmpg123 lacks support for certain encodings (ID3 or ICY stuff missing).
+ *  Also, you might want to take a bit of care with preparing the data; for example, strip leading zeroes (I have seen that).
+ *  \param sb  target string
+ *  \param enc mpg123 text encoding value
+ *  \param source source buffer with plain unsigned bytes (you might need to cast from signed char)
+ *  \param source_size number of bytes in the source buffer
+ *  \return 0 on error, 1 on success (on error, mpg123_free_string is called on sb)
+ */
+MPG123_EXPORT int mpg123_store_utf8(mpg123_string *sb, enum mpg123_text_encoding enc, const unsigned char *source, size_t source_size);
+#endif
+
+/** Store text data in string, after converting to UTF-8 from indicated encoding. No enums.
+ *
+ *  This is actually called instead of mpg123_store_utf8()
+ *  unless MPG123_ENUM_API is defined.
+ *
+ *  A prominent error can be that you provided an unknown encoding value, or this build of libmpg123 lacks support for certain encodings (ID3 or ICY stuff missing).
+ *  Also, you might want to take a bit of care with preparing the data; for example, strip leading zeroes (I have seen that).
+ *  \param sb  target string
+ *  \param enc mpg123 text encoding value (enum mpg123_text_encoding)
+ *  \param source source buffer with plain unsigned bytes (you might need to cast from signed char)
+ *  \param source_size number of bytes in the source buffer
+ *  \return 0 on error, 1 on success (on error, mpg123_free_string is called on sb)
+ */
+MPG123_EXPORT int mpg123_store_utf8_2(mpg123_string *sb
+,	int enc, const unsigned char *source, size_t source_size);
+
+/** Sub data structure for ID3v2, for storing various text fields (including comments).
+ *  This is for ID3v2 COMM, TXXX and all the other text fields.
+ *  Only COMM, TXXX and USLT may have a description, only COMM and USLT
+ *  have a language.
+ *  You should consult the ID3v2 specification for the use of the various text fields
+ * ("frames" in ID3v2 documentation, I use "fields" here to separate from MPEG frames). */
+typedef struct
+{
+	char lang[3]; /**< Three-letter language code (not terminated). */
+	char id[4];   /**< The ID3v2 text field id, like TALB, TPE2, ... (4 characters, no string termination). */
+	mpg123_string description; /**< Empty for the generic comment... */
+	mpg123_string text;        /**< ... */
+} mpg123_text;
+
+/** The picture type values from ID3v2. */
+enum mpg123_id3_pic_type
+{
+	 mpg123_id3_pic_other          =  0 /**< see ID3v2 docs */
+	,mpg123_id3_pic_icon           =  1 /**< see ID3v2 docs */
+	,mpg123_id3_pic_other_icon     =  2 /**< see ID3v2 docs */
+	,mpg123_id3_pic_front_cover    =  3 /**< see ID3v2 docs */
+	,mpg123_id3_pic_back_cover     =  4 /**< see ID3v2 docs */
+	,mpg123_id3_pic_leaflet        =  5 /**< see ID3v2 docs */
+	,mpg123_id3_pic_media          =  6 /**< see ID3v2 docs */
+	,mpg123_id3_pic_lead           =  7 /**< see ID3v2 docs */
+	,mpg123_id3_pic_artist         =  8 /**< see ID3v2 docs */
+	,mpg123_id3_pic_conductor      =  9 /**< see ID3v2 docs */
+	,mpg123_id3_pic_orchestra      = 10 /**< see ID3v2 docs */
+	,mpg123_id3_pic_composer       = 11 /**< see ID3v2 docs */
+	,mpg123_id3_pic_lyricist       = 12 /**< see ID3v2 docs */
+	,mpg123_id3_pic_location       = 13 /**< see ID3v2 docs */
+	,mpg123_id3_pic_recording      = 14 /**< see ID3v2 docs */
+	,mpg123_id3_pic_performance    = 15 /**< see ID3v2 docs */
+	,mpg123_id3_pic_video          = 16 /**< see ID3v2 docs */
+	,mpg123_id3_pic_fish           = 17 /**< see ID3v2 docs */
+	,mpg123_id3_pic_illustration   = 18 /**< see ID3v2 docs */
+	,mpg123_id3_pic_artist_logo    = 19 /**< see ID3v2 docs */
+	,mpg123_id3_pic_publisher_logo = 20 /**< see ID3v2 docs */
+};
+
+/** Sub data structure for ID3v2, for storing picture data including comment.
+ *  This is for the ID3v2 APIC field. You should consult the ID3v2 specification
+ *  for the use of the APIC field ("frames" in ID3v2 documentation, I use "fields"
+ *  here to separate from MPEG frames). */
+typedef struct
+{
+	char type;                 /**< mpg123_id3_pic_type value */
+	mpg123_string description; /**< description string */
+	mpg123_string mime_type;   /**< MIME type */
+	size_t size;               /**< size in bytes */
+	unsigned char* data;       /**< pointer to the image data */
+} mpg123_picture;
+
+/** Data structure for storing IDV3v2 tags.
+ *  This structure is not a direct binary mapping with the file contents.
+ *  The ID3v2 text frames are allowed to contain multiple strings.
+ *  So check for null bytes until you reach the mpg123_string fill.
+ *  All text is encoded in UTF-8. */
+typedef struct
+{
+	unsigned char version; /**< 3 or 4 for ID3v2.3 or ID3v2.4. */
+	mpg123_string *title;   /**< Title string (pointer into text_list). */
+	mpg123_string *artist;  /**< Artist string (pointer into text_list). */
+	mpg123_string *album;   /**< Album string (pointer into text_list). */
+	mpg123_string *year;    /**< The year as a string (pointer into text_list). */
+	mpg123_string *genre;   /**< Genre String (pointer into text_list). The genre string(s) may very well need postprocessing, esp. for ID3v2.3. */
+	mpg123_string *comment; /**< Pointer to last encountered comment text with empty description. */
+	/* Encountered ID3v2 fields are appended to these lists.
+	   There can be multiple occurences, the pointers above always point to the last encountered data. */
+	mpg123_text    *comment_list; /**< Array of comments. */
+	size_t          comments;     /**< Number of comments. */
+	mpg123_text    *text;         /**< Array of ID3v2 text fields (including USLT) */
+	size_t          texts;        /**< Numer of text fields. */
+	mpg123_text    *extra;        /**< The array of extra (TXXX) fields. */
+	size_t          extras;       /**< Number of extra text (TXXX) fields. */
+	mpg123_picture  *picture;     /**< Array of ID3v2 pictures fields (APIC).
+		Only populated if MPG123_PICTURE flag is set! */
+	size_t           pictures;    /**< Number of picture (APIC) fields. */
+} mpg123_id3v2;
+
+/** Data structure for ID3v1 tags (the last 128 bytes of a file).
+ *  Don't take anything for granted (like string termination)!
+ *  Also note the change ID3v1.1 did: comment[28] = 0; comment[29] = track_number
+ *  It is your task to support ID3v1 only or ID3v1.1 ...*/
+typedef struct
+{
+	char tag[3];         /**< Always the string "TAG", the classic intro. */
+	char title[30];      /**< Title string.  */
+	char artist[30];     /**< Artist string. */
+	char album[30];      /**< Album string. */
+	char year[4];        /**< Year string. */
+	char comment[30];    /**< Comment string. */
+	unsigned char genre; /**< Genre index. */
+} mpg123_id3v1;
+
+#define MPG123_ID3     0x3 /**< 0011 There is some ID3 info. Also matches 0010 or NEW_ID3. */
+#define MPG123_NEW_ID3 0x1 /**< 0001 There is ID3 info that changed since last call to mpg123_id3. */
+#define MPG123_ICY     0xc /**< 1100 There is some ICY info. Also matches 0100 or NEW_ICY.*/
+#define MPG123_NEW_ICY 0x4 /**< 0100 There is ICY info that changed since last call to mpg123_icy. */
+
+/** Query if there is (new) meta info, be it ID3 or ICY (or something new in future).
+ *  \param mh handle
+ *  \return combination of flags, 0 on error (same as "nothing new")
+ */
+MPG123_EXPORT int mpg123_meta_check(mpg123_handle *mh);
+
+/** Clean up meta data storage (ID3v2 and ICY), freeing memory.
+ *  \param mh handle
+ */
+MPG123_EXPORT void mpg123_meta_free(mpg123_handle *mh);
+
+/** Point v1 and v2 to existing data structures wich may change on any next read/decode function call.
+ *  v1 and/or v2 can be set to NULL when there is no corresponding data.
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_id3( mpg123_handle *mh
+,	mpg123_id3v1 **v1, mpg123_id3v2 **v2 );
+
+/** Return pointers to and size of stored raw ID3 data if storage has
+ *  been configured with MPG123_STORE_RAW_ID3 and stream parsing passed the
+ *  metadata already. Null value with zero size is a possibility!
+ *  The storage can change at any next API call.
+ *
+ *  \param mh mpg123 handle
+ *  \param v1 address to store pointer to v1 tag
+ *  \param v1_size size of v1 data in bytes
+ *  \param v2 address to store pointer to v2 tag
+ *  \param v2_size size of v2 data in bytes
+ *  \return MPG123_OK or MPG123_ERR. Only on MPG123_OK the output
+ *          values are set.
+ */
+MPG123_EXPORT int mpg123_id3_raw( mpg123_handle *mh
+,	unsigned char **v1, size_t *v1_size
+,	unsigned char **v2, size_t *v2_size );
+
+/** Point icy_meta to existing data structure wich may change on any next read/decode function call.
+ *  \param mh handle
+ *  \param icy_meta return address for ICY meta string (set to NULL if nothing there)
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_icy(mpg123_handle *mh, char **icy_meta);
+
+/** Decode from windows-1252 (the encoding ICY metainfo used) to UTF-8.
+ *  Note that this is very similar to mpg123_store_utf8(&sb, mpg123_text_icy, icy_text, strlen(icy_text+1)) .
+ *  \param icy_text The input data in ICY encoding
+ *  \return pointer to newly allocated buffer with UTF-8 data (You free() it!) */
+MPG123_EXPORT char* mpg123_icy2utf8(const char* icy_text);
+
+
+/** @} */
+
+
+/** \defgroup mpg123_advpar mpg123 advanced parameter API
+ *
+ *  Direct access to a parameter set without full handle around it.
+ *	Possible uses:
+ *    - Influence behaviour of library _during_ initialization of handle (MPG123_VERBOSE).
+ *    - Use one set of parameters for multiple handles.
+ *
+ *	The functions for handling mpg123_pars (mpg123_par() and mpg123_fmt() 
+ *  family) directly return a fully qualified mpg123 error code, the ones 
+ *  operating on full handles normally MPG123_OK or MPG123_ERR, storing the 
+ *  specific error code itseld inside the handle. 
+ *
+ * @{
+ */
+
+/** Opaque structure for the libmpg123 decoder parameters. */
+struct mpg123_pars_struct;
+
+/** Opaque structure for the libmpg123 decoder parameters. */
+typedef struct mpg123_pars_struct   mpg123_pars;
+
+/** Create a handle with preset parameters.
+ *  \param mp parameter handle
+ *  \param decoder decoder choice
+ *  \param error error code return address
+ *  \return mpg123 handle
+ */
+MPG123_EXPORT mpg123_handle *mpg123_parnew( mpg123_pars *mp
+,	const char* decoder, int *error );
+
+/** Allocate memory for and return a pointer to a new mpg123_pars
+ *  \param error error code return address
+ *  \return new parameter handle
+ */
+MPG123_EXPORT mpg123_pars *mpg123_new_pars(int *error);
+
+/** Delete and free up memory used by a mpg123_pars data structure
+ *  \param mp parameter handle
+ */
+MPG123_EXPORT void mpg123_delete_pars(mpg123_pars* mp);
+
+/** Configure mpg123 parameters to accept no output format at all, 
+ *  use before specifying supported formats with mpg123_format
+ *  \param mp parameter handle
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_fmt_none(mpg123_pars *mp);
+
+/** Configure mpg123 parameters to accept all formats 
+ *  (also any custom rate you may set) -- this is default. 
+ *  \param mp parameter handle
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_fmt_all(mpg123_pars *mp);
+
+/** Set the audio format support of a mpg123_pars in detail:
+ * \param mp parameter handle
+ * \param rate The sample rate value (in Hertz).
+ * \param channels A combination of MPG123_STEREO and MPG123_MONO.
+ * \param encodings A combination of accepted encodings for rate and channels,
+ *                  p.ex MPG123_ENC_SIGNED16|MPG123_ENC_ULAW_8 (or 0 for no
+ *                  support).
+ * \return MPG123_OK on success
+*/
+MPG123_EXPORT int mpg123_fmt(mpg123_pars *mp
+,	long rate, int channels, int encodings);
+
+/** Set the audio format support of a mpg123_pars in detail:
+ * \param mp parameter handle
+ * \param rate The sample rate value (in Hertz). Special value 0 means
+ *             all rates (reason for this variant of mpg123_fmt).
+ * \param channels A combination of MPG123_STEREO and MPG123_MONO.
+ * \param encodings A combination of accepted encodings for rate and channels,
+ *                  p.ex MPG123_ENC_SIGNED16|MPG123_ENC_ULAW_8 (or 0 for no
+ *                  support).
+ * \return MPG123_OK on success
+*/
+MPG123_EXPORT int mpg123_fmt2(mpg123_pars *mp
+,	long rate, int channels, int encodings);
+
+/** Check to see if a specific format at a specific rate is supported
+ *  by mpg123_pars.
+ *  \param mp parameter handle
+ *  \param rate sampling rate
+ *  \param encoding encoding
+ *  \return 0 for no support (that includes invalid parameters), MPG123_STEREO, 
+ *          MPG123_MONO or MPG123_STEREO|MPG123_MONO. */
+MPG123_EXPORT int mpg123_fmt_support(mpg123_pars *mp, long rate, int encoding);
+
+#ifdef MPG123_ENUM_API
+/** Set a specific parameter in a par handle.
+ *
+ *  Note that this name is mapped to mpg123_par2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  \param mp parameter handle
+ *  \param type parameter choice
+ *  \param value integer value
+ *  \param fvalue floating point value
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_par( mpg123_pars *mp
+,	enum mpg123_parms type, long value, double fvalue );
+#endif
+
+/** Set a specific parameter in a par handle. No enums.
+ *
+ *  This is actually called instead of mpg123_par()
+ *  unless MPG123_ENUM_API is defined.
+ *
+ *  \param mp parameter handle
+ *  \param type parameter choice (enum mpg123_parms)
+ *  \param value integer value
+ *  \param fvalue floating point value
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_par2( mpg123_pars *mp
+,	int type, long value, double fvalue );
+
+#ifdef MPG123_ENUM_API
+/** Get a specific parameter from a par handle.
+ *
+ *  Note that this name is mapped to mpg123_getpar2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  \param mp parameter handle
+ *  \param type parameter choice
+ *  \param value integer value return address
+ *  \param fvalue floating point value return address
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_getpar( mpg123_pars *mp
+,	enum mpg123_parms type, long *value, double *fvalue );
+#endif
+
+/** Get a specific parameter from a par handle. No enums.
+ *
+ *  This is actually called instead of mpg123_getpar()
+ *  unless MPG123_ENUM_API is defined.
+ *
+ *  \param mp parameter handle
+ *  \param type parameter choice (enum mpg123_parms)
+ *  \param value integer value return address
+ *  \param fvalue floating point value return address
+ *  \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_getpar2( mpg123_pars *mp
+,	int type, long *value, double *fvalue );
+
+/** @} */
+
+
+/** \defgroup mpg123_lowio mpg123 low level I/O
+  * You may want to do tricky stuff with I/O that does not work with mpg123's default file access or you want to make it decode into your own pocket...
+  *
+  * @{ */
+
+/** Replace default internal buffer with user-supplied buffer.
+  * Instead of working on it's own private buffer, mpg123 will directly use the one you provide for storing decoded audio.
+  * Note that the required buffer size could be bigger than expected from output
+  * encoding if libmpg123 has to convert from primary decoder output (p.ex. 32 bit
+  * storage for 24 bit output).
+  *
+  *  Note: The type of data changed to a void pointer in mpg123 1.26.0
+  *  (API version 45).
+  *
+  * \param mh handle
+  * \param data pointer to user buffer
+  * \param size of buffer in bytes
+  * \return MPG123_OK on success
+  */
+MPG123_EXPORT int mpg123_replace_buffer(mpg123_handle *mh
+,	void *data, size_t size);
+
+/** The max size of one frame's decoded output with current settings.
+ *  Use that to determine an appropriate minimum buffer size for decoding one frame.
+ *  \param mh handle
+ *  \return maximum decoded data size in bytes
+ */
+MPG123_EXPORT size_t mpg123_outblock(mpg123_handle *mh);
+
+#ifndef MPG123_PORTABLE_API
+/** Replace low-level stream access functions; read and lseek as known in POSIX.
+ *  You can use this to make any fancy file opening/closing yourself, 
+ *  using mpg123_open_fd() to set the file descriptor for your read/lseek
+ *  (doesn't need to be a "real" file descriptor...).
+ *  Setting a function to NULL means that just a call to POSIX read/lseek is
+ *  done (without handling signals).
+ *  Note: As it would be troublesome to mess with this while having a file open,
+ *  this implies mpg123_close().
+ * \param mh handle
+ * \param r_read callback for reading (behaviour like POSIX read)
+ * \param r_lseek callback for seeking (like POSIX lseek)
+ * \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_replace_reader( mpg123_handle *mh
+,	mpg123_ssize_t (*r_read) (int, void *, size_t)
+,	off_t (*r_lseek)(int, off_t, int)
+);
+
+/** Replace I/O functions with your own ones operating on some kind of
+ *  handle instead of integer descriptors.
+ *  The handle is a void pointer, so you can pass any data you want...
+ *  mpg123_open_handle() is the call you make to use the I/O defined here.
+ *  There is no fallback to internal read/seek here.
+ *  Note: As it would be troublesome to mess with this while having a file open,
+ *  this mpg123_close() is implied here.
+ *  \param mh handle
+ *  \param r_read callback for reading (behaviour like POSIX read)
+ *  \param r_lseek callback for seeking (like POSIX lseek)
+ *  \param cleanup A callback to clean up a non-NULL I/O handle on mpg123_close,
+ *         can be NULL for none (you take care of cleaning your handles).
+ * \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_replace_reader_handle( mpg123_handle *mh
+,	mpg123_ssize_t (*r_read) (void *, void *, size_t)
+,	off_t (*r_lseek)(void *, off_t, int)
+,	void (*cleanup)(void*) );
+#endif
+
+/** Set up portable read functions on an opaque handle.
+ *  The handle is a void pointer, so you can pass any data you want...
+ *  mpg123_open64() (since API 49) or mpg123_open_handle() is the call you make
+ *  to use the I/O defined here.
+ *  There is no fallback to internal read/seek here.
+ *  Note: As it would be troublesome to mess with this while having a file open,
+ *  this mpg123_close() is implied here.
+ *  \param mh handle
+ *  \param r_read callback for reading
+ *     The parameters are the handle, the buffer to read into, a byte count to read,
+ *     address to store the returned byte count. Return value is zero for
+ *     no issue, non-zero for some error. Recoverable signal handling has to happen
+ *     inside the callback.
+ *  \param r_lseek callback for seeking (like POSIX lseek), maybe NULL for
+ *         non-seekable streams
+ *  \param cleanup A callback to clean up a non-NULL I/O handle on mpg123_close,
+ *         maybe NULL for none
+ * \return MPG123_OK on success
+ */
+MPG123_EXPORT int mpg123_reader64( mpg123_handle *mh, int (*r_read) (void *, void *, size_t, size_t *), int64_t (*r_lseek)(void *, int64_t, int), void (*cleanup)(void*) );
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/deps/mpg123/include/out123.h
+++ b/deps/mpg123/include/out123.h
@@ -1,0 +1,751 @@
+/*
+	out123: audio output interface
+
+	copyright 1995-2016 by the mpg123 project,
+	free software under the terms of the LGPL 2.1
+
+	see COPYING and AUTHORS files in distribution or http://mpg123.org
+	initially written as audio.h by Michael Hipp, reworked into out123 API
+	by Thomas Orgis
+*/
+
+#ifndef _OUT123_H_
+#define _OUT123_H_
+
+/** \file out123.h The header file for the libout123 audio output facility. */
+
+/** A macro to check at compile time which set of API functions to expect.
+ * This must be incremented at least each time a new symbol is added
+ * to the header.
+ */
+#define OUT123_API_VERSION 5
+/** library patch level at client build time */
+#define OUT123_PATCHLEVEL  2
+
+/* We only need size_t definition. */
+#include <stddef.h>
+
+/* Common audio encoding specification, including a macro for getting
+ *  size of encoded samples in bytes. Said macro is still hardcoded
+ *  into out123_encsize(). Relying on this one may help an old program
+ *  know sizes of encodings added to fmt123.h later on.
+ *  If you don't care, just use the macro.
+ */
+#include "fmt123.h"
+
+#ifndef MPG123_EXPORT
+/** Defines needed for MS Visual Studio(tm) DLL builds.
+ * Every public function must be prefixed with MPG123_EXPORT. When building 
+ * the DLL ensure to define BUILD_MPG123_DLL. This makes the function accessible
+ * for clients and includes it in the import library which is created together
+ * with the DLL. When consuming the DLL ensure to define LINK_MPG123_DLL which
+ * imports the functions from the DLL. 
+ */
+#ifdef BUILD_MPG123_DLL
+/* The dll exports. */
+#define MPG123_EXPORT __declspec(dllexport)
+#else
+#ifdef LINK_MPG123_DLL
+/* The exe imports. */
+#define MPG123_EXPORT __declspec(dllimport)
+#else
+/* Nothing on normal/UNIX builds */
+#define MPG123_EXPORT
+#endif
+#endif
+#endif
+
+/* Earlier versions of libout123 put enums into public API calls,
+ * thich is not exactly safe. There are ABI rules, but you can use
+ * compiler switches to change the sizes of enums. It is safer not
+ * to have them in API calls. Thus, the default is to remap calls and
+ * structs to variants that use plain ints. Define MPG123_ENUM_API to
+ * prevent that remapping.
+ *
+ * You might want to define this to increase the chance of your binary
+ * working with an older version of the library. But if that is your goal,
+ * you should better build with an older version to begin with.
+ */
+#ifndef MPG123_ENUM_API
+
+#define out123_param    out123_param2
+#define out123_getparam out123_getparam2
+
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \defgroup out123_api out123 library API
+ *  This is out123, a library focused on continuous playback of audio streams
+ *  via various platform-specific output methods. It glosses over details of
+ *  the native APIs to give an interface close to simply writing data to a
+ *  file. There might be the option to tune details like buffer (period) sizes
+ *  and the number of them on the device side in future, but the focus of the
+ *  library is to ease the use case of just getting that raw audio data out
+ *  there, without interruptions.
+ *
+ *  The basic idea is to create a handle with out123_new() and open a certain
+ *  output device (using a certain driver module, possibly build-time defaults)
+ *  with out123_open(). Now, you can query the output device for supported
+ *  encodings for given rate and channel count with out123_get_encodings() and
+ *  decide what to use for actually starting playback with out123_start().
+ *
+ *  Then, you just need to provide (interleaved pcm) data for playback with
+ *  out123_play(), which will block when the device's buffers are full. You get
+ *  your timing from that (instead of callbacks). If your program does the
+ *  production of the audio data just a little bit faster than the playback,
+ *  causing out123_play() to block ever so briefly, you're fine.
+ *
+ *  You stop playback with out123_stop(), or just close the device and driver
+ *  via out123_close(), or even just decide to drop it all and do out123_del()
+ *  right away when you're done.
+ *
+ *  There are other functions for specific needs, but the basic idea should be
+ *  covered by the above.
+ *
+ *  Note that the driver modules that bind to the operating system API for
+ *  output might impose restrictions on what you can safely do regarding your
+ *  out123_handle and multiple threads or processes. You should be on the safe
+ *  side ensuring that you confine usage of a handle to a single thread instead
+ *  of passing it around.
+ @{
+ */
+
+/** Opaque structure for the libout123 handle. */
+struct out123_struct;
+/** Typedef shortcut as preferrend name for the handle type. */
+typedef struct out123_struct out123_handle;
+
+/** Get version of the mpg123 distribution this library build came with.
+ * (optional means non-NULL)
+ * \param major optional address to store major version number
+ * \param minor optional address to store minor version number
+ * \param patch optional address to store patchlevel version number
+ * \return full version string (like "1.2.3-beta4 (experimental)")
+ */
+MPG123_EXPORT
+const char *out123_distversion(unsigned int *major, unsigned int *minor, unsigned int *patch);
+
+/** Get API version of library build.
+ * \param patch optional address to store patchlevel
+ * \return API version of library
+ */
+MPG123_EXPORT
+unsigned int out123_libversion(unsigned int *patch);
+
+/** Enumeration of codes for the parameters that it is possible to set/get. */
+enum out123_parms
+{
+	OUT123_FLAGS = 1 /**< integer, various flags, see enum #out123_flags */
+,	OUT123_PRELOAD /**< float, fraction of buffer to fill before playback */
+,	OUT123_GAIN    /**< integer, output device gain (module-specific) */
+,	OUT123_VERBOSE /**< integer, verbosity to stderr, >= 0 */
+,	OUT123_DEVICEBUFFER /**<
+ *  float, length of device buffer in seconds;
+ *  This might be ignored, might have only a loose relation to actual
+ *  buffer sizes and latency, depending on output driver. Try to tune
+ *  this before opening a device if you want to influcence latency or reduce
+ *  dropouts. Value <= 0 uses some default, usually favouring stable playback
+ *  over low latency. Values above 0.5 are probably too much.
+ */
+,	OUT123_PROPFLAGS /**< integer, query driver/device property flags (r/o) */
+,	OUT123_NAME /**< string, name of this instance (NULL restores default);
+ * The value returned by out123_getparam() might be different if the audio
+ * backend changed it (to be unique among clients, p.ex.).
+ * TODO: The name provided here is used as prefix in diagnostic messages. */
+,	OUT123_BINDIR /**< string, path to a program binary directory to use
+ * as starting point in the search for the output module directory
+ * (e.g. ../lib/mpg123 or ./plugins). The environment variable MPG123_MODDIR
+ * is always tried first and the in-built installation path last.
+ */
+,	OUT123_ADD_FLAGS /**< enable given flags */
+,	OUT123_REMOVE_FLAGS /**< disable diven flags */
+};
+
+/** Flags to tune out123 behaviour */
+enum out123_flags
+{
+	OUT123_HEADPHONES       = 0x01 /**< output to headphones (if supported) */
+,	OUT123_INTERNAL_SPEAKER = 0x02 /**< output to speaker (if supported) */
+,	OUT123_LINE_OUT         = 0x04 /**< output to line out (if supported) */
+,	OUT123_QUIET            = 0x08 /**< no printouts to standard error */
+,	OUT123_KEEP_PLAYING     = 0x10 /**<
+ *  When this is set (default), playback continues in a loop when the device
+ *  does not consume all given data at once. This happens when encountering
+ *  signals (like SIGSTOP, SIGCONT) that cause interruption of the underlying
+ *  functions.
+ *  Note that this flag is meaningless when the optional buffer is employed,
+ *  There, your program will always block until the buffer completely took
+ *  over the data given to it via out123_play(), unless a communication error
+ *  arises.
+ */
+,	OUT123_MUTE             = 0x20 /**< software mute (play silent audio) */
+};
+
+/** Read-only output driver/device property flags (OUT123_PROPFLAGS). */
+enum out123_propflags
+{
+	OUT123_PROP_LIVE = 0x01 /**< This is a live output, meaning that
+ *  special care might be needed for pauses in playback (p.ex. stream
+ *  of silence instead of interruption), as opposed to files on disk.
+ */
+,	OUT123_PROP_PERSISTENT = 0x02 /**< This (live) output does not need
+ *  special care for pauses (continues with silence itself),
+ *  out123_pause() does nothing to the device.
+ */
+};
+
+/** Create a new output handle.
+ *  This only allocates and initializes memory, so the only possible
+ *  error condition is running out of memory.
+ * \return pointer to new handle or NULL on error
+ */
+MPG123_EXPORT
+out123_handle *out123_new(void);
+
+/** Delete output handle.
+ *  This implies out123_close().
+ */
+MPG123_EXPORT
+void out123_del(out123_handle *ao);
+
+/** Free plain memory allocated within libout123.
+ *  This is for library users that are not sure to use the same underlying
+ *  memory allocator as libout123. It is just a wrapper over free() in
+ *  the underlying C library.
+ */
+MPG123_EXPORT void out123_free(void *ptr);
+
+/** Error code enumeration
+ * API calls return a useful (positve) value or zero (OUT123_OK) on simple
+ * success. A negative value (-1 == OUT123_ERR) usually indicates that some
+ * error occured. Which one, that can be queried using out123_errcode()
+ * and friends.
+ */
+enum out123_error
+{
+	OUT123_ERR = -1 /**< generic alias for verbosity, always == -1 */
+,	OUT123_OK  = 0  /**< just a name for zero, not going to change */
+,	OUT123_DOOM /**< dazzled, out of memory */
+,	OUT123_BAD_DRIVER_NAME /**< bad driver name given */
+,	OUT123_BAD_DRIVER /**< unspecified issue loading a driver */
+,	OUT123_NO_DRIVER /**< no driver loaded */
+,	OUT123_NOT_LIVE /**< no active audio device */
+,	OUT123_DEV_PLAY /**< some device playback error */
+,	OUT123_DEV_OPEN /**< error opening device */
+,	OUT123_BUFFER_ERROR /**<
+ * Some (really unexpected) error in buffer infrastructure.
+ */
+,	OUT123_MODULE_ERROR /**< basic failure in module loading */
+,	OUT123_ARG_ERROR /**< some bad function arguments supplied */
+,	OUT123_BAD_PARAM /**< unknown parameter code */
+,	OUT123_SET_RO_PARAM /**< attempt to set read-only parameter */
+,	OUT123_BAD_HANDLE /**< bad handle pointer (NULL, usually) */
+,	OUT123_NOT_SUPPORTED /**< some requested operation is not supported (right now) */
+,	OUT123_DEV_ENUMERATE /**< device enumeration itself failed */
+,	OUT123_ERRCOUNT /**< placeholder for shaping arrays */
+};
+
+/** Get string representation of last encountered error in the
+ *  context of given handle.
+ * \param ao handle
+ * \return error string
+ */
+MPG123_EXPORT
+const char* out123_strerror(out123_handle *ao);
+
+/** Get the plain errcode intead of a string.
+ * Note that this used to return OUT123_ERR instead of
+ * OUT123_BAD_HANDLE in case of ao==NULL before mpg123-1.23.5 .
+ * \param ao handle
+ * \return error code recorded in handle or OUT123_BAD_HANDLE
+ */
+MPG123_EXPORT
+int out123_errcode(out123_handle *ao);
+
+/** Return the error string for a given error code.
+ * \param errcode the integer error code
+ * \return error string
+ */
+MPG123_EXPORT
+const char* out123_plain_strerror(int errcode);
+
+/** Set a desired output buffer size.
+ *  This starts a separate process that handles the audio output, decoupling
+ *  the latter from the main process with a memory buffer and saving you the
+ *  burden to ensure sparing CPU cycles for actual playback.
+ *  This is for applicatons that prefer continuous playback over small latency.
+ *  In other words: The kind of applications that out123 is designed for.
+ *  This routine always kills off any currently active audio output module /
+ *  device, even if you just disable the buffer when there is no buffer.
+ *
+ *  Keep this in mind for memory-constrainted systems: Activating the
+ *  buffer causes a fork of the calling process, doubling the virtual memory
+ *  use. Depending on your operating system kernel's behaviour regarding
+ *  memory overcommit, it might be wise to call out123_set_buffer() very
+ *  early in your program before allocating lots of memory.
+ *
+ *  There _might_ be a change to threads in future, but for now this is
+ *  classic fork with shared memory, working without any threading library.
+ *  If your platform or build does not support that, you will always get an
+ *  error on trying to set up a non-zero buffer (but the API call will be
+ *  present).
+ *
+ *  Also, if you do intend to use this from a multithreaded program, think
+ *  twice and make sure that your setup is happy with forking full-blown
+ *  processes off threaded programs. Probably you are better off spawning a
+ *  buffer thread yourself.
+ *
+ * \param ao handle
+ * \param buffer_bytes size (bytes) of a memory buffer for decoded audio,
+ *    a value of zero disables the buffer.
+ * \return 0 on success, OUT123_ERR on error
+ */
+MPG123_EXPORT
+int out123_set_buffer(out123_handle *ao, size_t buffer_bytes);
+
+#ifdef MPG123_ENUM_API
+/** Set a parameter on a out123_handle.
+ *
+ *  Note that this name is mapped to out123_param2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ *  The parameters usually only change what happens on next out123_open, not
+ *  incfluencing running operation. There are macros To ease the API a bit:
+ *  You can call out123_param_int(ao, code, value) for integer (long) values,
+ *  same with out123_param_float() and out123_param_string().
+ *
+ * \param ao handle
+ * \param code parameter code
+ * \param value input value for integer parameters
+ * \param fvalue input value for floating point parameters
+ * \param svalue input value for string parameters (contens are copied)
+ * \return 0 on success, OUT123_ERR on error.
+ */
+MPG123_EXPORT
+int out123_param( out123_handle *ao, enum out123_parms code
+,                 long value, double fvalue, const char *svalue );
+#endif
+
+/** Set a parameter on a out123_handle. No enum.
+ *
+ *  This is actually called instead of out123_param()
+ *  unless MPG123_ENUM_API is defined.
+ *
+ *  The parameters usually only change what happens on next out123_open, not
+ *  incfluencing running operation. There are macros To ease the API a bit:
+ *  You can call out123_param_int(ao, code, value) for integer (long) values,
+ *  same with out123_param_float() and out123_param_string().
+ *
+ * \param ao handle
+ * \param code parameter code (from enum #out123_parms)
+ * \param value input value for integer parameters
+ * \param fvalue input value for floating point parameters
+ * \param svalue input value for string parameters (contens are copied)
+ * \return 0 on success, OUT123_ERR on error.
+ */
+MPG123_EXPORT
+int out123_param2( out123_handle *ao, int code
+,                 long value, double fvalue, const char *svalue );
+
+
+/** Shortcut for out123_param() to set an integer parameter. */
+#define out123_param_int(ao, code, value) \
+	out123_param((ao), (code), (value), 0., NULL)
+/** Shortcut for out123_param() to set a float parameter. */
+#define out123_param_float(ao, code, value) \
+	out123_param((ao), (code), 0, (value), NULL)
+/** Shortcut for out123_param() to set an string parameter. */
+#define out123_param_string(ao, code, value) \
+	out123_param((ao), (code), 0, 0., (value))
+
+#ifdef MPG123_ENUM_API
+/** Get a parameter from an out123_handle.
+ *
+ *  Note that this name is mapped to out123_param2() instead unless
+ *  MPG123_ENUM_API is defined.
+ *
+ * \param ao handle
+ * \param code parameter code
+ * \param ret_value output address for integer parameters
+ * \param ret_fvalue output address for floating point parameters
+ * \param ret_svalue output address for string parameters (pointer to
+ *        internal memory, so no messing around, please)
+ * \return 0 on success, OUT123_ERR on error (bad parameter name or bad handle).
+ */
+MPG123_EXPORT
+int out123_getparam( out123_handle *ao, enum out123_parms code
+,                    long *ret_value, double *ret_fvalue, char* *ret_svalue );
+#endif
+
+/** Get a parameter from an out123_handle. No enum.
+ *
+ *  This is actually called instead of out123_getparam()
+ *  unless MPG123_ENUM_API is defined.
+ *
+ * \param ao handle
+ * \param code parameter code (from enum #out123_parms)
+ * \param ret_value output address for integer parameters
+ * \param ret_fvalue output address for floating point parameters
+ * \param ret_svalue output address for string parameters (pointer to
+ *        internal memory, so no messing around, please)
+ * \return 0 on success, OUT123_ERR on error (bad parameter name or bad handle).
+ */
+MPG123_EXPORT
+int out123_getparam2( out123_handle *ao, int code
+,                    long *ret_value, double *ret_fvalue, char* *ret_svalue );
+
+/** Shortcut for out123_getparam() to get an integer parameter. */
+#define out123_getparam_int(ao, code, value) \
+	out123_getparam((ao), (code), (value), NULL, NULL)
+/** Shortcut for out123_getparam() to get a float parameter. */
+#define out123_getparam_float(ao, code, value) \
+	out123_getparam((ao), (code), NULL, (value), NULL)
+/** Shortcut for out123_getparam() to get a string parameter. */
+#define out123_getparam_string(ao, code, value) \
+	out123_getparam((ao), (code), NULL, NULL, (value))
+
+/** Copy parameters from another out123_handle.
+ * \param ao handle
+ * \param from_ao the handle to copy parameters from
+ * \return 0 in success, -1 on error
+ */
+MPG123_EXPORT
+int out123_param_from(out123_handle *ao, out123_handle* from_ao);
+
+/** Get list of driver modules reachable in system in C argv-style format.
+ *
+ *  The client is responsible for freeing the memory of both the individual
+ *  strings and the lists themselves.  There is out123_stringlists_free()
+ *  to assist.
+ *
+ *  A module that is not loadable because of missing libraries is simply
+ *  skipped. You will get stderr messages about that unless OUT123_QUIET was
+ *  was set, though. Failure to open the module directory is a serious error,
+ *  resulting in negative return value.
+ *
+ * \param ao handle
+ * \param names address for storing list of names
+ * \param descr address for storing list of descriptions
+ * \return number of drivers found, -1 on error
+ */
+MPG123_EXPORT
+int out123_drivers(out123_handle *ao, char ***names, char ***descr);
+
+/** Get a list of available output devices for a given driver.
+ *
+ *  If the driver supports enumeration, you can get a listing of possible
+ *  output devices. If this list is exhaustive, depends on the driver.
+ *  Note that this implies out123_close(). When you have a device already
+ *  open, you don't need to look for one anymore. If you really do, just
+ *  create another handle.
+ *
+ *  Your provided pointers are only used for non-negative return values.
+ *  In this case, you are responsible for freeing the associated memory of
+ *  the strings and the lists themselves. The format of the lists is an
+ *  array of char pointers, with the returned count just like the usual
+ *  C argv and argc. There is out123_stringlists_free() to assist.
+ *
+ *  Note: Calling this on a handle with a configured buffer process will
+ *  yield #OUT123_NOT_SUPPORTED.
+ *
+ * \param ao handle
+ * \param driver driver name or comma-separated list of names
+ *   to try, just like for out123_open(), possibly NULL for some default
+ * \param names address for storing list of names
+ * \param descr address for storing list of descriptions
+ * \param active_driver address for storing a copy of the actually active
+ *    driver name (in case you gave a list or NULL as driver), can be NULL
+ *    if not interesting
+ * \return count of devices or #OUT123_ERR if some error was encountered,
+ *   possibly just #OUT123_NOT_SUPPORTED if the driver lacks enumeration support
+ */
+MPG123_EXPORT
+int out123_devices( out123_handle *ao, const char *driver
+,	char ***names, char ***descr, char **active_driver );
+
+/** Helper to free string list memory.
+ *
+ *  This aids in freeing the memory allocated by out123_devices() and
+ *  out123_drivers().
+ *
+ *  Any of the given lists can be NULL and nothing will happen to it.
+ *
+ * \param name first string list
+ * \param descr second string list
+ * \param count count of strings
+ */
+MPG123_EXPORT
+void out123_stringlists_free(char **name, char **descr, int count);
+
+
+/** Open an output device with a certain driver
+ *  Note: Opening means that the driver code is loaded and the desired
+ *  device name recorded, possibly tested for availability or tentatively
+ *  opened. After out123_open(), you can ask for supported encodings
+ *  and then really open the device for playback with out123_start().
+ * \param ao handle
+ * \param driver (comma-separated list of) output driver name(s to try),
+ *               NULL for default
+ * \param device device name to open, NULL for default 
+ *               (stdout for file-based drivers)
+ * \return 0 on success, -1 on error.
+ */
+MPG123_EXPORT
+int out123_open(out123_handle *ao, const char* driver, const char* device);
+
+/** Give info about currently loaded driver and device
+ *  Any of the return addresses can be NULL if you are not interested in
+ *  everything. You get pointers to internal storage. They are valid
+ *  as long as the driver/device combination is opened.
+ *  The device may be NULL indicating some unnamed default.
+ *  TODO: Make the driver modules return names for such defaults.
+ * \param ao handle
+ * \param driver return address for driver name
+ * \param device return address for device name
+ * \return 0 on success, -1 on error (i.e. no driver loaded)
+ */
+MPG123_EXPORT
+int out123_driver_info(out123_handle *ao, char **driver, char **device);
+
+/** Close the current output device and driver.
+ *  This implies out123_drain() to ensure no data is lost.
+ *  With a buffer, that might cause considerable delay during
+ *  which your main application is blocked waiting.
+ *  Call out123_drop() beforehand if you want to end things
+ *  quickly.
+ * \param ao handle
+ */
+MPG123_EXPORT
+void out123_close(out123_handle *ao);
+
+/** Get supported audio encodings for given rate and channel count,
+ *  for the currently openend audio device.
+ *  Usually, a wider range of rates is supported, but the number
+ *  of sample encodings is limited, as is the number of channels.
+ *  So you can call this with some standard rate and hope that the
+ *  returned encodings work also for others, with the tested channel
+ *  count.
+ *  The return value of -1 on some encountered error conveniently also
+ *  does not match any defined format (only 15 bits used for encodings,
+ *  so this would even work with 16 bit integers).
+ *  This implies out123_stop() to enter query mode.
+ * \param ao handle
+ * \param rate sampling rate
+ * \param channels number of channels
+ * \return supported encodings combined with bitwise or, to be checked
+ *         against your favourite bitmask, -1 on error
+ */
+MPG123_EXPORT
+int out123_encodings(out123_handle *ao, long rate, int channels);
+
+/** Return the size (in bytes) of one mono sample of the named encoding.
+ * \param encoding The encoding value to analyze.
+ * \return positive size of encoding in bytes, 0 on invalid encoding. */
+MPG123_EXPORT int out123_encsize(int encoding);
+
+/** Get list of supported formats for currently opened audio device.
+ *  Given a list of sampling rates and minimal/maximal channel count,
+ *  this quickly checks what formats are supported with these
+ *  constraints. The first entry is always reserved for a default
+ *  format for the output device. If there is no such default,
+ *  all values of the format are -1.
+ *  For each requested combination of rate and channels, a format entry is
+ *  created, possible with encoding value 0 to indicate that this combination
+ *  has been tested and rejected. So, when there is no basic error, the
+ *  number of returned format entries should be
+ *     (ratecount*(maxchannels-minchannels+1)+1)
+ *  . But instead of forcing you to guess, this will be allocated by
+ *  successful run.
+ *  For the first entry, the encoding member is supposed to be a definite
+ *  encoding, for the others it is a bitwise combination of all possible
+ *  encodings.
+ *  This function is more efficient than many calls to out123_encodings().
+ * \param ao handle
+ * \param rates pointer to an array of sampling rates, may be NULL for none
+ * \param ratecount number of provided sampling rates
+ * \param minchannels minimal channel count
+ * \param maxchannels maximal channel count
+ * \param fmtlist return address for array of supported formats
+ *        the encoding field of each entry is a combination of all
+ *        supported encodings at this rate and channel count;
+ *        Memory shall be freed by user.
+ * \return number of returned format enries, -1 on error
+ */
+MPG123_EXPORT
+int out123_formats( out123_handle *ao, const long *rates, int ratecount
+                  , int minchannels, int maxchannels
+                  , struct mpg123_fmt **fmtlist );
+
+/** Get list of encodings known to the library.
+ *  You are responsible for freeing the allocated array.
+ * \param enclist return address for allocated array of encoding codes
+ * \return number of encodings, -1 on error
+ */
+MPG123_EXPORT
+int out123_enc_list(int **enclist);
+
+/** Find encoding code by name.
+ * \param name short or long name to find encoding code for
+ * \return encoding if found (enum #mpg123_enc_enum), else 0
+ */
+MPG123_EXPORT
+int out123_enc_byname(const char *name);
+
+/** Get name of encoding.
+ * \param encoding code (enum #mpg123_enc_enum)
+ * \return short name for valid encodings, NULL otherwise
+ */
+MPG123_EXPORT
+const char* out123_enc_name(int encoding);
+
+/** Get long name of encoding.
+ * \param encoding code (enum #mpg123_enc_enum)
+ * \return long name for valid encodings, NULL otherwise
+ */
+MPG123_EXPORT
+const char* out123_enc_longname(int encoding);
+
+/** Start playback with a certain output format
+ *  It might be a good idea to have audio data handy to feed after this
+ *  returns with success.
+ *  Rationale for not taking a pointer to struct mpg123_fmt: This would
+ *  always force you to deal with that type and needlessly enlarge the
+ *  shortest possible program.
+ * \param ao handle
+ * \param encoding sample encoding (values matching libmpg123 API)
+ * \param channels number of channels (1 or 2, usually)
+ * \param rate sampling rate
+ * \return 0 on success, negative on error (bad format, usually)
+ */
+MPG123_EXPORT
+int out123_start( out123_handle *ao
+,                 long rate, int channels, int encoding );
+
+/** Pause playback
+ *  Interrupt playback, holding any data in the optional buffer.
+ *
+ *  This closes the audio device if it is a live sink, ready to be re-opened
+ *  by out123_continue() or out123_play() with the existing parameters.
+ * \param ao handle
+ */
+MPG123_EXPORT
+void out123_pause(out123_handle *ao);
+
+/** Continue playback
+ *  The counterpart to out123_pause(). Announce to the driver that playback
+ *  shall continue.
+ *
+ *  Playback might not resume immediately if the optional buffer is configured
+ *  to wait for a minimum fill and close to being empty. You can force playback
+ *  of the last scrap with out123_drain(), or just by feeding more data with
+ *  out123_play(), which will trigger out123_continue() for you, too.
+ * \param ao handle
+ */
+MPG123_EXPORT
+void out123_continue(out123_handle *ao);
+
+/** Stop playback.
+ *  This waits for pending audio data to drain to the speakers.
+ *  You might want to call out123_drop() before stopping if you want
+ *  to end things right away.
+ * \param ao handle
+ */
+MPG123_EXPORT
+void out123_stop(out123_handle *ao);
+
+/** Hand over data for playback and wait in case audio device is busy.
+ *  This survives non-fatal signals like SIGSTOP/SIGCONT and keeps on
+ *  playing until the buffer is done with if the flag
+ *  OUT123_KEEP_PLAYING ist set (default). So, per default, if
+ *  you provided a byte count divisible by the PCM frame size, it is an
+ *  error when less bytes than given are played.
+ *  To be sure if an error occured, check out123_errcode().
+ *  Also note that it is no accident that the buffer parameter is not marked
+ *  as constant. Some output drivers might need to do things like swap
+ *  byte order. This is done in-place instead of wasting memory on yet
+ *  another copy. Software muting also overwrites the data.
+ * \param ao handle
+ * \param buffer pointer to raw audio data to be played
+ * \param bytes number of bytes to read from the buffer
+ * \return number of bytes played (might be less than given, even zero)
+ */
+MPG123_EXPORT
+size_t out123_play( out123_handle *ao
+                  , void *buffer, size_t bytes );
+
+/** Drop any buffered data, making next provided data play right away.
+ *  This does not imply an actual pause in playback.
+ *  You are expected to play something, unless you called out123_pause().
+ *  Feel free to call out123_stop() afterwards instead for a quicker
+ *  exit than the implied out123_drain().
+ *  For live sinks, this may include dropping data from their buffers.
+ *  For others (files), this only concerns data in the optional buffer.
+ * \param ao handle
+ */
+MPG123_EXPORT
+void out123_drop(out123_handle *ao);
+
+/** Drain the output, waiting until all data went to the hardware.
+ * This does imply out123_continue() before and out123_pause()
+ * after draining.
+ * This might involve only the optional buffer process, or the
+ * buffers on the audio driver side, too.
+ * \param ao handle
+ */
+MPG123_EXPORT
+void out123_drain(out123_handle *ao);
+
+/** Drain the output, but only partially up to the given number of
+ *  bytes. This gives you the opportunity to do something while
+ *  the optional buffer is writing remaining data instead of having
+ *  one atomic API call for it all.
+ *
+ *  It is wholly expected that the return value of out123_buffered()
+ *  before and after calling this has a bigger difference than the
+ *  provided limit, as the buffer is writing all the time in the
+ *  background.
+ *
+ *  This is just a plain out123_drain() if the optional buffer is not
+ *  in use. Also triggers out123_continue(), but only out123_pause()
+ *  if there is no buffered data anymore.
+ * \param ao handle
+ * \param bytes limit of buffered bytes to drain
+ * \return number of bytes drained from buffer
+ */
+MPG123_EXPORT
+void out123_ndrain(out123_handle *ao, size_t bytes);
+
+/** Get an indication of how many bytes reside in the optional buffer.
+ * This might get extended to tell the number of bytes queued up in the
+ * audio backend, too.
+ * \param ao handle
+ * \return number of bytes in out123 library buffer
+ */
+MPG123_EXPORT
+size_t out123_buffered(out123_handle *ao);
+
+/** Extract currently used audio format from handle.
+ *  matching mpg123_getformat().
+ *  Given return addresses may be NULL to indicate no interest.
+ * \param ao handle
+ * \param rate address for sample rate
+ * \param channels address for channel count
+ * \param encoding address for encoding
+ * \param framesize size of a full PCM frame (for convenience)
+ * \return 0 on success, -1 on error
+ */
+MPG123_EXPORT
+int out123_getformat( out123_handle *ao
+,	long *rate, int *channels, int *encoding, int *framesize );
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/deps/mpg123/include/syn123.h
+++ b/deps/mpg123/include/syn123.h
@@ -1,0 +1,1211 @@
+/*
+	syn123: some audio signal synthesis and format conversion
+
+	copyright 2017-2023 by the mpg123 project,
+	free software under the terms of the LGPL 2.1
+	see COPYING and AUTHORS files in distribution or http://mpg123.org
+
+	initially written by Thomas Orgis
+
+	Consider defining SYN123_PORTABLE_API to limit the definitions to
+	a safer subset without some problematic features (mainly off_t usage).
+*/
+
+#ifndef SYN123_H
+#define SYN123_H
+
+/** \file syn123.h The header file for the libsyn123 library. */
+
+/* Common audio encoding specification. */
+#include "fmt123.h"
+
+/** A macro to check at compile time which set of API functions to expect.
+ * This must be incremented at least each time a new symbol is added
+ * to the header.
+ */
+#define SYN123_API_VERSION 2
+/** library patch level at client build time */
+#define SYN123_PATCHLEVEL  3
+
+#ifndef MPG123_EXPORT
+/** Defines needed for MS Visual Studio(tm) DLL builds.
+ * Every public function must be prefixed with MPG123_EXPORT. When building 
+ * the DLL ensure to define BUILD_MPG123_DLL. This makes the function accessible
+ * for clients and includes it in the import library which is created together
+ * with the DLL. When consuming the DLL ensure to define LINK_MPG123_DLL which
+ * imports the functions from the DLL. 
+ */
+#ifdef BUILD_MPG123_DLL
+/* The dll exports. */
+#define MPG123_EXPORT __declspec(dllexport)
+#else
+#ifdef LINK_MPG123_DLL
+/* The exe imports. */
+#define MPG123_EXPORT __declspec(dllimport)
+#else
+/* Nothing on normal/UNIX builds */
+#define MPG123_EXPORT
+#endif
+#endif
+#endif
+
+/** Support the restrict keyword for handed-in pointers. Defined to
+    'restrict' if available.
+ */
+#ifndef MPG123_RESTRICT
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define MPG123_RESTRICT restrict
+#else
+#define MPG123_RESTRICT
+#endif
+#endif
+
+// for off_t and ssize_t
+#ifndef SYN123_PORTABLE_API
+#include <sys/types.h>
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \defgroup syn123_api syn123 library API
+ *  I wanted to create some test signals in different encodings for testing
+ *  libout123. Also, they shall serve to verify the decoding of libmpg123
+ *  in automated testing. Then, the awful drop-sample resampling inside the
+ *  latter needed replacement. As digital filtering is part of the resampler
+ *  dance, a chain of those can also be configured and applied. I hope I can
+ *  avoid adding yet more functionality. It's a little utility library to
+ *  accompany libmpg123 and libout123, OK?
+ *
+ *  This is what libsyn123 offers:
+ *
+ *  - signal generation (mix of differing wave shapes, noise, a simulated
+ *    Geiger counter for fun)
+ *  - format conversion and channel mixing and amplification, with hard and
+ *    soft clipping, also optional dithering
+ *  - near-zero-latency good-enough quite-fast resampling
+ *  - applying digital filters with user-provided coefficients
+ *
+ *  The usage model for signal generation is this:
+ *
+ *  1. Create handle with desired output format.
+ *  2. Set up synthesis mode with parameters.
+ *  3. Repeatedly extract buffers with PCM samples.
+ *
+ *  If your hardware is slow on floating point operations, you may benefit
+ *  from the period buffer in the handle that only needs actual computation
+ *  once in the setup function. The frequencies of a wave mix may be fudged
+ *  a bit to make for a configured period size.
+ *
+ *  The usage model for resampling is this:
+ *
+ *  1. Create handle with any format or re-use a signal generation handle.
+ *  2. Set up resampling (rate ratio, channels, dirty mode).
+ *  3. Use predictor functions to work out matching sizes of input and
+ *     output buffers.
+ *  4. Call the resampler on chunks of input, immediately producing matching
+ *     chunks of output.
+ *
+ *  The resampler works on 32 bit float, exclusively. This is what is required
+ *  and appropriate for the provided quality.
+ *
+ *  The usage model for filtering is this:
+ *
+ *  1. Create or re-use a handle.
+ *  2. Set up the filter chain for single or double precision floating point.
+ *  3. Apply the filter to chunks of input in succession.
+ *
+ *  Computations are generally done in floating point, either 32 bit or 64
+ *  bit (single or double precision). The functions for encoding conversion,
+ *  (de-)interleaving, and interleaved mixing can work without a handle and
+ *  only use the buffers you hand in. Some support using a syn123 handle to
+ *  provide the temporary buffers for encoding conversion on the fly to apply
+ *  flotating-point processing to integer encodings.
+ *
+ *  Only the functions that are able to return a success code do check
+ *  arguments for obvious trouble like NULL pointers. You are supposed to
+ *  act responsibly when calling.
+ *
+ *  The size of buffers is either counted in bytes or samples, which,
+ *  depending on the context, refer to individual PCM samples or to what is
+ *  more strictly called a frame (one sample for each channel counted
+ *  together).
+ @{
+ */
+
+/** Opaque structure for the libsyn123 handle.
+ *
+ *  Simple context-free API functions do not need a handle, while
+ *  others require it. Those that require it want it as first argument.
+ *  Functions taking a handle as last argument after others make optional
+ *  use of it (if non-NULL) to enable advanced functionality like
+ *  on-the-fly encoding conversion that needs temporary storage.
+ */
+struct syn123_struct;
+/** Typedef shortcut as preferrend name for the handle type. */
+typedef struct syn123_struct syn123_handle;
+
+/** Get version of the mpg123 distribution this library build came with.
+ * (optional means non-NULL)
+ * \param major optional address to store major version number
+ * \param minor optional address to store minor version number
+ * \param patch optional address to store patchlevel version number
+ * \return full version string (like "1.2.3-beta4 (experimental)")
+ */
+MPG123_EXPORT
+const char *syn123_distversion(unsigned int *major, unsigned int *minor, unsigned int *patch);
+
+/** Get API version of library build.
+ * \param patch optional address to store patchlevel
+ * \return API version of library
+ */
+MPG123_EXPORT
+unsigned int syn123_libversion(unsigned int *patch);
+
+/** Functions that return an integer success code either return
+ *  SYN123_OK if everything went fine, or one of the other detailed
+ *  error codes.
+ */
+enum syn123_error
+{
+	SYN123_OK = 0   /**< no error */
+,	SYN123_BAD_HANDLE /**< bad handle given (NULL) */
+,	SYN123_BAD_FMT  /**< bad format (rate/channels) */
+,	SYN123_BAD_ENC  /**< bad encoding given */
+,	SYN123_BAD_CONV /**< unsupported conversion */
+,	SYN123_BAD_SIZE /**< buffer size bad (too small) */
+,	SYN123_BAD_BUF  /**< bad buffer pointer (NULL) */
+,	SYN123_BAD_CHOP /**< byte buffer not cut at sample boundaries */
+,	SYN123_DOOM     /**< Disaster, Out Of Memory. */
+,	SYN123_WEIRD    /**< An internal error that should never occur. */
+,	SYN123_BAD_FREQ /**< Invalid wave frequency given. */
+,	SYN123_BAD_SWEEP /**< Invalid sweep curve given. */
+,	SYN123_OVERFLOW  /**< Some fatal (integer) overflow that prevents proper operation. */
+,	SYN123_NO_DATA   /**< Not enough data to do something. */
+,	SYN123_BAD_DATA  /**< Data present, but not usable. */
+};
+
+/** Give a short phrase explaining an error code.
+ *  \param errcode the code returned by an API function
+ *  \return error phrase
+ */
+const char* syn123_strerror(int errcode);
+
+/** Create new handle with specified output format.
+ *  \param rate sampling rate
+ *  \param channels channel count (duplicated mono channels)
+ *  \param encoding sample encoding (see enum mpg123_enc_enum)
+ *  \param maxbuf maximum buffer size in bytes to allow for caching periodic
+ *    signals. When this is given, it is attempted to fit any configured signal
+ *    into this buffer in the hope it will work being played periodically. Maybe
+ *    there will be tricks with non-periodic signals.
+ *    A buffer size of zero turns off buffering and signals are always generated
+ *    during extraction.
+ *  \param err address to store error code, non-NULL if you care
+ *  \return Pointer to allocated handle structure or NULL on error.
+ */
+MPG123_EXPORT
+syn123_handle* syn123_new( long rate, int channels, int encoding
+,	size_t maxbuf, int *err );
+
+/** Delete a handle.
+ *  \param sh the handle to delete
+ */
+MPG123_EXPORT
+void syn123_del(syn123_handle *sh);
+
+/** Enable/disable dithering for conversions.
+ *
+ *  The default is no dither for conversions to integer encodings. You can
+ *  enable dithering after handle creation, or disable it, as you wish.
+ *  Enabling the dither resets the random number generator seed to the provided
+ *  value or an internal default if the provided value is zero. The dither noise
+ *  is unfiltered with triangular distribution (TPDF), as a sensible common
+ *  choice. No further filtering of questionable benefit.
+ *
+ *  \param sh handle to work on
+ *  \param dither Disable (0) or enable (1, actually nonzero) dithering.
+ *    Positive values > 1 may trigger differing dither modes in future, but not
+ *    now.
+ *  \param seed optional address to read the initial seed value from (if non-zero)
+ *    and to write the current value to
+ */
+MPG123_EXPORT
+int syn123_dither(syn123_handle *sh, int dither, unsigned long *seed);
+
+/** Extract desired amount of data from the generator.
+ *  \param sh handle
+ *  \param dst destination buffer
+ *  \param dst_bytes number of bytes to extract
+ *  \return actual number of extracted bytes
+ *  (might differ if dst_bytes is no multiple of the PCM frame size)
+ */
+MPG123_EXPORT
+size_t syn123_read(syn123_handle *sh, void *dst, size_t dst_bytes);
+
+/** Wave types */
+enum syn123_wave_id
+{
+	SYN123_WAVE_INVALID = -1 /**< invalid wave pattern */
+,	SYN123_WAVE_FLAT = 0 /**< flat line, silence */
+,	SYN123_WAVE_SINE     /**< sinusodial wave*/
+,	SYN123_WAVE_SQUARE   /**< square wave */
+,	SYN123_WAVE_TRIANGLE /**< triangle wave */
+,	SYN123_WAVE_SAWTOOTH /**< sawtooth wave */
+,	SYN123_WAVE_GAUSS    /**< Gaussian bell shape */
+,	SYN123_WAVE_PULSE    /**< pulse shape, x^2 exp(-A x^2)/S */
+,	SYN123_WAVE_SHOT     /**< shot (sharper pulse), x^2 exp(-A x)/S
+	* (different values for A and S) */
+,	SYN123_WAVE_LIMIT /**< valid IDs below that. A newer release of
+	* the library might support more. */
+};
+
+/** Setup periodic wave generator.
+ *  This sets up a series of oscillators with differing wave shapes.
+ *  They are multiplied/scaled with each other instead of mixed
+ *  in a sum of signals. It's more fun this way to generate interesting
+ *  sounds. If you want to mix differing streams with differing volumes,
+ *  channel balance and phase shifts, just create multiple single-channel
+ *  generators with a convenient format (float encoding comes to mind)
+ *  and mix to your heart's desire. You can then still use this library
+ *  to get your channel buffers interleaved and converted to something
+ *  your output device likes.
+ *
+ *  You can ensure strict periodicity without possible shifts in phases
+ *  due to floating point rounding errors with the buffered variant.
+ *  That may adjust your chosen frequencies to be able to keep the limit
+ *  on buffer size, but the resulting data is then strictly periodic
+ *  without any further computations that may introduce timing errors.
+ *  Apart from possibly saving computing time via the precomputed table,
+ *  this is the reason to pre-mix multiple waves into a common buffer at
+ *  all.
+ *
+ *  The adjustments of the wave frequencies also include limiting them
+ *  between some minimal value and the Nyquist frequency. Without the
+ *  buffer, you can happily choose waves that are not resolved at all
+ *  by the sampling rate and get the nasty results. Things get nasty
+ *  inside the buffer, too, when you approach the Nyquist limit, but that
+ *  is life (and mathematics).
+ *
+ *  The default wave is a 440 Hz sine without phase offset. If any setting
+ *  is missing, the default is taken from that.
+ *
+ *  \param sh handle
+ *  \param count number of waves (if zero, one default wave is configured)
+ *  \param id array of wave IDs (enum syn123_wave_id), may be NULL
+ *  \param freq array of wave frequencies, may be NULL
+ *     Your provided frequencies are overwritten with the actual
+ *     values if the periodic buffer is chosen.
+ *  \param phase array of wave phases, may be NULL
+ *  \param backwards array of true (non-zero) or false (zero), indicating
+      whether the wave is being inverted in time, may be NULL
+ *  \param period address to store the size of the period buffer
+ *    in samples (zero if not using the buffer), ignored if NULL
+ *  \return success code
+ */
+MPG123_EXPORT
+int syn123_setup_waves( syn123_handle* sh, size_t count
+,	int *id, double *freq, double *phase, int* backwards
+,	size_t *period );
+
+/** Query current wave generator setup and state.
+ *
+ *  This lets you extract the setup of the wave generator and
+ *  the current phases to be able to re-create it and continue
+ *  seamlessly, or maybe intentionally in some tweaked form with
+ *  slight phase or frequency shifts.
+ *
+ *  You only need to set target pointers to non-NULL where you
+ *  want the corresponding values extracted. You need to have
+ *  the storage prepared for the correct wave count. A common
+ *  mode of usage might be to make a first call to only query
+ *  the count, allocate storage, then a do a second call for the
+ *  wave data.
+ *
+ *  \param sh handle
+ *  \param count address to store number of waves
+ *  \param id storage for array of wave IDs
+ *  \param freq storage for array of wave frequencies
+ *  \param phase storage for array of wave phases
+ *  \param backwards storage for array of true (non-zero) or false (zero),
+ *    indicating whether the wave is being inverted in time
+ *  \param period address to store the size of the period buffer
+ *    in samples (zero if not using the buffer)
+ *  \return success code
+ */
+MPG123_EXPORT
+int syn123_query_waves( syn123_handle* sh, size_t *count
+,	int *id, double *freq, double *phase, int* backwards
+,	size_t *period );
+
+/** Return the name of the indicated wave pattern.
+ *  \param id The numerical ID of the wave pattern
+ *    (out of enum syn123_wave_id).
+ *  \return The name string, guaranteed to be non-NULL.
+ *    Invalid codes yield the string "???".
+ */
+MPG123_EXPORT
+const char* syn123_wave_name(int id);
+
+/** Return the wave pattern id given a name string.
+ *  \param name The name string.
+ *  \return The numerical id (out of enum syn123_wave_id).
+ *  
+ */
+MPG123_EXPORT
+int syn123_wave_id(const char *name);
+
+/** Types of frequency sweeps.
+ *  There are no functions mapping those to/from strings,
+ *  as this list is supposed to be fixed and small.
+ *  There are only so many types of sweeps that make sense.
+ */
+enum syn123_sweep_id
+{
+	SYN123_SWEEP_LIN = 0 /**< linear frequency change */
+,	SYN123_SWEEP_QUAD    /**< quadratic frequency change */
+,	SYN123_SWEEP_EXP     /**< exponential (octave per time unit) */
+,	SYN123_SWEEP_LIMIT   /**< valid IDs less than that */
+};
+
+/** Frequency sweep generator.
+ *  This generates a sweep from one frequency to another with one
+ *  of the available wave shapes over a given time.
+ *  While you can just extract your single sweep by exactly reading
+ *  the requestet duration, the generator is set up to run the sweep
+ *  a bit longer until the beginning phase is reached again
+ *  (one sample before that, of course). That way, reasonably smooth 
+ *  periodic playback from the buffer is possible without that nasty jump.
+ *  Still, a large freqency difference will result in an audible pop,
+ *  but at least that is not whole spectrum due to a phase jump.
+ *  \param sh handle
+ *  \param wave_id wave ID (enum syn123_wave_id)
+ *  \param f1 pointer to beginning frequency in Hz (>= 1e-4, please,
+ *    a value <= 0 being replaced by the standard frequency and stored for you)
+ *  \param f2 ending frequency in Hz (>= 1e-4, please,
+ *    in case of exponential sweep: f2-f1 >= 1e-4, too,
+ *    a value <= 0 being replaced by the standard frequency and stored for you)
+ *  \param sweep_id choice of sweep curve (enum syn123_sweep_id)
+ *  \param smooth enable the periodic smoothing, if sensible
+ *    (extending signal beyond the sweep to avoid phase jumps, a continuing
+ *    starting at given start phase, not the returned endphase)
+ *  \param duration duration of sweep in samples (> 1, please)
+ *    This theoretically should be an off_t relating to the size of a
+ *    file you produce, but off_t in API headers causes headaches.
+ *    A 32 bit size_t still gives you over 24 hours of sweeping with 44100 kHz
+ *    rate. On top of that, you can use the returned endphase to chop
+ *    your monster sweep into pieces.
+ *  \param phase initial phase of the sweep
+ *  \param backwards invert the waveform in time if true
+ *  \param endphase address to store the normal phase that would
+ *    smoothly continue the signal without the period correction
+ *    (You can create a following sweep that continues smoothly to a new
+ *    target frequency by handing in this endphase as initial phase. Combine
+ *    that with phases of constant tone and you could simulate a Theremin
+ *    player by approximating the reaction to hand movements via sweeps.)
+ *  \param period address to store the periodic sample count, usually
+ *    being a bit bigger than the duration for getting the phase
+ *    back down; does not imply use of the internal period buffer
+ *  \param buffer_period address to store the period count only if the
+ *    period buffer is actually in use
+ */
+MPG123_EXPORT
+int syn123_setup_sweep( syn123_handle* sh
+,	int wave_id, double phase, int backwards
+,	int sweep_id, double *f1, double *f2, int smooth, size_t duration
+,	double *endphase, size_t *period, size_t *buffer_period );
+
+/** Set up pink noise generator.
+ *  This employs the Gardner/McCartney method to the approximate
+ *  the real thing. The number of rows in the tree pattern is tunable.
+ *  The result is pink noise with around 2.5 dB/octave. Do not expect
+ *  more than 32 bits of randomness (or anything;-).
+ *  \param sh handle
+ *  \param rows rows for the generator algorithm
+ *    It maxes out at 30 rows. Below 1 chooses a default.
+ *  \param seed a 32 bit seed value for the pseudo-random number generator
+ *  \param period optional address to store the size of the enforced period
+ *    (zero for endlessly freshly generated signal)
+ *  \return success code
+ */
+MPG123_EXPORT
+int syn123_setup_pink( syn123_handle *sh, int rows, unsigned long seed
+,	size_t *period );
+
+/** Set up white noise generator.
+ *  A simple white noise source using some cheap pseudo RNG. Do not
+ *  expect more than 32 bits of randomness (or anything;-).
+ *  \param sh handle
+ *  \param seed a 32 bit seed value for the pseudo-random number generator
+ *  \param period optional address to store the size of the
+ *    enforced period (zero for endlessly freshly generated signal)
+ */
+MPG123_EXPORT
+int syn123_setup_white(syn123_handle *sh, unsigned long seed, size_t *period);
+
+/** Set up Geiger counter simulator.
+ *  This models a speaker that is triggered by the pulses from
+ *  the Geiger-Mueller counter. That creepy ticking sound.
+ *  \param sh handle
+ *  \param activity average events per second
+ *  \param seed a 32 bit seed value for the pseudo-random number generator
+ *  \param period optional address to store the size of the enforced period
+ *    (zero for endlessly freshly generated signal)
+ *  \return success code
+ */
+MPG123_EXPORT
+int syn123_setup_geiger( syn123_handle *sh, double activity
+,	unsigned long seed, size_t *period );
+
+/** Set up silence.
+ *  This goes back to the vanilla state.
+ *  \return success code
+ */
+MPG123_EXPORT
+int syn123_setup_silence(syn123_handle *sh);
+
+/** Convert between supported encodings.
+ *  The buffers must not overlap.
+ *  Note that syn123 converts -1.0 to -127 for 8 bit signed (and analogous for
+ *  other encodings), but still clips asymmetrically at -128 as that is the
+ *  range of the type. If you do explicit clipping using syn123_clip(),
+ *  the resulting range will be symmetrical inside [-1.0:1.0] and hence
+ *  only down to -127 for 8 bit signed encoding.
+ *  The conversions only work directly either from anything to double/float or
+ *  from double/float to anything. This process is wrapped in the routine if
+ *  a handle is provided, using the fixed mixing buffer in that. Clipping
+ *  is only handled for floating point to integer conversions. Also, NaN
+ *  is set to zero on conversion and counted as clipped.
+ *  The ulaw and alaw conversions use Sun's reference implementation of the
+ *  G711 standard (differing from libmpg123's big lookup table).
+ *
+ *  \param dst destination buffer
+ *  \param dst_enc destination encoding (enum mpg123_enc_enum)
+ *  \param dst_size size of destination buffer in bytes
+ *  \param src source buffer
+ *  \param src_enc source encoding
+ *  \param src_bytes source buffer size in bytes
+ *  \param dst_bytes optional address to store the written byte count to
+ *  \param clipped optional address to store number of clipped samples to
+ *  \param sh an optional syn123_handle which enables arbitrary encoding
+ *    conversions by utilizing the contained buffer as intermediate storage,
+ *    can be NULL, disabling any conversion not involving floating point
+ *    input or output
+ *  \return success code
+ */
+MPG123_EXPORT
+int syn123_conv( void * MPG123_RESTRICT dst, int dst_enc, size_t dst_size
+,	void * MPG123_RESTRICT src, int src_enc, size_t src_bytes
+,	size_t *dst_bytes, size_t *clipped, syn123_handle * sh );
+
+/** The range of decibel values handled by syn123 goes from
+ *  -SYN123_DB_LIMIT to +SYN123_DB_LIMIT
+ *  This value ensures that a resulting linear volume can still
+ *  be expressed using single-precision float.
+ *  The resulting amplitude from -500 dB is still small enough
+ *  to drive a 32 bit integer sample value orders of magnitude below
+ *  1, so it is effectively a zero. Note that physical volume controls
+ *  typically give a range as small as 60 dB. You might want to present
+ *  a tighter range to the user than +/- 500 dB!
+ */
+#define SYN123_DB_LIMIT 500
+
+/** Convert decibels to linear volume (amplitude factor).
+ *  This just returns pow(10, db/20) in the supported range.
+ *  The dB value is limited according to SYN123_DB_LIMIT, with
+ *  NaN being put at the lower end of the range. Better silent
+ *  than insanely loud.
+ *  \param db relative volume in dB
+ *  \return linear volume factor
+ */
+MPG123_EXPORT double syn123_db2lin(double db);
+
+/** Convert linear volume (amplitude factor) to decibels.
+ *  This just returns 20*log10(volume) in the supported range.
+ *  The returned value is limited according to SYN123_DB_LIMIT, with
+ *  NaN being put at the lower end of the range. Better silent
+ *  than insanely loud.
+ *  \param volume linear volume factor
+ *  \return relative volume in dB
+ */
+MPG123_EXPORT double syn123_lin2db(double volume);
+
+/** Amplify given buffer.
+ *  This multiplies all samples by the given floating point value
+ *  (possibly converting to/from floating point on the fly, if a
+ *  handle with the included working buffer is given).
+ *  Also an offset correction is provided.
+ *
+ *  \param buf the buffer to work on
+ *  \param encoding the sample encoding
+ *  \param samples number of samples
+ *  \param volume linear volume factor (use syn123_db2lin() for
+ *    applying a change in dB)
+ *  \param offset offset to add to the sample values before
+ *    multiplication
+ *  \param clipped optional address to store number of clipped samples to
+ *  \param sh optional handle to enable work on non-float
+ *    encodings
+ *  \return success code (e.g. bad encoding without handle)
+ */
+MPG123_EXPORT
+int syn123_amp( void* buf, int encoding, size_t samples
+,	double volume, double offset,	size_t *clipped, syn123_handle *sh );
+
+/** Clip samples in buffer to default range.
+ *  This only does anything with floating point encoding, but you can always
+ *  call it without damage as a no-op on other encodings. After this, the
+ *  samples are guaranteed to be in the range [-1,+1]. NaNs are mapped
+ *  to zero (and counted as clipped), so they will still sound bad.
+ *  If you want to hard clip to a smaller range, use syn123_soft_clip() with
+ *  a width of zero.
+ *  \param buf buffer to work on
+ *  \param encoding sample encoding
+ *  \param samples total number of samples
+ *  \return number of clipped samples
+ */
+MPG123_EXPORT
+size_t syn123_clip(void *buf, int encoding, size_t samples);
+
+/** Soft clipping / cheap limiting.
+ *  This limits the samples above the threshold of limit-width with a
+ *  smooth curve, dampening the high-frequency content of the clipping.
+ *  This is no proper frequency filter, but just an independent function on
+ *  each sample value, also ignorant of the channel count. This can
+ *  directly work on float encodings and does nothing on others unless
+ *  a handle is provided for on-line conversion.
+ *  \param buf buffer to work on
+ *  \param encoding sample encoding
+ *  \param samples total number of samples
+ *  \param limit the limit to clip to (normally 1 for full scale)
+ *  \param width smoothing range
+ *  \param sh optional handle to work on non-float encodings
+ *  \return number of clipped samples
+ */
+MPG123_EXPORT
+size_t syn123_soft_clip( void *buf, int encoding, size_t samples
+,	double limit, double width, syn123_handle *sh );
+
+/** Interleave given number of channels into one stream.
+ *  A rather trivial functionality, here for completeness. As the
+ *  algorithm is agnostic to what is actually stored as a "sample",
+ *  the parameter types are so generic that you could use these
+ *  functions to arrange huge structs (hence samplesize as size_t)
+ *  or whatever. If that makes sense is up to you.
+ *  The buffers shall not overlap!
+ *  \param dst destination buffer
+ *  \param src source buffer array (one per channel)
+ *  \param channels channel count
+ *  \param samplesize size of one sample
+ *  \param samplecount count of samples per channel
+ */
+MPG123_EXPORT
+void syn123_interleave( void * MPG123_RESTRICT dst, void** MPG123_RESTRICT src
+,	int channels, size_t samplesize, size_t samplecount );
+
+/** Deinterleave given number of channels out of one stream.
+ *  A rather trivial functionality, here for completeness. As the
+ *  algorithm is agnostic to what is actually stored as a "sample",
+ *  the parameter types are so generic that you could use these
+ *  functions to arrange huge structs (hence samplesize as size_t)
+ *  or whatever. If that makes sense is up to you.
+ *  The buffers must not overlap!
+ *  \param dst destination buffer array (one per channel)
+ *  \param src source buffer
+ *  \param channels channel count
+ *  \param samplesize size of one sample (see MPG123_SAMPLESIZE)
+ *  \param samplecount count of samples per channel
+ */
+MPG123_EXPORT
+void syn123_deinterleave( void ** MPG123_RESTRICT dst, void * MPG123_RESTRICT src
+,	int channels, size_t samplesize, size_t samplecount );
+
+/** Simply copies mono samples into an interleaved stream.
+ *  This might be implemented by a call to syn123_interleave(), it might
+ *  be optimized to something different. You could have fun measuring that.
+ *  \param dst destination buffer
+ *  \param src source buffer
+ *  \param channels channel count
+ *  \param samplesize size of one sample (see MPG123_SAMPLESIZE)
+ *  \param samplecount count of samples per channel
+ */
+MPG123_EXPORT
+void syn123_mono2many( void * MPG123_RESTRICT dst, void * MPG123_RESTRICT src
+, int channels, size_t samplesize, size_t samplecount );
+
+/** A little helper/reminder on how interleaved format works:
+ *  Produce the offset of the given sample for the given channel.
+ */
+#define SYN123_IOFF(sample, channel, channels) ((sample)*(channels)+(channel))
+
+/** Specify floating point encoding to use for preserving precision in
+ *  intermediate computations for given source and destination encoding.
+ *  This should return either MPG123_ENC_FLOAT_32 or MPG123_ENC_FLOAT_64,
+ *  unless an uncertain future adds things like 16 bit fp ...
+ *  This is what syn123_conv() and syn123_mix() will use internally if
+ *  intermediate conversion is necessary.
+ *  Note that 64 bit floating point material will be mixed in 32 bit if the
+ *  destination encoding does not need more precision.
+ *  \param src_enc source/input encoding
+ *  \param dst_enc destination/output encoding
+ *  \return encoding value, zero if none can be chosen (invalid parameters)
+ */
+MPG123_EXPORT
+int syn123_mixenc(int src_enc, int dst_enc);
+
+/** Mix n input channels on top of m output channels.
+ *  This takes an interleaved input stream and mixes its channels
+ *  into the output stream given a channel matrix (m,n) where
+ *  each of the m rows contains the n volume factors (weights)
+ *  to apply when summing the samples from the n input channels.
+ *  Sample values are added to what is already present unless
+ *  initial silence is explicitly requested.
+ *  This works directly with identical floating point encodings. It
+ *  may have some optimization to work faster with mono or stereo on
+ *  either side and slower generic code for arbitrary channel counts.
+ *  You can use syn123_conv() to convert from/to input/output encodings
+ *  or provide a syn123_handle to do it on the fly.
+ *  There are no optimizations for special cases of mixing factors, so
+ *  you should always be able to predict the number of floating point
+ *  operations being executed.
+ *  For fun, you could give the same problem to a BLAS implementation
+ *  of your choice and compare the performance;-)
+ *  \param dst destination buffer
+ *  \param dst_enc output sample encoding, must be MPG123_ENC_FLOAT_32 or
+ *   MPG123_ENC_FLOAT_64 unless a syn123_handle is provided
+ *  \param dst_channels destination channel count (m)
+ *  \param src source buffer
+ *  \param src_enc input sample encoding, must be MPG123_ENC_FLOAT_32 or
+ *   MPG123_ENC_FLOAT_64 unless a syn123_handle is provided
+ *  \param src_channels source channel count (n)
+ *  \param mixmatrix mixing factors ((m,n) matrix), same encoding as
+ *    the audio data
+ *  \param samples count of samples (PCM frames) to work on
+ *  \param silence Set to non-zero value to intialize the output
+ *    to a silent signal before adding the input.
+ *  \param clipped optional address to store number of clipped samples to
+ *    (in case of mixing to an integer encoding)
+ *  \param sh an optional syn123_handle which enables work on non-float
+ *    encodings by utilizing the contained buffer as intermediate storage,
+ *    converting to/from float transparently; Note that this may limit
+ *    the amount of channels depending on the fixed internal buffer space.
+ *    As long as you have up to 128 channels, you should not worry.
+ *  \return success code (e.g. bad encoding, channel counts ...)
+ */
+MPG123_EXPORT
+int syn123_mix( void * MPG123_RESTRICT dst, int dst_enc, int dst_channels
+,	void * MPG123_RESTRICT src, int src_enc, int src_channels
+,	const double * mixmatrix
+,	size_t samples, int silence, size_t *clipped, syn123_handle *sh );
+
+/** Set up a generic digital filter.
+ *
+ *  This takes a filter order N and coefficient set to prepare
+ *  the internal state of a digital filter defined by the transfer
+ *  function
+ *  \f[
+ *             
+ *    H(z) = \frac
+ *            {b_0 + b_1 z^{-1} + ... + b_N z^{-N}}
+ *            {1 + a_1 z^{-1} + ... + a_N z^{-N}}
+ *  \f]
+ *  It is your task to come up with fun values for the coefficients
+ *  b_n and a_n to implement various FIR and IIR filters.
+ *
+ *  Since it is easy to do and useful, this configures not only a single
+ *  filter but a chain of them. If you do configure a chain, the choice
+ *  of mixenc and channels must match. No conversion between filters.
+ *
+ *  \param sh mandatory handle
+ *  \param append if true, append a filter to the chain, fresh chain otherwise
+ *  \param order filter order N (filter length minus one)
+ *  \param b nominator coefficients, starting with b_0 (order+1 elements)
+ *  \param a denominator coefficients, starting with a_0=1 (order+1 elements).
+ *    It is an error to provide a sequence that does not start with 1.
+ *    For a non-recursive (FIR) filter, you can set all following
+ *    values from a_1 on to zero or choose to provide a NULL pointer.
+ *  \param mixenc either MPG123_ENC_FLOAT_32 or MPG123_ENC_FLOAT_64 for
+ *    computation in single or double precision, can be zero to refer to
+ *    the value demanded by an already present filter
+ *  \param channels number of channels in the audio signal, can be zero
+ *    to refer to the value demanded by an already present filter
+ *  \param init_firstval If non-zero, initialize the filter history with
+ *    a constant stream of the first encountered sample instead of zero.
+ *  \return success code
+ */
+MPG123_EXPORT
+int syn123_setup_filter( syn123_handle *sh
+,	int append, unsigned int order, double *b, double *a
+,	int mixenc, int channels, int init_firstval );
+
+/** init_firstval is the effective setting (extreme coefficients may remove the distinction) */
+
+MPG123_EXPORT
+int syn123_query_filter( syn123_handle *sh, size_t position
+,	size_t *count, unsigned int *order, double *b, double *a
+,	int *mixenc, int *channels, int *init_firstval );
+
+/** drop the n last filters */
+MPG123_EXPORT
+void syn123_drop_filter(syn123_handle *sh, size_t count);
+
+/** Apply a prepared digital filter.
+ * 
+ *  This applies the filter prepared by syn123_setup_filter to yur
+ *  provided buffer in single or double precision float.
+ *  Handing in a non-float encoding is an error. You are supposed
+ *  to convert and clip before/after applying the filters.
+ *
+ *  If you got no filters configured, this always succeeds and
+ *  does nothing.
+ *
+ *  \param sh handle
+ *  \param buf audio data to work on (channel count matching what
+ *     was given to mpg123_setup_filter())
+ *  \param encoding audio encoding
+ *  \param samples count of samples (PCM frames) in the buffer
+ *  \return success code
+ */
+MPG123_EXPORT
+int syn123_filter( syn123_handle *sh
+,	void* buf, int encoding, size_t samples );
+
+/** Set up the resampler.
+ *
+ *  This works independently of the signal generators. You can combine
+ *  syn123_setup_resample() with syn123_setup_geiger(), for example.
+ *
+ *  People can get worked up a lot about differing algorithms for resampling,
+ *  while many folks can actually bear the simple drop/repeat method and most
+ *  probably do not bother about the distortions from linear resampling.
+ *  A testament to this is that in the 18 years of me maintaining mpg123, I
+ *  got bugged about the missing dithering and on subtle bias in shuffling
+ *  a playlist, but people seem to insist on using the NtoM resampoler inside
+ *  libmpg123, despite me warning about its horrible consequences for audio
+ *  quality. It is a plain drop-sample implementation. The only good things to
+ *  say about it is that it is cheap and is embedded with the sample-accurate
+ *  decoder so that you do not have to worry about offsets in terms of input
+ *  and output samples.
+ *
+ *  Anyhow, this is my take on a reasonably good and efficient resampler that is
+ *  neither the best-sounding, nor the fastest in terms of CPU time, but gets
+ *  by without significant latency. It needs far less computation than usual
+ *  high-quality windowed-sinc resampling (libsamplerate), but cannot beat
+ *  libsoxr with its FFT-based approach. The less stringent dirty mode (using
+ *  only a 72 dB lowpass filter, in practice still close to CD-DA quality)
+ *  comes quite close, though.
+ *
+ *  The selling point is that it produces output samples as soon as you start
+ *  feeding, without any buffering of future samples to fill a window for the
+ *  FIR filter or the Fourier transform. It employs IIR filters for low-passing,
+ *  possibly in multiple stages for decimation, and optimized interpolation
+ *  formulas using up to 6 points. These formulas, based on research by
+ *  Olli Niemitalo using using Differential Evolution, are what enables a
+ *  dynamic range of 108 dB, well above 16 bit CD-DA quality. Simple
+ *  cubic splines after low-passing distort up to around -40 dB in my tests.
+ *
+ *  There is some effective signal delay well below 10 samples. The impulse
+ *  response is about 3 samples late, so this is well inside the realm of
+ *  (nonlinear) phase shift. The phase distortion looks bad on paper but does
+ *  not matter much in the intended domain of application: the final change in
+ *  sampling rate before playback on audio hardware, the last filter that is
+ *  applied before the sound hits the speakers (or all the other filters
+ *  implemented in your audio harware, that you can choose to be ignorant
+ *  about). Use better resamplers for mixing in the studio. Use better
+ *  resamplers for converting files on disk. For live playback, consider this
+ *  one because it is good enough, fast enough, cheap enough.
+ *
+ *  Note that if you call this function repeatedly, the internal history
+ *  is only cleared if you change anything besides the sampling rates. If
+ *  only the rates change, the state of the resampler is kept to enable
+ *  you to continue on prior data. This means you can vary the resampling
+ *  ratio during operation, somewhat smoothly depending on your buffer size.
+ *
+ *  Also note that even on identical input and output rates, the resampler
+ *  will apply the full filtering as for any ratio close to that, including
+ *  oversampling. No special shortcuts.
+ *
+ *  A returned error guarantees that the internal resampler setup has
+ *  been cleared (frees a little bit of memory). You can provide zero
+ *  inrate, outrate, and channel count at the same time to that effect
+ *  without an error message being produced (but still SYN123_BAD_FMT
+ *  being returned).
+ *
+ *  \param sh mandatory handle
+ *  \param inrate input sample rate (nominator of ratio)
+ *  \param outrate output sample rate (denominator of ratio)
+ *  \param channels number of interleaved channels
+ *  \param dirty Enable (!= 0) the dirty mode for even more 'good enough'
+ *  resampling with less computing time. Offers -72 dB low pass attentuation,
+ *  worst-case distortion around that, too, and 85% worst-case bandwidth.
+ *  With this set to zero, the normal mode is used, offering at least 108 dB
+ *  dynamic range and worst-case bandwidth above 84%.
+ *  \param smooth Enable (!=0) extra code smoothing the resampler response to
+ *  on-the-fly changes of sampling rate ratio. This involves keeping
+ *  some per-stage history to bootstrap additional decimation filters and the
+ *  changed final lowpass/interpolation.
+ *  \return success code
+ */
+MPG123_EXPORT
+int syn123_setup_resample( syn123_handle *sh, long inrate, long outrate
+,	int channels, int dirty, int smooth );
+
+/** Return the maximum allowed value for sample rates given to the resampler.
+ *
+ *  Not every possible value of the underlying data type is a valid sample
+ *  rate for the resampler. It needs some headroom for computations. This
+ *  function returns the maximal rate you can specify. For 32-bit long, this
+ *  will be above 1e9, for 64-bit long above 4e18. The minimum is 1, of course.
+ *  So, with 32 bit, you can speed up/down by a factor of one million if you
+ *  want to keep 0.1% precision in the rates.
+ *
+ *  \return upper sample rate limit
+ */
+MPG123_EXPORT
+long syn123_resample_maxrate(void);
+
+/** Give upper limit for output sample count from the resampler.
+ *
+ *  Since there is some rounding involved, the exact number of output samples
+ *  from the resampler, being given a certain amount of input samples, can
+ *  vary (one more or less than expected). This function is here to give you
+ *  a safe output buffer size given a certain input buffer size. If you intend
+ *  to vary the output rate for a fixed input rate, you may compute the output
+ *  buffer size for the largest intended output rate and use that throughout.
+ *  The same applies to the input sample count.
+ *  A return value of zero indicates an error (zero, negative, or too large
+ *  rate given) unless the given input sample count is also zero.
+ *  The resampler only produces output when given new input.
+ *  \param inrate input sample rate
+ *  \param outrate output sample rate
+ *  \param ins input sample count for one buffer
+ *  \return number of maximum output samples for one buffer, or zero
+ *     if no sensible value exists
+ */
+MPG123_EXPORT
+size_t syn123_resample_count(long inrate, long outrate, size_t ins);
+
+/** Return the amount of input samples needed to recreate resample filter state.
+ *
+ *  This returns a number of input samples that should fill the internal
+ *  filter states good enough for output being close to that produced from
+ *  the full input since the beginning. Since recursive filters are employed,
+ *  there is no exact number that recreates a state apart from the full sequence
+ *  that created it the first time.  This number here shall be more than the
+ *  non-recursive history, but not by a huge factor. For extreme cases, this
+ *  value may be saturated at SIZE_MAX and thus smaller than what is demanded
+ *  by the above definition. It is assumed that you define a maximal practical
+ *  size of history to consider for your application, anyway.
+ *
+ *  \param inrate input sample rate
+ *  \param outrate output sample rate
+ *  \param dirty switch for dirty resampling mode (see syn123_setup_resample())
+ *  \return number of input samples to fill history, zero on error
+ */
+MPG123_EXPORT
+size_t syn123_resample_history(long inrate, long outrate, int dirty);
+
+/** Compute the minimal input sample count needed for given output sample count.
+ *
+ *  The reverse of syn123_resample_count(), in a way. This gives you the
+ *  minimum amount of input samples to guarantee at least the desired amount
+ *  of output samples. Once you got that, ensure to call syn123_resample_count()
+ *  to get a safe buffer size for that amount of input and prepare accordingly.
+ *  With this approach, you can ensure that you get your realtime output device
+ *  buffer filled with each loop run fetching a bit of input, at the expense
+ *  of handling some additional buffering for the returned sample counts above
+ *  the minimum.
+ *
+ *  \param input_rate input sample rate
+ *  \param output_rate output sample rate
+ *  \param outs desired minimal output sample count for one input buffer
+ *  \return number of minimal input samples in one buffer, or zero if no
+ *    sensible value exists (invalid input parameters, or zero outs)
+ */
+MPG123_EXPORT
+size_t syn123_resample_incount(long input_rate, long output_rate, size_t outs);
+
+/** Compute the input sample count needed for close to given output sample
+ *  count, but never more.
+ *
+ *  Call this to get a safe fixed count of input samples to make best use
+ *  of a preallocated output buffer, filling it as much as safely possible.
+ *  This can also be achieved by calling syn123_resample_incount() and reducing
+ *  the value until syn123_resample_count() fits into your buffer.
+ *
+ *  \param input_rate input sample rate
+ *  \param output_rate output sample rate
+ *  \param outs desired output sample count for one input buffer
+ *  \return number of input samples in one buffer, or zero if no
+ *    sensible value exists (invalid input parameters, or zero outs)
+ */
+MPG123_EXPORT
+size_t syn123_resample_fillcount(long input_rate, long output_rate, size_t outs);
+
+
+/** Compute the maximum number of input samples for a resampling buffer.
+ *
+ *  Upsampling means that you will get more output samples than input samples.
+ *  This larger number still needs to fit into the data type for sample
+ *  counts. So please don't feed more than the value returned here.
+ *
+ *  \param input_rate input sample rate
+ *  \param output_rate output sample rate
+ *  \return maximum safe input sample count
+ */
+MPG123_EXPORT
+size_t syn123_resample_maxincount(long input_rate, long output_rate);
+
+/** Give exact output sample count for feeding given input now.
+ *
+ *  This gives you the exact number of samples you will get returned
+ *  when feeding the resampler the given additional input samples now,
+ *  given the current resampler state contained in the handle.
+ *
+ *  On error, zero is returned and the error code is set to a nonzero
+ *  syn123 error code.
+ *
+ *  \param sh syn123 handle
+ *  \param ins input sample count
+ *  \param err location to store error code
+ *  \return output sample count
+ */
+MPG123_EXPORT
+size_t syn123_resample_out(syn123_handle *sh, size_t ins, int *err);
+
+/** Give minimum input sample count needed now for given output.
+ *
+ *  This give you the minimal number of input samples needed right
+ *  now to yield at least the specified amount of output samples.
+ *  Since one input sample can result in several output sampels in one
+ *  go, you have to check using syn123_resample_out() how many
+ *  output samples to really expect.
+ *
+ *  On error, zero is returned and the error code is set to a nonzero
+ *  syn123 error code.
+ *
+ *  \param sh syn123 handle
+ *  \param outs output sample count
+ *  \param err location to store error code
+ *  \return minimal input sample count
+ */
+MPG123_EXPORT
+size_t syn123_resample_in(syn123_handle *sh, size_t outs, int *err);
+
+/** Give exact output sample count for total input sample count.
+ *
+ *  Use this to determine the total length of your output stream
+ *  given the length of the input stream. The computation is exact.
+ *  But: It is only valid for a constant sampling rate ratio. If you
+ *  play with that during runtime, you need to figure out your output
+ *  offset yourself.
+ *
+ *  \param inrate input sample rate
+ *  \param outrate output sample rate
+ *  \param ins input sample count for the whole stream
+ *  \return number of output samples or -1 if the computation fails
+ *    (bad/too large sampling rates, integer overflow)
+ */
+MPG123_EXPORT
+int64_t syn123_resample_total64(long inrate, long outrate, int64_t ins);
+
+/** Give minimum input sample count for total output sample count.
+ *
+ *  You need to feed at least that amount of input samples to get
+ *  the desired amount of output samples from the resampler. Depending
+ *  on the resampling ratio, you may in fact get more than the desired
+ *  amount (one input sample being worth multiple output samples during
+ *  upsampling) so make sure to call syn123_resample_total() to get
+ *  the exact number of samples you need to prepare for.
+ *  Again, the output offset is only meaninful for a constant sampling
+ *  rate ratio.
+ *
+ *  \param inrate input sample rate
+ *  \param outrate output sample rate
+ *  \param outs output sample count for the whole stream
+ *  \return number of input samples or -1 if the computation fails
+ *    (bad/too large sampling rates, integer overflow)
+ */
+MPG123_EXPORT
+int64_t syn123_resample_intotal64(long inrate, long outrate, int64_t outs);
+
+/** Resample input buffer to output buffer.
+ *
+ *  This executes the resampling configured by syn123_setup_resample(). The
+ *  input and output encoding is fixed at single-precision float
+ *  (MPG123_ENC_FLOAT_32) and multiple channels are interleaved. There
+ *  is no implicit conversion of other encodings since the fixed internal
+ *  buffers for that may not fit your chosen extreme resampling ratios. Also,
+ *  dealing with double precision does not make sense with the mathematical
+ *  limitations of the employed filters.
+ *
+ *  You are responsible for having your buffers prepared with the correct sizes.
+ *  Use syn123_resample_count() to ensure that you are prepared for the correct
+ *  number of output samples given your input sample count.
+ *
+ *  Also, ensuring a minimal number of input samples using
+ *  syn123_resample_incount() helps to identify an error situation where zero
+ *  samples are returned (which would be valid for low input sample count).
+ *  The only error apart from handing in an invalid/unprepared handle is
+ *  a too large number of input samples. Check syn123_resample_maxincount().
+ *
+ *  \param sh handle with prepared resampling method
+ *    If this is NULL or if the resampler has not been initialized before, the
+ *    function returns zero instead of crashing randomly.
+ *  \param dst destination buffer
+ *  \param src source buffer
+ *  \param samples input samples (PCM frames) in source buffer
+ *  \return number of output samples (PCM frames)
+ */
+MPG123_EXPORT
+size_t syn123_resample( syn123_handle *sh,
+	float * MPG123_RESTRICT dst, float * MPG123_RESTRICT src, size_t samples );
+
+/** Swap byte order between little/big endian.
+ *  \param buf buffer to work on
+ *  \param samplesize size of one sample (see MPG123_SAMPLESIZE)
+ *  \param samplecount count of samples
+ */
+MPG123_EXPORT
+void syn123_swap_bytes(void* buf, size_t samplesize, size_t samplecount);
+
+/* Wrappers over the above to convert to/from syn123's native byte order
+   from/to little or big endian. */
+
+/** Convert from host order to little endian.
+ *  \param buf buffer to work on
+ *  \param samplesize size of one sample (see MPG123_SAMPLESIZE)
+ *  \param samplecount count of samples
+ */
+MPG123_EXPORT
+void syn123_host2le(void *buf, size_t samplesize, size_t samplecount);
+
+/** Convert from host order to big endian.
+ *  \param buf buffer to work on
+ *  \param samplesize size of one sample (see MPG123_SAMPLESIZE)
+ *  \param samplecount count of samples
+ */
+MPG123_EXPORT
+void syn123_host2be(void *buf, size_t samplesize, size_t samplecount);
+
+/** Convert from little endian to host order.
+ *  \param buf buffer to work on
+ *  \param samplesize size of one sample (see MPG123_SAMPLESIZE)
+ *  \param samplecount count of samples
+ */
+MPG123_EXPORT
+void syn123_le2host(void *buf, size_t samplesize, size_t samplecount);
+
+/** Convert from big endian to host order.
+ *  \param buf buffer to work on
+ *  \param samplesize size of one sample (see MPG123_SAMPLESIZE)
+ *  \param samplecount count of samples
+ */
+MPG123_EXPORT
+void syn123_be2host(void *buf, size_t samplesize, size_t samplecount);
+
+// You are invited to defined SYN123_PORTABLE_API to avoid seeing shape-shifting off_t
+// anywhere, also to avoid using non-standard types like ssize_t.
+#if !defined(SYN123_PORTABLE_API) && !defined(SYN123_NO_LARGEFUNC)
+
+/** A little hack to help MSVC not having ssize_t, duplicated in internal header. */
+#ifdef _MSC_VER
+#include <stddef.h>
+typedef ptrdiff_t syn123_ssize_t;
+#else
+typedef ssize_t syn123_ssize_t;
+#endif
+
+/** Give exact output sample count for feeding given input now.
+ *
+ *  Old variant of syn123_resample_out() that (ab)uses ssize_t.
+ *
+ *  \deprecated Use syn123_resample_out() instead.
+ *    The return of errors (integer overflow in
+ *    calculation)is broken, as both the error codes and the valid results
+ *    are positive integers. I screwed up.
+ *
+ *  \param sh syn123 handle
+ *  \param ins input sample count
+ *  \return output sample count or error code, hard to distinguish
+ */
+MPG123_EXPORT
+syn123_ssize_t syn123_resample_expect(syn123_handle *sh, size_t ins);
+
+/** Give minimum input sample count needed now for given output.
+ *
+ *  Old variant of syn123_resample_in() that (ab)uses ssize_t.
+ *
+ *  \deprecated Use syn123_resample_in() instead.
+ *    The return of errors (integer overflow in
+ *    calculation)is broken, as both the error codes and the valid results
+ *    are positive integers. I screwed up.
+ *
+ *  \param sh syn123 handle
+ *  \param outs output sample count
+ *  \return minimal input sample count or error code, hard to distinguish
+ */
+MPG123_EXPORT
+syn123_ssize_t syn123_resample_inexpect(syn123_handle *sh, size_t outs);
+
+/* Lightweight large file hackery to enable worry-reduced use of off_t.
+   Depending on the size of off_t in your client build, the corresponding
+   library function needs to be chosen. */
+
+#if defined(_FILE_OFFSET_BITS) && !defined(MPG123_NO_LARGENAME)
+#  if _FILE_OFFSET_BITS+0 == 32
+#    define syn123_resample_total   syn123_resample_total_32
+#    define syn123_resample_intotal syn123_resample_intotal_32
+#  elif _FILE_OFFSET_BITS+0 == 64
+#    define syn123_resample_total   syn123_resample_total_64
+#    define syn123_resample_intotal syn123_resample_intotal_64
+#  else
+#    error "Unpredicted _FILE_OFFSET_BITS value."
+#  endif
+#endif
+
+/** Give exact output sample count for total input sample count.
+ *
+ *  This is syn123_resample_total64() with shape-shifting off_t,
+ *  possibly renamed by macro. For type safety, use the former.
+ *
+ *  \deprecated Use syn123_resample_total64() instead.
+ *
+ *  \param inrate input sample rate
+ *  \param outrate output sample rate
+ *  \param ins input sample count for the whole stream
+ *  \return number of output samples or -1 if the computation fails
+ *    (bad/too large sampling rates, integer overflow)
+ */
+MPG123_EXPORT
+off_t syn123_resample_total(long inrate, long outrate, off_t ins);
+
+/** Give minimum input sample count for total output sample count.
+ *
+ *  This is syn123_resample_intotal64() with shape-shifting off_t,
+ *  possibly renamed by macro. For type safety, use the former.
+ *
+ *  \deprecated Use syn123_resample_intotal64() instead.
+ *
+ *  \param inrate input sample rate
+ *  \param outrate output sample rate
+ *  \param outs output sample count for the whole stream
+ *  \return number of input samples or -1 if the computation fails
+ *    (bad/too large sampling rates, integer overflow)
+ */
+MPG123_EXPORT
+off_t syn123_resample_intotal(long inrate, long outrate, off_t outs);
+
+#endif
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
CN3Base::s_SndMgr.ReleaseObj(&m_pSnd_Rotate);
m_pSnd_Rotate =CN3Base::s_SndMgr.CreateObj(ID_SOUND_CHR_SELECT_ROTATE); seems to be causing massive fps drops
a dirty move to make it instantly play and stop seems to fix the issue. temporary fix

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Code style update (formatting, renaming)
- [x] Other (please describe):

## What is the current behaviour?
https://github.com/Open-KO/KnightOnline/issues/271

## What is the new behaviour?
Just a play stop instantly might not be the perfect way, but having the game drain everything is worse.

## Why and how did I change this?
Something was hugging up and it would only resolve once you rotated the chairs I tried initing lightning, animations, camera positions nothing helped untill i removed sounds from it then it was fine. Instead of going through all the hassle i thought about playing it once that did the trick but it played the ugly sound so I just did this instead.

## Demo
https://github.com/Open-KO/KnightOnline/issues/271

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
