### PR TITLE
fixing image tooltip for saletype = 1 items[gold bar, silver coin etc.]

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -706,7 +706,7 @@ struct __TABLE_ITEM_BASIC
 	int16_t		siWeight;				// 19 Weight (in 0.1 units)
 	int16_t		siMaxDurability;		// 20 Max durability
 	int			iPrice;					// 21 Purchase price
-	int			iPriceSale;				// 22 Sale price
+	int			iSaleType;				// 22 Sale type ([1 - same price], [0 - 1/6 of buy price], [2 - 1/6 & cant be repaired] ) - [1/4 premium(all)]
 	int16_t		siDefense;				// 23 Defense
 	uint8_t		byContable;				// 24 Is the item countable/stackable?
 

--- a/Client/WarFare/UIImageTooltipDlg.cpp
+++ b/Client/WarFare/UIImageTooltipDlg.cpp
@@ -1164,7 +1164,18 @@ exceptions:;
 			}
 			else
 			{	
-				int iSellPrice = (spItem->pItemBasic->iPrice*spItem->pItemExt->siPriceMultiply/6);
+				int iSellPrice = 0;
+
+				if (spItem->pItemBasic->iSaleType == 1) 
+				{   //sale type = 1, selling for the same price of buying
+					iSellPrice = spItem->pItemBasic->iPrice * spItem->pItemExt->siPriceMultiply;
+				}
+				else
+				{
+					//non premium : selling for 1/6 of purchasing price
+					iSellPrice = spItem->pItemBasic->iPrice * spItem->pItemExt->siPriceMultiply / 6;
+				}
+
 				if (iSellPrice < 1)
 					iSellPrice = 1;
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Tooltip prices are not updated with respect to sale type, related to issue #386 

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Sale type 1,0 and 2 handled accordingly. Premium features should be tested and implemented if required.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
iPriceSale was misleading and renamed under __TABLE_BASICS. UITooltip has been updated to provide correct results.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
