### PR TITLE
Allow for cleaning fetch-only submodules

### DIFF
--- a/build_scripts/build_dependency.cmd
+++ b/build_scripts/build_dependency.cmd
@@ -56,7 +56,7 @@ IF EXIST "%REPO_ROOT%\%DEP_PATH%\.git" (
 	FOR /F "tokens=3" %%c IN ('"%GitPath%" ls-tree HEAD %DEP_PATH%') DO SET "INTENDED_COMMIT=%%c"
 
 	REM Determine if the developer has staged a change to this submodule.
-	FOR /F %%c in ('"%GitPath%" diff --cached HEAD --name-only') DO (
+	FOR /F %%c IN ('"%GitPath%" diff --cached HEAD --name-only') DO (
 		IF /i "%%c"=="%DEP_PATH_NORMALISED%" (
 			SET "SUBMODULE_STAGED=1"
 			SET "OVERRIDE_BUILD=1"

--- a/build_scripts/clean_dependency.cmd
+++ b/build_scripts/clean_dependency.cmd
@@ -2,8 +2,8 @@
 SETLOCAL
 
 REM Validate arguments
-IF "%~4"=="" (
-	ECHO Usage: %~nx0 DEP_NAME BUILD_CONFIG BUILD_PLATFORM PROJECT_PATH
+IF "%~3"=="" (
+	ECHO Usage: %~nx0 DEP_NAME BUILD_CONFIG BUILD_PLATFORM [PROJECT_PATH]
 	ECHO Example: %~nx0 zlib Release Win32 deps\zlib-msvc\zlib.vcxproj
 	EXIT /B 1
 )
@@ -23,18 +23,20 @@ SET "REPO_ROOT=%~dp0.."
 SET "BUILD_STATE_DIR=%~dp0..\deps\fetch-and-build-wrappers\last-build-states\%BUILD_PLATFORM%\%BUILD_CONFIG%"
 SET "BUILD_STATE_FILE=%BUILD_STATE_DIR%\%DEP_NAME%.txt"
 
-REM Validate dependency project even exists
-IF NOT EXIST "%PROJECT_PATH%" (
-	ECHO ERROR: Dependency project not found: "%PROJECT_PATH%"
-	EXIT /B 1
-)
+IF NOT "%PROJECT_PATH%" == "" (
+	REM Validate dependency project even exists
+	IF NOT EXIST "%PROJECT_PATH%" (
+		ECHO ERROR: Dependency project not found: "%PROJECT_PATH%"
+		EXIT /B 1
+	)
 
-REM Build dependency
-"%MSBUILD%" "%PROJECT_PATH%" /t:Clean /p:Configuration=%BUILD_CONFIG% /p:Platform=%BUILD_PLATFORM%
+	REM Build dependency
+	"%MSBUILD%" "%PROJECT_PATH%" /t:Clean /p:Configuration="%BUILD_CONFIG%" /p:Platform="%BUILD_PLATFORM%"
 
-IF ERRORLEVEL 1 (
-	ECHO ERROR: Failed to build dependency: %DEP_NAME%
-	EXIT /B 1
+	IF ERRORLEVEL 1 (
+		ECHO ERROR: Failed to build dependency: %DEP_NAME%
+		EXIT /B 1
+	)
 )
 
 REM Delete build key so the next request will invoke a build.


### PR DESCRIPTION
`clean_dependency.cmd` currently assumes we're cleaning a dependency with a build project.
As this logic is shared and invoked by everything, rather than handled on a case-by-case basis since we need it to reset the "last build state" (or fetch state in this case), we need to simply let it continue to handle and clean the "last build state" even for projects that don't actually have a project to build (e.g. ko-client-assets, dx9sdk).