### PR TITLE
fixing clan font for playermyself

### DIFF
--- a/Client/WarFare/PlayerMySelf.cpp
+++ b/Client/WarFare/PlayerMySelf.cpp
@@ -1053,12 +1053,12 @@ void CPlayerMySelf::KnightsInfoSet(int iID, const std::string& szName, int iGrad
 		std::string szFontID;
 		GetText(IDS_FONT_ID, &szFontID);
 
-		m_pClanFont = new CDFont(szFontID, 12);
+		m_pClanFont = new CDFont(szFontID, 12, D3DFONT_BOLD);
 		m_pClanFont->InitDeviceObjects(s_lpD3DDev);
 		m_pClanFont->RestoreDeviceObjects();
 	}
 
-	m_pClanFont->SetText(m_InfoExt.szKnights.c_str(), D3DFONT_BOLD); // 폰트에 텍스트 지정.
+	m_pClanFont->SetText(m_InfoExt.szKnights.c_str()); // 폰트에 텍스트 지정.
 	m_pClanFont->SetFontColor(KNIGHTS_FONT_COLOR);
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
clan font is not bold

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
clan font is set as bold on CPlayerMyself class

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
used predefined flag inside CFont class ( D3DFONT_BOLD ). It was inside SetText function before, but it seems it should be used while creating object.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
