### PR TITLE
Move debugger defaults to the project file

### DIFF
--- a/Client/WarFare/WarFare.vcxproj
+++ b/Client/WarFare/WarFare.vcxproj
@@ -63,9 +63,6 @@
     </Link>
     <PreBuildEvent>
       <Command>
-        if exist "$(ProjectDir)WarFare.vcxproj.user.default" if not exist "$(ProjectDir)WarFare.vcxproj.user" (
-          copy /Y "$(ProjectDir)WarFare.vcxproj.user.default" "$(ProjectDir)WarFare.vcxproj.user"
-        )
         if exist "$(ProjectDir)warfare_config.h.default" if not exist "$(ProjectDir)warfare_config.h" (
           copy /Y "$(ProjectDir)warfare_config.h.default" "$(ProjectDir)warfare_config.h"
         )
@@ -338,4 +335,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <PropertyGroup Label="Debugger defaults">
+    <LocalDebuggerWorkingDirectory>..\Data\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
 </Project>

--- a/Client/WarFare/WarFare.vcxproj.user.default
+++ b/Client/WarFare/WarFare.vcxproj.user.default
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <LocalDebuggerWorkingDirectory>..\Data\</LocalDebuggerWorkingDirectory>
-    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
We don't need a user default for this at all.

Note that it will no longer show in the IDE, but this only matters if you're changing it anyway.