### PR TITLE
Display scroll charges ("durability") on UIs

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -292,7 +292,7 @@ enum e_ItemClass	{	ITEM_CLASS_DAGGER = 11, // dagger
 						ITEM_CLASS_ARMOR_PRIEST = 240, // Priest armor
 
 						ITEM_CLASS_ETC = 251, // Miscellaneous
-						ITEM_CLASS_POWER_SCROLL = 255, //scrolls,premiums and power up potions, pets
+						ITEM_CLASS_CONSUMABLE = 255, // Consumable items with 'charges' that use the durability/duration instead of stacks
 
 						ITEM_CLASS_UNKNOWN = 0xffffffff }; // 
 

--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -292,6 +292,7 @@ enum e_ItemClass	{	ITEM_CLASS_DAGGER = 11, // dagger
 						ITEM_CLASS_ARMOR_PRIEST = 240, // Priest armor
 
 						ITEM_CLASS_ETC = 251, // Miscellaneous
+						ITEM_CLASS_POWER_SCROLL = 255, //scrolls,premiums and power up potions, pets
 
 						ITEM_CLASS_UNKNOWN = 0xffffffff }; // 
 

--- a/Client/WarFare/UIInventory.cpp
+++ b/Client/WarFare/UIInventory.cpp
@@ -338,7 +338,8 @@ void CUIInventory::Render()
 	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
 		if ( m_pMyInvWnd[i] && ((m_pMyInvWnd[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) || 
-					(m_pMyInvWnd[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL)) )
+					(m_pMyInvWnd[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) ||
+					(m_pMyInvWnd[i]->pItemBasic->byClass == ITEM_CLASS_POWER_SCROLL)) )
 		{
 			// string 얻기..
 			CN3UIString* pStr = GetChildStringByiOrder(i);
@@ -353,7 +354,12 @@ void CUIInventory::Render()
 					if ( m_pMyInvWnd[i]->pUIIcon->IsVisible() )
 					{
 						pStr->SetVisible(true);
-						pStr->SetStringAsInt(m_pMyInvWnd[i]->iCount);
+						
+						if (m_pMyInvWnd[i]->pItemBasic->byClass == ITEM_CLASS_POWER_SCROLL)
+							pStr->SetStringAsInt(m_pMyInvWnd[i]->iDurability);
+						else
+							pStr->SetStringAsInt(m_pMyInvWnd[i]->iCount);
+						
 						pStr->Render();
 					}
 					else
@@ -2401,9 +2407,18 @@ int CUIInventory::GetCountInInvByID(int iID)
 	int i;
 	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
-		if ( (m_pMyInvWnd[i] != NULL) && (m_pMyInvWnd[i]->pItemBasic->dwID == (iID/1000*1000)) &&
-				(m_pMyInvWnd[i]->pItemExt->dwID == (iID%1000)) )
-		return m_pMyInvWnd[i]->iCount;
+		if ((m_pMyInvWnd[i] != NULL) && (m_pMyInvWnd[i]->pItemBasic->dwID == (iID / 1000 * 1000)) &&
+				(m_pMyInvWnd[i]->pItemExt->dwID == (iID % 1000)))
+		{
+			if (m_pMyInvWnd[i]->pItemBasic->byClass == ITEM_CLASS_POWER_SCROLL)
+			{
+				return m_pMyInvWnd[i]->iDurability;
+			}
+			else
+			{
+				return m_pMyInvWnd[i]->iCount;
+			}
+		}	
 	}
 
 	return 0;

--- a/Client/WarFare/UIInventory.cpp
+++ b/Client/WarFare/UIInventory.cpp
@@ -337,9 +337,10 @@ void CUIInventory::Render()
 	// 갯수 표시되야 할 아이템 갯수 표시..
 	for( int i = 0; i < MAX_ITEM_INVENTORY; i++ )
 	{
-		if ( m_pMyInvWnd[i] && ((m_pMyInvWnd[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) || 
-					(m_pMyInvWnd[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL) ||
-					(m_pMyInvWnd[i]->pItemBasic->byClass == ITEM_CLASS_POWER_SCROLL)) )
+		if (m_pMyInvWnd[i] != nullptr
+			&& ((m_pMyInvWnd[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE)
+				|| (m_pMyInvWnd[i]->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL)
+				|| (m_pMyInvWnd[i]->pItemBasic->byClass == ITEM_CLASS_CONSUMABLE)))
 		{
 			// string 얻기..
 			CN3UIString* pStr = GetChildStringByiOrder(i);
@@ -355,7 +356,7 @@ void CUIInventory::Render()
 					{
 						pStr->SetVisible(true);
 						
-						if (m_pMyInvWnd[i]->pItemBasic->byClass == ITEM_CLASS_POWER_SCROLL)
+						if (m_pMyInvWnd[i]->pItemBasic->byClass == ITEM_CLASS_CONSUMABLE)
 							pStr->SetStringAsInt(m_pMyInvWnd[i]->iDurability);
 						else
 							pStr->SetStringAsInt(m_pMyInvWnd[i]->iCount);
@@ -2402,23 +2403,20 @@ void CUIInventory::ReceiveResultFromServer(int iResult, int iUserGold)
 	m_cItemRepairMgr.ReceiveResultFromServer(iResult, iUserGold);
 }
 
-int CUIInventory::GetCountInInvByID(int iID)
+int CUIInventory::GetCountInInvByID(int iID) const
 {
-	int i;
-	for( i = 0; i < MAX_ITEM_INVENTORY; i++ )
+	for (int i = 0; i < MAX_ITEM_INVENTORY; i++)
 	{
-		if ((m_pMyInvWnd[i] != NULL) && (m_pMyInvWnd[i]->pItemBasic->dwID == (iID / 1000 * 1000)) &&
-				(m_pMyInvWnd[i]->pItemExt->dwID == (iID % 1000)))
-		{
-			if (m_pMyInvWnd[i]->pItemBasic->byClass == ITEM_CLASS_POWER_SCROLL)
-			{
-				return m_pMyInvWnd[i]->iDurability;
-			}
-			else
-			{
-				return m_pMyInvWnd[i]->iCount;
-			}
-		}	
+		__IconItemSkill* spItem = m_pMyInvWnd[i];
+		if (spItem == nullptr
+			|| spItem->pItemBasic->dwID != (iID / 1000 * 1000)
+			|| spItem->pItemExt->dwID != (iID % 1000))
+			continue;
+
+		if (spItem->pItemBasic->byClass == ITEM_CLASS_CONSUMABLE)
+			return spItem->iDurability;
+
+		return spItem->iCount;
 	}
 
 	return 0;

--- a/Client/WarFare/UIInventory.h
+++ b/Client/WarFare/UIInventory.h
@@ -142,7 +142,7 @@ public:
 
 	void				ReceiveResultFromServer(int iResult, int iUserGold);
 
-	int					GetCountInInvByID(int iID);
+	int					GetCountInInvByID(int iID) const;
 
 	// 소모성 아이템을 소비한 경우 or Not..
 	void				ItemCountChange(int iDistrict, int iIndex, int iCount, int iID, int iDurability);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
number of scrolls not seen correct on inventory and hotkey UIs.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
They seen correct.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
Scroll quantity is controlled by iDurability instead of iCount

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
