### PR TITLE
correcting special items' appearance

### DIFF
--- a/Client/WarFare/GameBase.cpp
+++ b/Client/WarFare/GameBase.cpp
@@ -489,7 +489,8 @@ e_ItemType CGameBase::MakeResrcFileNameForUPC(	__TABLE_ITEM_BASIC* pItem,
 												std::string* pszIconFN,
 												e_PartPosition& ePartPosition,
 												e_PlugPosition& ePlugPosition,
-												e_Race eRace /*= RACE_UNKNOWN*/)
+												e_Race eRace /*= RACE_UNKNOWN*/,
+												__TABLE_ITEM_EXT* pItemExt /*= nullptr*/)
 {	
 	ePartPosition = PART_POS_UNKNOWN;
 	ePlugPosition = PLUG_POS_UNKNOWN;
@@ -546,27 +547,44 @@ e_ItemType CGameBase::MakeResrcFileNameForUPC(	__TABLE_ITEM_BASIC* pItem,
 	}
 
 	char buffer[256] = {};
+	
+	//check and replace icon and resource ids if item is special
+	int iIDResrc = 0, iIDIcon = 0;
+	
+	if (pItemExt != nullptr && pItemExt->dwIDResrc != 0)
+		iIDResrc = pItemExt->dwIDResrc;
+	else
+		iIDResrc = pItem->dwIDResrc;
+
+	if (pItemExt && pItemExt->dwIDIcon != 0)
+		iIDIcon = pItemExt->dwIDIcon;
+	else
+		iIDIcon = pItem->dwIDIcon;
+
 	if(pszResrcFN)
 	{
 		if(pItem->dwIDResrc) 
 		{
-			if(eRace != RACE_UNKNOWN && ePos >= /*ITEM_POS_DUAL*/ITEM_POS_UPPER && ePos <= ITEM_POS_SHOES) {
+			if (eRace != RACE_UNKNOWN && ePos >= /*ITEM_POS_DUAL*/ITEM_POS_UPPER && ePos <= ITEM_POS_SHOES)
+			{
 				// NOTE: no idea but perhaps this will work for now
 				sprintf(buffer, "Item\\%.1d_%.4d_%.2d_%.1d%s",
-					(pItem->dwIDResrc / 10000000),
-					((pItem->dwIDResrc / 1000) % 10000) + eRace,
-					(pItem->dwIDResrc / 10) % 100,
-					pItem->dwIDResrc % 10,
-					szExt.c_str());
-			} else {
-				sprintf(buffer, "Item\\%.1d_%.4d_%.2d_%.1d%s",
-					(pItem->dwIDResrc / 10000000),
-					(pItem->dwIDResrc / 1000) % 10000,
-					(pItem->dwIDResrc / 10) % 100,
-					pItem->dwIDResrc % 10,
+					(iIDResrc / 10000000),
+					((iIDResrc / 1000) % 10000) + eRace,
+					(iIDResrc / 10) % 100,
+					iIDResrc % 10,
 					szExt.c_str());
 			}
-
+			else
+			{
+				sprintf(buffer, "Item\\%.1d_%.4d_%.2d_%.1d%s",
+					(iIDResrc / 10000000),
+					(iIDResrc / 1000) % 10000,
+					(iIDResrc / 10) % 100,
+					iIDResrc % 10,
+					szExt.c_str());
+			}
+			
 			*pszResrcFN = buffer;
 		}
 		// Some items don't have models -- only icons.
@@ -577,11 +595,11 @@ e_ItemType CGameBase::MakeResrcFileNameForUPC(	__TABLE_ITEM_BASIC* pItem,
 	}
 	if(pszIconFN)
 	{
-		sprintf(buffer,	"UI\\ItemIcon_%.1d_%.4d_%.2d_%.1d.dxt",
-			(pItem->dwIDIcon / 10000000), 
-			(pItem->dwIDIcon / 1000) % 10000, 
-			(pItem->dwIDIcon / 10) % 100, 
-			pItem->dwIDIcon % 10);
+		sprintf(buffer, "UI\\ItemIcon_%.1d_%.4d_%.2d_%.1d.dxt",
+		(iIDIcon / 10000000),
+		(iIDIcon / 1000) % 10000,
+		(iIDIcon / 10) % 100,
+		iIDIcon % 10);
 		*pszIconFN = &buffer[0];
 	}
 	

--- a/Client/WarFare/GameBase.h
+++ b/Client/WarFare/GameBase.h
@@ -57,7 +57,8 @@ public:
 												std::string* szIconFN,
 												e_PartPosition& ePartPosition,
 												e_PlugPosition& ePlugPosition,
-												e_Race eRace = RACE_UNKNOWN);
+												e_Race eRace = RACE_UNKNOWN,
+												__TABLE_ITEM_EXT* pItemExt = nullptr);
 
 	class CPlayerBase*	CharacterGetByID(int iID, bool bFromAlive);
 	bool				IsValidCharacter(CPlayerBase* pCharacter);

--- a/Client/WarFare/GameProcCharacterSelect.cpp
+++ b/Client/WarFare/GameProcCharacterSelect.cpp
@@ -617,8 +617,12 @@ void CGameProcCharacterSelect::AddChrPart(	int iPosIndex,
 	CN3CPart* pPart = NULL;
 	e_PartPosition ePartPosTmp = PART_POS_UNKNOWN;
 	e_PlugPosition ePlugPosTmp = PLUG_POS_UNKNOWN;
+	
+	__TABLE_ITEM_EXT* pItemExt = nullptr;
+	if(pItem != nullptr)
+		pItemExt = s_pTbl_Items_Exts[pItem->byExtIndex].Find(dwItemID % 1000);
 
-	CGameProcedure::MakeResrcFileNameForUPC(pItem, &szResrcFN, NULL, ePartPosTmp, ePlugPosTmp, m_InfoChrs[iPosIndex].eRace);
+	CGameProcedure::MakeResrcFileNameForUPC(pItem, &szResrcFN, NULL, ePartPosTmp, ePlugPosTmp, m_InfoChrs[iPosIndex].eRace, pItemExt);
 	if(szResrcFN.empty()) pPart = m_pChrs[iPosIndex]->PartSet(ePartPos, pLooks->szPartFNs[ePartPos]);	// 기본 파트
 	else pPart = m_pChrs[iPosIndex]->PartSet(ePartPos, szResrcFN);
 	if(pPart && pItem && pItem->siMaxDurability > 0)

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -1988,7 +1988,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 
 		e_PartPosition ePart;
 		e_PlugPosition ePlug;
-		e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, &szResrcFN, &szIconFN, ePart, ePlug, s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+		e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, &szResrcFN, &szIconFN, ePart, ePlug, s_pPlayer->m_InfoBase.eRace, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 		if(ITEM_TYPE_UNKNOWN == eType) CLogWriter::Write("MyInfo - slot - Unknown Item");
 		__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item Type");
 		e_ItemSlot eSlot = (e_ItemSlot)i;
@@ -2071,7 +2071,7 @@ bool CGameProcMain::MsgRecv_MyInfo_All(Packet& pkt)
 
 		e_PartPosition ePart;
 		e_PlugPosition ePlug;
-		e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+		e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, s_pPlayer->m_InfoBase.eRace, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 		if(ITEM_TYPE_UNKNOWN == eType) CLogWriter::Write("MyInfo - slot - Unknown Item");
 		__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item");
 		
@@ -2893,7 +2893,7 @@ bool CGameProcMain::MsgRecv_NPCIn(Packet& pkt)
 				e_PartPosition ePart;
 				e_PlugPosition ePlug;
 				std::string szItemFN;
-				CGameProcedure::MakeResrcFileNameForUPC(pItem0, &szItemFN, NULL, ePart, ePlug, s_pPlayer->m_InfoBase.eRace);
+				CGameProcedure::MakeResrcFileNameForUPC(pItem0, &szItemFN, NULL, ePart, ePlug, s_pPlayer->m_InfoBase.eRace, pItemExt0);
 				pNPC->PlugSet(PLUG_POS_RIGHTHAND, szItemFN, pItem0, pItemExt0);
 			}
 			else
@@ -2913,7 +2913,7 @@ bool CGameProcMain::MsgRecv_NPCIn(Packet& pkt)
 				e_PartPosition ePart;
 				e_PlugPosition ePlug;
 				std::string szItemFN;
-				CGameProcedure::MakeResrcFileNameForUPC(pItem1, &szItemFN, NULL, ePart, ePlug, s_pPlayer->m_InfoBase.eRace);
+				CGameProcedure::MakeResrcFileNameForUPC(pItem1, &szItemFN, NULL, ePart, ePlug, s_pPlayer->m_InfoBase.eRace, pItemExt1);
 				pNPC->PlugSet(PLUG_POS_LEFTHAND, szItemFN, pItem1, pItemExt1);
 			}
 			else
@@ -3413,7 +3413,7 @@ bool CGameProcMain::MsgRecv_UserLookChange(Packet& pkt)
 		if(dwItemID) // 아이템이 있는 경우
 		{
 			std::string szItemFN;
-			CGameProcedure::MakeResrcFileNameForUPC(pItem, &szItemFN, NULL, ePartPos2, ePlugPos2, s_pPlayer->m_InfoBase.eRace);
+			CGameProcedure::MakeResrcFileNameForUPC(pItem, &szItemFN, NULL, ePartPos2, ePlugPos2, s_pPlayer->m_InfoBase.eRace, pItemExt);
 			pUPC->PartSet(ePartPos, szItemFN, pItem, pItemExt); // 아이템 붙이기..
 			pUPC->DurabilitySet(eSlot, iDurability);
 		}

--- a/Client/WarFare/PlayerBase.cpp
+++ b/Client/WarFare/PlayerBase.cpp
@@ -2001,7 +2001,7 @@ CN3CPart* CPlayerBase::PartSet(e_PartPosition ePos, const std::string& szFN, __T
 					e_PartPosition ePartPos2 = PART_POS_UNKNOWN;
 					e_PlugPosition ePlugPos2 = PLUG_POS_UNKNOWN;
 
-					CGameProcedure::MakeResrcFileNameForUPC(m_pItemPartBasics[PART_POS_LOWER], &szFN2, NULL, ePartPos2, ePlugPos2, m_InfoBase.eRace);
+					CGameProcedure::MakeResrcFileNameForUPC(m_pItemPartBasics[PART_POS_LOWER], &szFN2, NULL, ePartPos2, ePlugPos2, m_InfoBase.eRace, pItemExt);
 					this->PartSet(PART_POS_LOWER, szFN2, m_pItemPartBasics[PART_POS_LOWER], m_pItemPartExts[PART_POS_LOWER]); // 하체에 전의 옷을 입힌다..
 				}
 				else // 하체에 입고 있었던 아이템이 없다면..

--- a/Client/WarFare/PlayerMySelf.cpp
+++ b/Client/WarFare/PlayerMySelf.cpp
@@ -656,7 +656,7 @@ CN3CPart* CPlayerMySelf::PartSet(e_PartPosition ePos, const std::string& szFN, _
 					std::string szFN2;
 					e_PartPosition ePartPos2 = PART_POS_UNKNOWN;
 					e_PlugPosition ePlugPos2 = PLUG_POS_UNKNOWN;
-					CGameProcedure::MakeResrcFileNameForUPC(m_pItemPartBasics[PART_POS_LOWER], &szFN2, NULL, ePartPos2, ePlugPos2, m_InfoBase.eRace);
+					CGameProcedure::MakeResrcFileNameForUPC(m_pItemPartBasics[PART_POS_LOWER], &szFN2, NULL, ePartPos2, ePlugPos2, m_InfoBase.eRace, pItemExt);
 					
 					m_ChrInv.PartSet(PART_POS_LOWER, szFN2); // 하체에 전의 옷을 입힌다..
 					m_Chr.PartSet(PART_POS_LOWER, szFN2);

--- a/Client/WarFare/PlayerOther.cpp
+++ b/Client/WarFare/PlayerOther.cpp
@@ -88,7 +88,7 @@ bool CPlayerOther::Init(e_Race eRace, int iFace, int iHair, uint32_t* pdwItemIDs
 			}
 
 
-			e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, &szFN, NULL, ePart, ePlug, m_InfoBase.eRace); // 리소스 파일 이름을 만들고..
+			e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, &szFN, NULL, ePart, ePlug, m_InfoBase.eRace, pItemExt); // 리소스 파일 이름을 만들고..
 
 			if(0 == i) { ePart = PART_POS_UPPER;			eSlot = ITEM_SLOT_UPPER; }
 			else if(1 == i) { ePart = PART_POS_LOWER;		eSlot = ITEM_SLOT_LOWER; }

--- a/Client/WarFare/SubProcPerTrade.cpp
+++ b/Client/WarFare/SubProcPerTrade.cpp
@@ -911,7 +911,7 @@ void CSubProcPerTrade::ReceiveMsgPerTradeOtherAdd(int iItemID, int iCount, int i
 				std::string szIconFN;
 				e_PartPosition ePart;
 				e_PlugPosition ePlug;
-				CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+				CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, RACE_UNKNOWN, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 
 				__IconItemSkill* spItem;
 
@@ -959,7 +959,7 @@ void CSubProcPerTrade::ReceiveMsgPerTradeOtherAdd(int iItemID, int iCount, int i
 			std::string szIconFN;
 			e_PartPosition ePart;
 			e_PlugPosition ePlug;
-			CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+			CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, RACE_UNKNOWN, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 
 			__IconItemSkill* spItem;
 
@@ -1075,7 +1075,7 @@ Make_Icon:
 	std::string szIconFN;
 	e_PartPosition ePart;
 	e_PlugPosition ePlug;
-	CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+	CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, RACE_UNKNOWN, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 
 	spItem				= new __IconItemSkill;
 	spItem->pItemBasic	= pItem;

--- a/Client/WarFare/UIDroppedItemDlg.cpp
+++ b/Client/WarFare/UIDroppedItemDlg.cpp
@@ -243,7 +243,7 @@ void CUIDroppedItemDlg::AddToItemTable(int iItemID, int iItemCount, int iOrder)
 	//TRACE("Dropped item from server to ItemDlg %d \n", iItemID);
 	e_PartPosition ePart;
 	e_PlugPosition ePlug;
-	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, RACE_UNKNOWN, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 	if ( ITEM_TYPE_UNKNOWN == eType ) return;
 	
 	spItem = new __IconItemSkill;
@@ -278,7 +278,7 @@ void CUIDroppedItemDlg::AddToItemTableToInventory(int iItemID, int iItemCount, i
 	//TRACE("Dropped item from server to ItemDlg %d \n", iItemID);
 	e_PartPosition ePart;
 	e_PlugPosition ePlug;
-	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, RACE_UNKNOWN, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 	if ( ITEM_TYPE_UNKNOWN == eType ) return;
 	
 	spItem = new __IconItemSkill;
@@ -424,7 +424,7 @@ bool CUIDroppedItemDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 				break;
 			}
 
-			eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+			eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, RACE_UNKNOWN, spItem->pItemExt); // 아이템에 따른 파일 이름을 만들어서
 
 			// 보낸 아이콘 배열이랑 비교.. 
 			iOrder = GetItemiOrder( spItem );

--- a/Client/WarFare/UIInventory.cpp
+++ b/Client/WarFare/UIInventory.cpp
@@ -612,11 +612,13 @@ int	CUIInventory::GetArmDestinationIndex(__IconItemSkill* spItem)
 		return false;
 
 	__TABLE_ITEM_BASIC*		pItem;
+	__TABLE_ITEM_EXT* pItemExt = nullptr;
 	pItem = CN3UIWndBase::m_sSelectedIconInfo.pItemSelect->pItemBasic;
+	pItemExt = CN3UIWndBase::m_sSelectedIconInfo.pItemSelect->pItemExt;
 
 	e_PartPosition ePart;
 	e_PlugPosition ePlug;
-	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 	if(ITEM_TYPE_UNKNOWN == eType) return false;
 
 	if ( IsValidRaceAndClass(pItem, CN3UIWndBase::m_sSelectedIconInfo.pItemSelect->pItemExt) )
@@ -1902,11 +1904,14 @@ bool CUIInventory::IsValidPosFromInvToArm(int iOrder)
 		return false;
 
 	__TABLE_ITEM_BASIC*		pItem;
+	__TABLE_ITEM_EXT* pItemExt;
+
 	pItem = CN3UIWndBase::m_sSelectedIconInfo.pItemSelect->pItemBasic;
+	pItemExt = CN3UIWndBase::m_sSelectedIconInfo.pItemSelect->pItemExt;
 
 	e_PartPosition ePart;
 	e_PlugPosition ePlug;
-	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 	if(ITEM_TYPE_UNKNOWN == eType) return false;
 
 	if ( IsValidRaceAndClass(pItem, CN3UIWndBase::m_sSelectedIconInfo.pItemSelect->pItemExt) )
@@ -2187,11 +2192,13 @@ bool CUIInventory::IsValidPosFromArmToArm(int iOrder)
 		return false;
 
 	__TABLE_ITEM_BASIC*		pItem;
+	__TABLE_ITEM_EXT* pItemExt;
 	pItem = CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic;
+	pItemExt = CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemExt;
 
 	e_PartPosition ePart;
 	e_PlugPosition ePlug;
-	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 	if(ITEM_TYPE_UNKNOWN == eType) return false;
 
 	if ( IsValidRaceAndClass(pItem, CN3UIWndBase::m_sSelectedIconInfo.pItemSelect->pItemExt) )
@@ -2246,11 +2253,13 @@ bool CUIInventory::IsValidPosFromArmToArmInverse(int iOrder)
 		return false;
 
 	__TABLE_ITEM_BASIC*		pItem;
+	__TABLE_ITEM_EXT* pItemExt;
 	pItem = CN3UIWndBase::m_sRecoveryJobInfo.pItemTarget->pItemBasic;
+	pItemExt = CN3UIWndBase::m_sRecoveryJobInfo.pItemTarget->pItemExt;
 
 	e_PartPosition ePart;
 	e_PlugPosition ePlug;
-	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace,pItemExt); // 아이템에 따른 파일 이름을 만들어서
 	if(ITEM_TYPE_UNKNOWN == eType) return false;
 
 	if ( IsValidRaceAndClass(pItem, CN3UIWndBase::m_sSelectedIconInfo.pItemSelect->pItemExt) )
@@ -2305,7 +2314,7 @@ void CUIInventory::ItemAdd(__TABLE_ITEM_BASIC* pItem, __TABLE_ITEM_EXT* pItemExt
 	std::string szFN;
 	e_PartPosition ePart;
 	e_PlugPosition ePlug;
-	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, &szFN, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, &szFN, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace,pItemExt); // 아이템에 따른 파일 이름을 만들어서
 
 	if(ITEM_TYPE_PLUG == eType)
 	{
@@ -2331,7 +2340,7 @@ void CUIInventory::ItemDelete(__TABLE_ITEM_BASIC* pItem, __TABLE_ITEM_EXT* pItem
 
 	e_PartPosition ePart;
 	e_PlugPosition ePlug;
-	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, NULL, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace,pItemExt); // 아이템에 따른 파일 이름을 만들어서
 	
 	if(pLooks)
 	{
@@ -2450,7 +2459,7 @@ void CUIInventory::ItemCountChange(int iDistrict, int iIndex, int iCount, int iI
 				e_PartPosition ePart;
 				e_PlugPosition ePlug;
 				std::string szIconFN;
-				e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+				e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace,pItemExt); // 아이템에 따른 파일 이름을 만들어서
 				if(ITEM_TYPE_UNKNOWN == eType) CLogWriter::Write("MyInfo - slot - Unknown Item");
 				__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item");
 				
@@ -2505,7 +2514,7 @@ void CUIInventory::ItemCountChange(int iDistrict, int iIndex, int iCount, int iI
 				e_PartPosition ePart;
 				e_PlugPosition ePlug;
 				std::string szIconFN;
-				e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+				e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace,pItemExt); // 아이템에 따른 파일 이름을 만들어서
 				if(ITEM_TYPE_UNKNOWN == eType) 
 				{ 
 					CLogWriter::Write("MyInfo - slot - Unknown Item");
@@ -2562,7 +2571,7 @@ void CUIInventory::ItemCountChange(int iDistrict, int iIndex, int iCount, int iI
 				e_PartPosition ePart;
 				e_PlugPosition ePlug;
 				std::string szIconFN;
-				e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+				e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace,pItemExt); // 아이템에 따른 파일 이름을 만들어서
 				if(ITEM_TYPE_UNKNOWN == eType) CLogWriter::Write("MyInfo - slot - Unknown Item");
 				__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item");
 				
@@ -2617,7 +2626,7 @@ void CUIInventory::ItemCountChange(int iDistrict, int iIndex, int iCount, int iI
 				e_PartPosition ePart;
 				e_PlugPosition ePlug;
 				std::string szIconFN;
-				e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace); // 아이템에 따른 파일 이름을 만들어서
+				e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, CGameBase::s_pPlayer->m_InfoBase.eRace,pItemExt); // 아이템에 따른 파일 이름을 만들어서
 				if(ITEM_TYPE_UNKNOWN == eType) CLogWriter::Write("MyInfo - slot - Unknown Item");
 				__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item");
 				

--- a/Client/WarFare/UITransactionDlg.cpp
+++ b/Client/WarFare/UITransactionDlg.cpp
@@ -314,7 +314,7 @@ void CUITransactionDlg::EnterTransactionState()
 
 		e_PartPosition ePart;
 		e_PlugPosition ePlug;
-		e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+		e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, RACE_UNKNOWN, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 		__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item");
 
 		spItem = new __IconItemSkill;
@@ -985,7 +985,7 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 					e_PartPosition ePart;
 					e_PlugPosition ePlug;
 					CGameProcedure::MakeResrcFileNameForUPC(m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->pItemBasic, 
-						NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+						NULL, &szIconFN, ePart, ePlug, RACE_UNKNOWN, m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]->pItemExt); // 아이템에 따른 파일 이름을 만들어서
 
 					__IconItemSkill* spItemNew;
 					spItemNew				= new __IconItemSkill;

--- a/Client/WarFare/UIWareHouseDlg.cpp
+++ b/Client/WarFare/UIWareHouseDlg.cpp
@@ -1803,7 +1803,7 @@ void CUIWareHouseDlg::AddItemInWare(int iItem, int iDurability, int iCount, int 
 
 	e_PartPosition ePart;
 	e_PlugPosition ePlug;
-	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug); // 아이템에 따른 파일 이름을 만들어서
+	e_ItemType eType = CGameProcedure::MakeResrcFileNameForUPC(pItem, NULL, &szIconFN, ePart, ePlug, RACE_UNKNOWN, pItemExt); // 아이템에 따른 파일 이름을 만들어서
 	if(ITEM_TYPE_UNKNOWN == eType) CLogWriter::Write("MyInfo - slot - Unknown Item");
 	__ASSERT(ITEM_TYPE_UNKNOWN != eType, "Unknown Item");
 	


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Items like scorpion shield, chitin shield, gigantic axe don't appear correctly, their ui icons and resource ids are wrong.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Special items which have additional resource and icon id inside Item_ext_[number].tbl overwritten so they now look correct.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
Core visual feature.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
