### PR TITLE
implementation of UIMsgBoxOkCancel

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -292,7 +292,7 @@ enum e_ItemClass	{	ITEM_CLASS_DAGGER = 11, // dagger
 						ITEM_CLASS_ARMOR_PRIEST = 240, // Priest armor
 
 						ITEM_CLASS_ETC = 251, // Miscellaneous
-
+						ITEM_CLASS_POWER_SCROLL = 255, //scrolls,premiums and power up potions, pets
 						ITEM_CLASS_UNKNOWN = 0xffffffff }; // 
 
 enum e_Nation { NATION_NOTSELECTED = 0, NATION_KARUS, NATION_ELMORAD, NATION_UNKNOWN = 0xffffffff };

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -55,6 +55,7 @@
 #include "UIDead.h"
 #include "UIUpgradeSelect.h"
 #include "UILevelGuide.h"
+#include "UIMsgBoxOkCancel.h"
 
 #include "SubProcPerTrade.h"
 #include "CountableItemEditDlg.h"
@@ -4190,6 +4191,22 @@ void CGameProcMain::InitUI()
 	iX = iW - (rc.right - rc.left);
 	iY = 10; //same pos with inventory
 	m_pUILevelGuide->SetPos(iX, iY);
+
+	
+	CN3UIWndBase::m_pMsgBoxOkCancel = new CUIMsgBoxOkCancel;
+	CN3UIWndBase::m_pMsgBoxOkCancel->Init(s_pUIMgr);
+	CN3UIWndBase::m_pMsgBoxOkCancel->LoadFromFile(pTbl->szMsgBoxOkCancel);
+	CN3UIWndBase::m_pMsgBoxOkCancel->SetStyle(UISTYLE_ALWAYSTOP);
+	rc = CN3UIWndBase::m_pMsgBoxOkCancel->GetRegion();
+	iX = (iW - (rc.right - rc.left)) / 2;
+	iY = (iH - (rc.bottom - rc.top)) / 2;
+	CN3UIWndBase::m_pMsgBoxOkCancel->SetPos(iX, iY);
+	CN3UIWndBase::m_pMsgBoxOkCancel->SetVisibleWithNoSound(false);
+	CN3UIWndBase::m_pMsgBoxOkCancel->SetUIType(UI_TYPE_BASE);
+	CN3UIWndBase::m_pMsgBoxOkCancel->SetState(UI_STATE_COMMON_NONE);
+	//add customized ID because this UI file dont have base ID, 
+	//it is required to make it on top on UImanager.
+	CN3UIWndBase::m_pMsgBoxOkCancel->SetID("base_msgboxokcancel");
 
 }
 

--- a/Client/WarFare/N3UIWndBase.cpp
+++ b/Client/WarFare/N3UIWndBase.cpp
@@ -31,6 +31,7 @@ __SkillSelectInfo		CN3UIWndBase::m_sSkillSelectInfo;
 
 CN3UIImage* CN3UIWndBase::m_pSelectionImage = NULL;
 CCountableItemEditDlg*	CN3UIWndBase::m_pCountableItemEdit = NULL;
+CUIMsgBoxOkCancel* CN3UIWndBase::m_pMsgBoxOkCancel = nullptr;
 
 CN3SndObj* CN3UIWndBase::s_pSnd_Item_Etc = NULL;
 CN3SndObj* CN3UIWndBase::s_pSnd_Item_Weapon = NULL;

--- a/Client/WarFare/N3UIWndBase.h
+++ b/Client/WarFare/N3UIWndBase.h
@@ -126,6 +126,7 @@ const int UIITEM_COUNT_FEW = 500;
 
 class CUIImageTooltipDlg;
 class CCountableItemEditDlg;
+class CUIMsgBoxOkCancel;
 
 // Class ^^
 class CN3UIWndBase  : public CN3UIBase		// 가상 함수로 자식의 Area 갯수를 파악할 수 있는 함수가 있어야 하지 않을 까???
@@ -141,6 +142,7 @@ public:
 	static __SkillSelectInfo		m_sSkillSelectInfo;
 	static CN3UIImage*				m_pSelectionImage;
 	static CCountableItemEditDlg*	m_pCountableItemEdit;
+	static CUIMsgBoxOkCancel*		m_pMsgBoxOkCancel;
 
 protected:
 	e_UIWND						m_eUIWnd;

--- a/Client/WarFare/UIManager.cpp
+++ b/Client/WarFare/UIManager.cpp
@@ -12,6 +12,7 @@
 #include "UITransactionDlg.h"
 #include "SubProcPerTrade.h"
 #include "CountableItemEditDlg.h"
+#include "UIMsgBoxOkCancel.h"
 #include "UIItemExchange.h"
 #include "UIWareHouseDlg.h"
 
@@ -61,10 +62,19 @@ uint32_t CUIManager::MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT
 		if ( CGameProcedure::s_pProcMain && CGameProcedure::s_pProcMain->m_pUITransactionDlg && 
 			(CGameProcedure::s_pProcMain->m_pUITransactionDlg->IsVisible()))// && (pChild->UIType() != UI_TYPE_ICON_MANAGER) )
 		{	
-			if ( CN3UIWndBase::m_pCountableItemEdit->IsLocked() )
+			if ( CN3UIWndBase::m_pCountableItemEdit->IsLocked())
 			{
 				if ( pChild->m_szID.compare("base_tradeedit") != 0 )
 					{	++itor; continue;	}
+			}
+
+			
+			if (CN3UIWndBase::m_pMsgBoxOkCancel->IsLocked())
+			{
+				if (pChild->m_szID.compare("base_msgboxokcancel") != 0)
+				{
+					++itor; continue;
+				}
 			}
 		}
 		// 보관함에 보관중이면 아이콘 매니저 윈도우만 작동..

--- a/Client/WarFare/UIMsgBoxOkCancel.cpp
+++ b/Client/WarFare/UIMsgBoxOkCancel.cpp
@@ -1,0 +1,176 @@
+﻿// UIMsgBoxOkCancel.cpp: implementation of the CUIMsgBoxOkCancel class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#include "stdafx.h"
+#include "UIMsgBoxOkCancel.h"
+#include <N3Base/N3UIButton.h>
+#include <N3Base/N3UIString.h>
+#include "GameProcMain.h"
+#include "UIManager.h"
+#include "UITransactionDlg.h"
+
+#ifdef _DEBUG
+#undef THIS_FILE
+static char THIS_FILE[] = __FILE__;
+#define new DEBUG_NEW
+#endif
+
+//////////////////////////////////////////////////////////////////////
+// Construction/Destruction
+//////////////////////////////////////////////////////////////////////
+
+CUIMsgBoxOkCancel::CUIMsgBoxOkCancel()
+{
+	m_eCallerWnd = UIWND_UNKNOWN;
+	m_eCallerWndDistrict = UIWND_DISTRICT_UNKNOWN;
+	m_pBtn_OK = nullptr;
+	m_pBtn_Cancel = nullptr;
+	m_pText_Msg = nullptr;
+	m_bLocked = false;
+}
+
+CUIMsgBoxOkCancel::~CUIMsgBoxOkCancel()
+{
+
+}
+
+void CUIMsgBoxOkCancel::Release()
+{
+	CN3UIBase::Release();
+}
+
+bool CUIMsgBoxOkCancel::Load(HANDLE hFile)
+{
+	if (CN3UIBase::Load(hFile) == false) return false;
+
+	N3_VERIFY_UI_COMPONENT(m_pBtn_OK, (CN3UIButton*) GetChildByID("btn_ok"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel, (CN3UIButton*) GetChildByID("btn_cancel"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Msg, (CN3UIString*) GetChildByID("text_msg"));
+
+	return true;
+}
+
+void CUIMsgBoxOkCancel::SetText(const std::string& szMsg)
+{
+	m_pText_Msg->SetString(szMsg);
+}
+
+void CUIMsgBoxOkCancel::Open(e_UIWND eUW, e_UIWND_DISTRICT eUD)
+{
+	m_bLocked = true;
+
+	SetVisible(true);
+	
+	m_eCallerWnd = eUW;
+	m_eCallerWndDistrict = eUD;
+
+	RECT rcParent, rcMsgBox;
+	int iParentW = 0, iParentH = 0, iParentX = 0, iParentY = 0;
+
+	//this ui region
+	rcMsgBox = GetRegion();
+	int iMsgW = rcMsgBox.right - rcMsgBox.left;
+	int iMsgH = rcMsgBox.bottom - rcMsgBox.top;
+
+	int iX = 0, iY = 0;
+
+	switch (eUW)
+	{
+		case UIWND_TRANSACTION:
+			rcParent = CGameProcedure::s_pProcMain->m_pUITransactionDlg->GetRegion();
+			break;
+		default:
+			rcParent = CGameProcedure::s_pProcMain->m_pUITransactionDlg->GetRegion();
+			break;
+		//note: this can be used inside other UI files in the future
+	}
+
+	iParentW = rcParent.right - rcParent.left;
+	iParentH = rcParent.bottom - rcParent.top;
+	iParentX = rcParent.left;
+	iParentY = rcParent.top;
+
+	if (eUW == UIWND_TRANSACTION)
+	{
+		iX = iParentX + (iParentW - iMsgW) / 2;
+		//Note: this is close to correct position, but better calc. is needed
+		iY = iParentY + (iParentH / 2) - iMsgH - 30; 
+	}
+
+	SetPos(iX, iY);
+
+}
+
+void CUIMsgBoxOkCancel::Close()
+{
+	m_bLocked = false;
+
+	SetVisibleWithNoSound(false); 
+}
+
+bool CUIMsgBoxOkCancel::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
+{
+	if (pSender == nullptr) return false;
+	if (IsVisible() == false) return false;
+	if (m_eCallerWnd == UIWND_UNKNOWN) return false;
+	if (m_eCallerWndDistrict == UIWND_DISTRICT_UNKNOWN) return false;
+	
+	if (dwMsg == UIMSG_BUTTON_CLICK)
+	{
+		if (pSender == m_pBtn_Cancel)
+		{
+			
+			switch (m_eCallerWnd)
+			{
+				case UIWND_TRANSACTION:
+					switch (m_eCallerWndDistrict)
+					{
+						case UIWND_DISTRICT_TRADE_NPC:
+						case UIWND_DISTRICT_TRADE_MY:
+							CGameProcedure::s_pProcMain->m_pUITransactionDlg->MsgBoxCancel();
+							break;
+					}
+					break;
+			}
+
+		}
+		else if (pSender == m_pBtn_OK)
+		{
+
+			switch (m_eCallerWnd)
+			{
+				case UIWND_TRANSACTION:
+					switch (m_eCallerWndDistrict)
+					{
+						case UIWND_DISTRICT_TRADE_NPC:
+						case UIWND_DISTRICT_TRADE_MY:
+							CGameProcedure::s_pProcMain->m_pUITransactionDlg->MsgBoxOK();
+							break;
+					}
+					break;
+			}
+
+		}
+	}
+	
+}
+
+void CUIMsgBoxOkCancel::SetVisible(bool bVisible)
+{
+	CN3UIBase::SetVisible(bVisible);
+	if (bVisible)
+		CGameProcedure::s_pUIMgr->SetVisibleFocusedUI(this);
+	else
+		CGameProcedure::s_pUIMgr->ReFocusUI();//this_ui
+}
+
+void CUIMsgBoxOkCancel::SetVisibleWithNoSound(bool bVisible, bool bWork, bool bReFocus)
+{
+	if (bWork)
+	{
+		ReceiveMessage(m_pBtn_Cancel, UIMSG_BUTTON_CLICK);
+	}
+
+	CN3UIBase::SetVisibleWithNoSound(bVisible, bWork, bReFocus);
+}

--- a/Client/WarFare/UIMsgBoxOkCancel.h
+++ b/Client/WarFare/UIMsgBoxOkCancel.h
@@ -1,0 +1,39 @@
+﻿// UIMsgBoxOkCancel.h: interface for the CUIMsgBoxOkCancel class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#if !defined(AFX_UIMSGBOXOKCANCEL_H__943941D4_06D0_40A0_BEF2_DA3A27406EDC__INCLUDED_)
+#define AFX_UIMSGBOXOKCANCEL_H__943941D4_06D0_40A0_BEF2_DA3A27406EDC__INCLUDED_
+
+#if _MSC_VER > 1000
+#pragma once
+#endif // _MSC_VER > 1000
+
+#include "N3UIWndBase.h"
+
+class CUIMsgBoxOkCancel : public CN3UIBase {
+	e_UIWND				m_eCallerWnd;
+	e_UIWND_DISTRICT	m_eCallerWndDistrict;
+	bool m_bLocked;
+public:
+	CN3UIButton* m_pBtn_OK;
+	CN3UIButton* m_pBtn_Cancel;
+	CN3UIString* m_pText_Msg;
+	
+public:
+	CUIMsgBoxOkCancel();
+	virtual ~CUIMsgBoxOkCancel() override;
+	bool Load(HANDLE hFile) override;
+	void Release() override;
+	void SetVisible(bool bVisible) override;
+	void SetVisibleWithNoSound(bool bVisible, bool bWork = false, bool bReFocus = false) override;
+	void Close();
+	void Open(e_UIWND eUW, e_UIWND_DISTRICT eUD);
+	void SetText(const std::string& szMsg);
+	bool IsLocked() const { return m_bLocked; }
+	e_UIWND	GetCallerWnd() const { return m_eCallerWnd; }
+	e_UIWND_DISTRICT GetCallerWndDistrict() const { return m_eCallerWndDistrict; }
+	bool ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg) override;
+};
+
+#endif // !defined(AFX_UIMSGBOXOKCANCEL_H__943941D4_06D0_40A0_BEF2_DA3A27406EDC__INCLUDED_)

--- a/Client/WarFare/UITransactionDlg.cpp
+++ b/Client/WarFare/UITransactionDlg.cpp
@@ -11,6 +11,7 @@
 #include "UIImageTooltipDlg.h"
 #include "UIInventory.h"
 #include "UIManager.h"
+#include "UIMsgBoxOkCancel.h"
 #include "PlayerMySelf.h"
 #include "CountableItemEditDlg.h"
 #include "UIHotKeyDlg.h"
@@ -177,12 +178,12 @@ void CUITransactionDlg::InitIconWnd(e_UIWND eWnd)
 
 	CN3UIWndBase::InitIconWnd(eWnd);
 
-	m_pStrMyGold    = (CN3UIString* )GetChildByID("string_item_name"); __ASSERT(m_pStrMyGold, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pStrMyGold, (CN3UIString*) GetChildByID("string_item_name"));
 	if(m_pStrMyGold) m_pStrMyGold->SetString("0");
 
-	m_pUIInn		= (CN3UIImage*)GetChildByID("img_inn");			__ASSERT(m_pUIInn, "NULL UI Component!!");
-	m_pUIBlackSmith = (CN3UIImage*)GetChildByID("img_blacksmith");	__ASSERT(m_pUIBlackSmith, "NULL UI Component!!");
-	m_pUIStore		= (CN3UIImage*)GetChildByID("img_store");		__ASSERT(m_pUIStore, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pUIInn, (CN3UIImage*) GetChildByID("img_inn"));
+	N3_VERIFY_UI_COMPONENT(m_pUIBlackSmith, (CN3UIImage*) GetChildByID("img_blacksmith"));
+	N3_VERIFY_UI_COMPONENT(m_pUIStore, (CN3UIImage*) GetChildByID("img_store"));
 	N3_VERIFY_UI_COMPONENT(m_pText_Weight, (CN3UIString*) GetChildByID("text_weight"));
 }
 
@@ -388,6 +389,30 @@ void CUITransactionDlg::GoldUpdate()
 
 	std::string strGold = CGameBase::FormatNumber(CGameBase::s_pPlayer->m_InfoExt.iGold);
 	m_pStrMyGold->SetString(strGold);
+}
+
+//generates item name, can be moved to main scope
+void CUITransactionDlg::GenerateItemName(__IconItemSkill* pItem, std::string& strName)
+{
+	if (pItem == nullptr)
+		return;
+
+	if ((e_ItemAttrib) (pItem->pItemExt->byMagicOrRare) != ITEM_ATTRIB_UNIQUE)
+	{
+		std::string strtemp;
+		if (pItem->pItemExt->dwID % 10 != 0)
+		{
+			char szExtID[20] = {};
+			sprintf(szExtID, "(+%d)", pItem->pItemExt->dwID % 10);
+			strtemp = szExtID;
+		}
+
+		strName = pItem->pItemBasic->szName + strtemp;
+	}
+	else
+	{
+		strName = pItem->pItemExt->szHeader;
+	}
 }
 
 void CUITransactionDlg::ItemMoveFromInvToThis()
@@ -665,6 +690,46 @@ void CUITransactionDlg::ItemCountCancel()
 
 	m_pCountableItemEdit->Close();
 }
+
+void CUITransactionDlg::MsgBoxCancel()
+{
+	s_bWaitFromServer = false;
+	m_sRecoveryJobInfo.pItemSource = nullptr;
+	m_sRecoveryJobInfo.pItemTarget = nullptr;
+
+	m_pMsgBoxOkCancel->Close();
+}
+
+void CUITransactionDlg::MsgBoxOK()
+{
+	//int iGold = CGameBase::s_pPlayer->m_InfoExt.iGold; //player gold can be used while buying
+	__IconItemSkill* spItem, * spItemNew = nullptr;
+
+	//other option is not possible target is always NPC
+	//but it can be used for high price items like gold bar etc.
+	switch (CN3UIWndBase::m_pMsgBoxOkCancel->GetCallerWndDistrict())
+	{
+		case UIWND_DISTRICT_TRADE_NPC: //buy,NPC to inventory
+			spItem = m_pMyTrade[m_iCurPage][CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder];
+			break;
+		case UIWND_DISTRICT_TRADE_MY: //sell,inventory to NPC
+			spItem = m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder];
+
+			s_bWaitFromServer = true;
+
+			spItem->pUIIcon->SetVisible(false);
+			
+			SendToServerSellMsg(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->dwID +
+				CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemExt->dwID,
+				CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder, 
+				CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->iCount);
+			break;
+	}
+
+	CN3UIWndBase::m_pMsgBoxOkCancel->Close();
+
+}
+
 
 void CUITransactionDlg::SendToServerSellMsg(int itemID, byte pos, int iCount)
 {
@@ -1037,11 +1102,40 @@ bool CUITransactionDlg::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 				}
 				else
 				{
-					// Server에게 보낸다..
-					SendToServerSellMsg(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->dwID+
-						CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemExt->dwID, 
-						CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder, 
-						CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->iCount);
+					//display MsgBoxOkCancel if item type is unique or upgrade
+					int iItemAttribID = CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemExt->byMagicOrRare;
+					int iItemClass = CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byClass;
+
+					
+					if (iItemAttribID == ITEM_ATTRIB_UPGRADE ||
+						iItemAttribID == ITEM_ATTRIB_UNIQUE || 
+						iItemClass == ITEM_CLASS_POWER_SCROLL)
+					{	
+						std::string strMessage, strItemName;
+						GenerateItemName(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource, strItemName);
+						CGameBase::GetTextF(IDS_TRANSACTION_OK_CANCEL_MESSAGE,
+											&strMessage,
+											strItemName.c_str());
+
+						//m_pUIMsgBoxOkCancel position
+						CN3UIWndBase::m_pMsgBoxOkCancel->SetText(strMessage);
+						s_bWaitFromServer = false;
+						CN3UIWndBase::m_pMsgBoxOkCancel->Open(UIWND_TRANSACTION, m_sSelectedIconInfo.UIWndSelect.UIWndDistrict);
+						
+						//avoid icon removal
+						FAIL_RETURN
+							
+					}
+					else
+					{
+						// Server에게 보낸다..
+						SendToServerSellMsg(CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->dwID +
+							CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemExt->dwID,
+							CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder,
+							CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->iCount);
+					}
+					
+					
 
 					// 원래 아이템을 삭제해야 하지만.. 되살릴 방법이 없기 때문에 원래 위치로 옮기고.. 
 					pArea = NULL;
@@ -1471,6 +1565,14 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 				}
 			}
 		}
+
+		/*
+		if (m_pUIMsgBox != nullptr && pSender == m_pUIMsgBox->m_pBtn_Cancel)
+		{
+			TRACE("Cancel button clickled\n");
+			m_pUIMsgBox->SetVisible(false);
+		} */
+
 	}
 
 	__IconItemSkill* spItem = NULL;
@@ -1578,6 +1680,9 @@ void CUITransactionDlg::SetVisible(bool bVisible)
 		if(CN3UIWndBase::m_pCountableItemEdit && CN3UIWndBase::m_pCountableItemEdit->IsVisible())
 			ItemCountCancel();
 
+		if (CN3UIWndBase::m_pMsgBoxOkCancel && CN3UIWndBase::m_pMsgBoxOkCancel->IsVisible())
+			MsgBoxCancel();
+
 		CGameProcedure::s_pUIMgr->ReFocusUI();//this_ui
 	}
 }
@@ -1590,6 +1695,9 @@ void CUITransactionDlg::SetVisibleWithNoSound(bool bVisible, bool bWork, bool bR
 	{
 		if(CN3UIWndBase::m_pCountableItemEdit && CN3UIWndBase::m_pCountableItemEdit->IsVisible())
 			ItemCountCancel();
+
+		if (CN3UIWndBase::m_pMsgBoxOkCancel && CN3UIWndBase::m_pMsgBoxOkCancel->IsVisible())
+			MsgBoxCancel();
 
 		if (GetState() == UI_STATE_ICON_MOVING)
 			IconRestore();

--- a/Client/WarFare/UITransactionDlg.h
+++ b/Client/WarFare/UITransactionDlg.h
@@ -31,7 +31,7 @@ public:
 	int						m_iTradeID;
 	int						m_iNpcID;
 	CUIImageTooltipDlg*		m_pUITooltipDlg;
-
+	
 	CN3UIImage*				m_pUIInn;
 	CN3UIImage*				m_pUIBlackSmith;
 	CN3UIImage*				m_pUIStore;
@@ -93,6 +93,10 @@ public:
 	void				ItemCountOK();
 	void				ItemCountCancel();
 
+	//MsgBox Ok Cancel
+	void				MsgBoxCancel();
+	void				MsgBoxOK();
+
 	void				ItemMoveFromInvToThis();
 	void				ItemMoveFromThisToInv();
 
@@ -105,6 +109,7 @@ public:
 
 	void				GoldUpdate();
 	void				UpdateWeight(const std::string& szWeight);
+	void				GenerateItemName(__IconItemSkill* pItem, std::string& strName);
 };
 
 #endif // !defined(AFX_UITRANSACTIONDLG_H__42671245_FF4F_42FC_AF7B_DACEDA8734B7__INCLUDED_)

--- a/Client/WarFare/WarFare.vcxproj
+++ b/Client/WarFare/WarFare.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="UIMessageBox.cpp" />
     <ClCompile Include="UIMessageBoxManager.cpp" />
     <ClCompile Include="UIMessageWnd.cpp" />
+    <ClCompile Include="UIMsgBoxOkCancel.cpp" />
     <ClCompile Include="UINationSelectDlg.cpp" />
     <ClCompile Include="UINotice.cpp" />
     <ClCompile Include="UINPCChangeEvent.cpp" />
@@ -288,6 +289,7 @@
     <ClInclude Include="UIMessageBox.h" />
     <ClInclude Include="UIMessageBoxManager.h" />
     <ClInclude Include="UIMessageWnd.h" />
+    <ClInclude Include="UIMsgBoxOkCancel.h" />
     <ClInclude Include="UINationSelectDlg.h" />
     <ClInclude Include="UINotice.h" />
     <ClInclude Include="UINPCChangeEvent.h" />

--- a/Client/WarFare/WarFare.vcxproj.filters
+++ b/Client/WarFare/WarFare.vcxproj.filters
@@ -339,6 +339,9 @@
     <ClCompile Include="N3ClientShapeMgr.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="UIMsgBoxOkCancel.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameProcedure.h">
@@ -684,6 +687,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="text_resources.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UIMsgBoxOkCancel.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Client/WarFare/text_resources.h
+++ b/Client/WarFare/text_resources.h
@@ -614,4 +614,5 @@ enum e_TextResourceID
 	IDS_CMD_PLC									= 9020,
 
 	IDS_QUEST_SEARCH_LEVEL_ERROR				= 10100, // You can only search up to +%d levels from your current level.
+	IDS_TRANSACTION_OK_CANCEL_MESSAGE			= 11500, // will you sell %s? 
 };


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Feature

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Currently in transactions UI confirm box feature is missing. Officially, upgrade items, unique items and scrolls should be sellable after confirmation.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
UIMsgBoxOkCancel is added to provide confirm dialog before selling mentioned items.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
This is core feature which prevents user from selling important items ( & maybe buying expensive ones from NPC ).

Buying part is unclear because I could not test it with Pet items on original client because those items demand clan grade, and that does not work well.

Had problems while setting Z order of newly added UI and so I took CountableItemEdit class as an example while writing the code.

## Demo
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/514d6b1b-7f59-4400-8406-7e2cba0992e3" />


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
