### PR TITLE
Promote WIZ_STATE_CHANGE buff type to 32-bit

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -4992,8 +4992,7 @@ void CGameProcMain::MsgRecv_UserState(Packet& pkt)
 {
 	int iID = pkt.read<int16_t>();
 	e_SubPacket_State eSP = (e_SubPacket_State)pkt.read<uint8_t>(); // 0x01
-	int iState = pkt.read<uint32_t>();// to support original exe
-	//int iState = pkt.read<uint8_t>();
+	int32_t iState = pkt.read<int32_t>();
 
 	CPlayerBase* pBPC = NULL;
 	if ( s_pPlayer->IDNumber() == iID )

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -4992,7 +4992,8 @@ void CGameProcMain::MsgRecv_UserState(Packet& pkt)
 {
 	int iID = pkt.read<int16_t>();
 	e_SubPacket_State eSP = (e_SubPacket_State)pkt.read<uint8_t>(); // 0x01
-	int iState = pkt.read<uint32_t>();//int iState = pkt.read<uint8_t>();
+	int iState = pkt.read<uint32_t>();// to support original exe
+	//int iState = pkt.read<uint8_t>();
 
 	CPlayerBase* pBPC = NULL;
 	if ( s_pPlayer->IDNumber() == iID )

--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -5340,17 +5340,23 @@ void CUser::StateChange(char* pBuf)
 	SetShort(send_buff, m_Sid, send_index);
 	SetByte(send_buff, type, send_index);
 
+	BYTE byResult = 0;
+
 	if (type == 1)
-		SetByte(send_buff, m_bResHpType, send_index);
+		byResult = m_bResHpType;
 	else if (type == 2)
-		SetByte(send_buff, m_bNeedParty, send_index);
+		byResult = m_bNeedParty;
 	else if (type == 3)
-		SetByte(send_buff, m_bAbnormalType, send_index);
+		byResult = m_bAbnormalType;
 	// Just plain echo :)
 	//		N3_SP_STATE_CHANGE_ACTION = 0x04,			// 1 - 인사, 11 - 도발
 	//		N3_SP_STATE_CHANGE_VISIBLE = 0x05 };		// 투명 0 ~ 255
 	else
-		SetByte(send_buff, buff, send_index);
+		byResult = buff;
+		
+	//conversion to uint32_t is required to support official client
+	SetDWORD(send_buff, static_cast<uint32_t>(byResult), send_index);
+	//SetByte(send_buff, iResult, send_index); //alternative if reading is demanded as uint8_t
 
 	m_pMain->Send_Region(send_buff, send_index, m_pUserData->m_bZone, m_RegionX, m_RegionZ);
 }

--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -5340,23 +5340,20 @@ void CUser::StateChange(char* pBuf)
 	SetShort(send_buff, m_Sid, send_index);
 	SetByte(send_buff, type, send_index);
 
-	BYTE byResult = 0;
-
+	uint32_t nResult = 0;
 	if (type == 1)
-		byResult = m_bResHpType;
+		nResult = m_bResHpType;
 	else if (type == 2)
-		byResult = m_bNeedParty;
+		nResult = m_bNeedParty;
 	else if (type == 3)
-		byResult = m_bAbnormalType;
+		nResult = m_bAbnormalType;
 	// Just plain echo :)
 	//		N3_SP_STATE_CHANGE_ACTION = 0x04,			// 1 - 인사, 11 - 도발
 	//		N3_SP_STATE_CHANGE_VISIBLE = 0x05 };		// 투명 0 ~ 255
 	else
-		byResult = buff;
+		nResult = buff;
 		
-	//conversion to uint32_t is required to support official client
-	SetDWORD(send_buff, static_cast<uint32_t>(byResult), send_index);
-	//SetByte(send_buff, iResult, send_index); //alternative if reading is demanded as uint8_t
+	SetDWORD(send_buff, nResult, send_index);
 
 	m_pMain->Send_Region(send_buff, send_index, m_pUserData->m_bZone, m_RegionX, m_RegionZ);
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
features related to WIZ_STATE_CHANGE packet does not work

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
they work now

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
return type of server should be converted to uint32_t instead of byte, this is probably done to support official also.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
