### PR TITLE
Rename server table and related maps/containers for consistency

### DIFF
--- a/Server/AIServer/GameSocket.cpp
+++ b/Server/AIServer/GameSocket.cpp
@@ -1016,7 +1016,7 @@ void CGameSocket::RecvGateOpen(char* pBuf)
 		return;
 	}
 
-	CNpc* pNpc = m_pMain->m_arNpc.GetData(nid);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(nid);
 	if (pNpc == nullptr)
 		return;
 
@@ -1076,7 +1076,7 @@ void CGameSocket::RecvPartyInfoAllData(char* pBuf)
 		//TRACE(_T("party info ,, index = %d, i=%d, uid=%d, %d, %d, %d \n"), sPartyIndex, i, uid, sHp, byLevel, sClass);
 	}
 
-	if (m_pMain->m_arParty.PutData(pParty->wIndex, pParty))
+	if (m_pMain->m_PartyMap.PutData(pParty->wIndex, pParty))
 	{
 		spdlog::debug("GameSocket::RecvPartyInfoAllData: created partyIndex={}", sPartyIndex);
 	}
@@ -1190,7 +1190,7 @@ void CGameSocket::RecvBattleEvent(char* pBuf)
 		m_pMain->ResetBattleZone();
 	}
 
-	for (const auto& [_, pNpc] : m_pMain->m_arNpc)
+	for (const auto& [_, pNpc] : m_pMain->m_NpcMap)
 	{
 		if (pNpc == nullptr)
 			continue;

--- a/Server/AIServer/MagicProcess.cpp
+++ b/Server/AIServer/MagicProcess.cpp
@@ -168,7 +168,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, BYTE type)
 	if (m_pSrcUser == nullptr)
 		return FALSE;
 
-	pTable = m_pMain->m_MagictableArray.GetData(magicid);     // Get main magic table.
+	pTable = m_pMain->m_MagicTableMap.GetData(magicid);     // Get main magic table.
 	if (pTable == nullptr)
 		goto fail_return;
 
@@ -192,7 +192,7 @@ BYTE CMagicProcess::ExecuteType1(int magicid, int tid, int data1, int data2, int
 	int damage = 0, send_index = 0, result = 1;     // Variable initialization. result == 1 : success, 0 : fail
 	char send_buff[128] = {};
 	model::Magic* pMagic = nullptr;
-	pMagic = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
+	pMagic = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pMagic == nullptr)
 		return 0;
 
@@ -201,7 +201,7 @@ BYTE CMagicProcess::ExecuteType1(int magicid, int tid, int data1, int data2, int
 	//TRACE(_T("magictype1 ,, magicid=%d, damage=%d\n"), magicid, damage);
 
 //	if (damage > 0) {
-	CNpc* pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 	if (pNpc == nullptr
 		|| pNpc->m_NpcState == NPC_DEAD
 		|| pNpc->m_iHP == 0)
@@ -265,7 +265,7 @@ BYTE CMagicProcess::ExecuteType2(int magicid, int tid, int data1, int data2, int
 
 	if (damage > 0)
 	{
-		CNpc* pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+		CNpc* pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 		if (pNpc == nullptr
 			|| pNpc->m_NpcState == NPC_DEAD
 			|| pNpc->m_iHP == 0)
@@ -342,7 +342,7 @@ void CMagicProcess::ExecuteType3(int magicid, int tid, int data1, int data2, int
 	model::MagicType3* pType = nullptr;
 	CNpc* pNpc = nullptr;      // Pointer initialization!
 
-	model::Magic* pMagic = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
+	model::Magic* pMagic = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pMagic == nullptr)
 		return;
 
@@ -355,7 +355,7 @@ void CMagicProcess::ExecuteType3(int magicid, int tid, int data1, int data2, int
 		return;
 	}
 
-	pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+	pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 	if (pNpc == nullptr
 		|| pNpc->m_NpcState == NPC_DEAD
 		|| pNpc->m_iHP == 0)
@@ -364,7 +364,7 @@ void CMagicProcess::ExecuteType3(int magicid, int tid, int data1, int data2, int
 		goto packet_send;
 	}
 
-	pType = m_pMain->m_Magictype3Array.GetData(magicid);      // Get magic skill table type 3.
+	pType = m_pMain->m_MagicType3TableMap.GetData(magicid);      // Get magic skill table type 3.
 	if (pType == nullptr)
 		return;
 
@@ -505,7 +505,7 @@ void CMagicProcess::ExecuteType4(int magicid, int sid, int tid, int data1, int d
 		return;
 	}
 
-	pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+	pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 	if (pNpc == nullptr
 		|| pNpc->m_NpcState == NPC_DEAD
 		|| pNpc->m_iHP == 0)
@@ -514,7 +514,7 @@ void CMagicProcess::ExecuteType4(int magicid, int sid, int tid, int data1, int d
 		goto fail_return;
 	}
 
-	pType = m_pMain->m_Magictype4Array.GetData(magicid);     // Get magic skill table type 4.
+	pType = m_pMain->m_MagicType4TableMap.GetData(magicid);     // Get magic skill table type 4.
 	if (pType == nullptr)
 		return;
 
@@ -629,7 +629,7 @@ short CMagicProcess::GetMagicDamage(int tid, int total_hit, int attribute, int d
 		|| tid > INVALID_BAND)
 		return 0;
 
-	CNpc* pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 	if (pNpc == nullptr
 		|| pNpc->m_NpcState == NPC_DEAD
 		|| pNpc->m_iHP == 0)
@@ -721,7 +721,7 @@ short CMagicProcess::AreaAttack(int magictype, int magicid, int moral, int data1
 
 	if (magictype == 3)
 	{
-		pType3 = m_pMain->m_Magictype3Array.GetData(magicid);
+		pType3 = m_pMain->m_MagicType3TableMap.GetData(magicid);
 		if (pType3 == nullptr)
 		{
 			spdlog::error("MagicProcess::AreaAttack: No MAGIC_TYPE3 definition [magicId={}]", magicid);
@@ -732,7 +732,7 @@ short CMagicProcess::AreaAttack(int magictype, int magicid, int moral, int data1
 	}
 	else if (magictype == 4)
 	{
-		pType4 = m_pMain->m_Magictype4Array.GetData(magicid);      // Get magic skill table type 3.
+		pType4 = m_pMain->m_MagicType4TableMap.GetData(magicid);      // Get magic skill table type 3.
 		if (pType4 == nullptr)
 		{
 			spdlog::error("MagicProcess::AreaAttack: No MAGIC_TYPE4 definition [magicId={}]", magicid);
@@ -821,7 +821,7 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 	int damage = 0, tid = 0, target_damage = 0, attribute = 0;
 	float fRadius = 0;
 
-	pMagic = m_pMain->m_MagictableArray.GetData(magicid);
+	pMagic = m_pMain->m_MagicTableMap.GetData(magicid);
 	if (pMagic == nullptr)
 	{
 		spdlog::error("MagicProcess::AreaAttackDamage: No MAGIC definition [magicId={}]", magicid);
@@ -830,7 +830,7 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 
 	if (magictype == 3)
 	{
-		pType3 = m_pMain->m_Magictype3Array.GetData(magicid);
+		pType3 = m_pMain->m_MagicType3TableMap.GetData(magicid);
 		if (pType3 == nullptr)
 		{
 			spdlog::error("MagicProcess::AreaAttackDamage: No MAGIC_TYPE3 definition [magicId={}]", magicid);
@@ -843,7 +843,7 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 	}
 	else if (magictype == 4)
 	{
-		pType4 = m_pMain->m_Magictype4Array.GetData(magicid);
+		pType4 = m_pMain->m_MagicType4TableMap.GetData(magicid);
 		if (pType4 == nullptr)
 		{
 			spdlog::error("MagicProcess::AreaAttackDamage: No MAGIC_TYPE4 definition [magicId={}]", magicid);
@@ -889,7 +889,7 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 		if (nid < NPC_BAND)
 			continue;
 
-		pNpc = m_pMain->m_arNpc.GetData(nid - NPC_BAND);
+		pNpc = m_pMain->m_NpcMap.GetData(nid - NPC_BAND);
 
 		if (pNpc != nullptr
 			&& pNpc->m_NpcState != NPC_DEAD)

--- a/Server/AIServer/Npc.cpp
+++ b/Server/AIServer/Npc.cpp
@@ -115,7 +115,7 @@ inline BOOL CNpc::SetUid(float x, float z, int id)
 
 		//TRACE(_T("++ Npc-SetUid RegionAdd : [nid=%d, name=%hs], x=%.2f, z=%.2f, nRX=%d, nRZ=%d \n"), m_sNid+NPC_BAND, m_strName,x,z, nRX, nRY);
 		// 새로운 region으로 npc이동 - npc의 정보 추가..
-		CNpc* pNpc = m_pMain->m_arNpc.GetData(id - NPC_BAND);
+		CNpc* pNpc = m_pMain->m_NpcMap.GetData(id - NPC_BAND);
 		if (pNpc == nullptr)
 			return FALSE;
 
@@ -957,7 +957,7 @@ void CNpc::NpcBack(CIOCPort* pIOCP)
 	else if (m_Target.id >= NPC_BAND
 		&& m_Target.id < INVALID_BAND)
 	{
-		if (m_pMain->m_arNpc.GetData(m_Target.id - NPC_BAND) == nullptr)
+		if (m_pMain->m_NpcMap.GetData(m_Target.id - NPC_BAND) == nullptr)
 		{
 			m_NpcState = NPC_STANDING;
 			m_Delay = m_sSpeed;
@@ -1106,14 +1106,14 @@ BOOL CNpc::SetLive(CIOCPort* pIOCP)
 	{
 		for (int i = 0; i < NPC_NUM; i++)
 		{
-			pNpc = m_pMain->m_arEventNpcThread[0]->m_ThreadInfo.pNpc[i];
-			if (m_pMain->m_arEventNpcThread[0]->m_ThreadInfo.pNpc[i] != nullptr)
+			pNpc = m_pMain->m_EventNpcThreadArray[0]->m_ThreadInfo.pNpc[i];
+			if (m_pMain->m_EventNpcThreadArray[0]->m_ThreadInfo.pNpc[i] != nullptr)
 			{
-				if (m_pMain->m_arEventNpcThread[0]->m_ThreadInfo.pNpc[i]->m_sNid == m_sNid)
+				if (m_pMain->m_EventNpcThreadArray[0]->m_ThreadInfo.pNpc[i]->m_sNid == m_sNid)
 				{
-					m_pMain->m_arEventNpcThread[0]->m_ThreadInfo.m_byNpcUsed[i] = 0;
+					m_pMain->m_EventNpcThreadArray[0]->m_ThreadInfo.m_byNpcUsed[i] = 0;
 					m_lEventNpc = 0;
-					m_pMain->m_arEventNpcThread[0]->m_ThreadInfo.pNpc[i] = nullptr;
+					m_pMain->m_EventNpcThreadArray[0]->m_ThreadInfo.pNpc[i] = nullptr;
 					spdlog::debug("Npc::SetLive: returning summoned monster pointer [threadIndex={} serial={} npcId={} npcName={}]",
 						i, m_sNid + NPC_BAND, m_sSid, m_strName);
 					return TRUE;
@@ -2646,7 +2646,7 @@ float CNpc::FindEnemyExpand(int nRX, int nRZ, float fCompDis, int nType)
 			if (nNpcid < NPC_BAND)
 				continue;
 
-			pNpc = m_pMain->m_arNpc.GetData(nNpcid - NPC_BAND);
+			pNpc = m_pMain->m_NpcMap.GetData(nNpcid - NPC_BAND);
 
 			if (m_sNid == pNpc->m_sNid)
 				continue;
@@ -3024,7 +3024,7 @@ int CNpc::IsCloseTarget(int nRange, int Flag)
 	else if (m_Target.id >= NPC_BAND
 		&& m_Target.id < INVALID_BAND)
 	{
-		pNpc = m_pMain->m_arNpc.GetData(m_Target.id - NPC_BAND);
+		pNpc = m_pMain->m_NpcMap.GetData(m_Target.id - NPC_BAND);
 		if (pNpc == nullptr)
 		{
 			InitTarget();
@@ -3223,7 +3223,7 @@ int CNpc::GetTargetPath(int option)
 	else if (m_Target.id >= NPC_BAND
 		&& m_Target.id < INVALID_BAND)
 	{
-		npcTarget = m_pMain->m_arNpc.GetData(m_Target.id - NPC_BAND);
+		npcTarget = m_pMain->m_NpcMap.GetData(m_Target.id - NPC_BAND);
 		if (npcTarget == nullptr)
 		{
 			InitTarget();
@@ -3628,7 +3628,7 @@ int CNpc::Attack(CIOCPort* pIOCP)
 	else if (nID >= NPC_BAND
 		&& m_Target.id < INVALID_BAND)
 	{
-		pNpc = m_pMain->m_arNpc.GetData(nID - NPC_BAND);
+		pNpc = m_pMain->m_NpcMap.GetData(nID - NPC_BAND);
 
 		// User 가 Invalid 한 경우
 		if (pNpc == nullptr)
@@ -3802,8 +3802,8 @@ int CNpc::LongAndMagicAttack(CIOCPort* pIOCP)
 	else if (nID >= NPC_BAND
 		&& m_Target.id < INVALID_BAND)
 	{
-		pNpc = m_pMain->m_arNpc.GetData(nID - NPC_BAND);
-		//pNpc = m_pMain->m_arNpc[nID - NPC_BAND];
+		pNpc = m_pMain->m_NpcMap.GetData(nID - NPC_BAND);
+		//pNpc = m_pMain->m_NpcMap[nID - NPC_BAND];
 
 		// User 가 Invalid 한 경우
 		if (pNpc == nullptr)
@@ -3904,7 +3904,7 @@ int CNpc::TracingAttack(CIOCPort* pIOCP)		// 0:attack fail, 1:attack success
 	else if (nID >= NPC_BAND
 		&& m_Target.id < INVALID_BAND)
 	{
-		pNpc = m_pMain->m_arNpc.GetData(nID - NPC_BAND);
+		pNpc = m_pMain->m_NpcMap.GetData(nID - NPC_BAND);
 
 		// User 가 Invalid 한 경우
 		if (pNpc == nullptr)
@@ -3998,8 +3998,8 @@ void CNpc::MoveAttack(CIOCPort* pIOCP)
 	else if (m_Target.id >= NPC_BAND
 		&& m_Target.id < INVALID_BAND)
 	{
-		pNpc = m_pMain->m_arNpc.GetData(m_Target.id - NPC_BAND);
-		//pNpc = m_pMain->m_arNpc[m_Target.id - NPC_BAND];
+		pNpc = m_pMain->m_NpcMap.GetData(m_Target.id - NPC_BAND);
+		//pNpc = m_pMain->m_NpcMap[m_Target.id - NPC_BAND];
 		if (pNpc == nullptr)
 		{
 			InitTarget();
@@ -4218,8 +4218,8 @@ BOOL CNpc::GetTargetPos(float& x, float& z)
 	else if (m_Target.id >= NPC_BAND
 		&& m_Target.id < INVALID_BAND)
 	{
-		CNpc* pNpc = m_pMain->m_arNpc.GetData(m_Target.id - NPC_BAND);
-		//CNpc* pNpc = m_pMain->m_arNpc[m_Target.id - NPC_BAND];
+		CNpc* pNpc = m_pMain->m_NpcMap.GetData(m_Target.id - NPC_BAND);
+		//CNpc* pNpc = m_pMain->m_NpcMap[m_Target.id - NPC_BAND];
 		if (pNpc == nullptr)
 			return FALSE;
 
@@ -4635,7 +4635,7 @@ void CNpc::ChangeNTarget(CNpc* pNpc, CIOCPort* pIOCP)
 	else if (m_Target.id >= NPC_BAND
 		&& m_Target.id < INVALID_BAND)
 	{
-		preNpc = m_pMain->m_arNpc.GetData(m_Target.id - NPC_BAND);
+		preNpc = m_pMain->m_NpcMap.GetData(m_Target.id - NPC_BAND);
 	}
 
 	if (pNpc == preNpc)
@@ -4765,7 +4765,7 @@ BOOL CNpc::SetDamage(int nAttackType, int nDamage, const char* sourceName, int u
 	else if (uid >= NPC_BAND
 		&& m_Target.id < INVALID_BAND)
 	{
-		pNpc = m_pMain->m_arNpc.GetData(uid - NPC_BAND);
+		pNpc = m_pMain->m_NpcMap.GetData(uid - NPC_BAND);
 		if (pNpc == nullptr)
 			return TRUE;
 
@@ -5044,7 +5044,7 @@ void CNpc::SendExpToUserList()
 				if (bFlag)
 				{
 					int uid = 0;
-					pParty = m_pMain->m_arParty.GetData(pUser->m_sPartyNumber);
+					pParty = m_pMain->m_PartyMap.GetData(pUser->m_sPartyNumber);
 					if (pParty != nullptr)
 					{
 						int nTotalMan = 0, nTotalLevel = 0;
@@ -5102,7 +5102,7 @@ void CNpc::SendExpToUserList()
 			else if (i == 0)
 			{
 				int uid = 0;
-				pParty = m_pMain->m_arParty.GetData(pUser->m_sPartyNumber);
+				pParty = m_pMain->m_PartyMap.GetData(pUser->m_sPartyNumber);
 				if (pParty != nullptr)
 				{
 					int nTotalMan = 0, nTotalLevel = 0;
@@ -5474,7 +5474,7 @@ void CNpc::FindFriendRegion(int x, int z, MAP* pMap, _TargetHealer* pHealer, int
 		if (nid < NPC_BAND)
 			continue;
 
-		pNpc = m_pMain->m_arNpc.GetData(nid - NPC_BAND);
+		pNpc = m_pMain->m_NpcMap.GetData(nid - NPC_BAND);
 
 		if (pNpc != nullptr
 			&& pNpc->m_NpcState != NPC_DEAD
@@ -6318,7 +6318,7 @@ void CNpc::IsNoPathFind(float fDistance)
 		return;
 	}
 
-	MAP* pMap = m_pMain->g_arZone[m_ZoneIndex];
+	MAP* pMap = m_pMain->m_ZoneArray[m_ZoneIndex];
 	if (pMap == nullptr)
 	{
 		ClearPathFindData();
@@ -6981,13 +6981,13 @@ int CNpc::GetWeaponItemCodeNumber(int item_type)
 	if (item_type == 1)
 	{
 		iItem_level = m_sLevel / 10;
-		pItemData = m_pMain->m_MakeWeaponItemArray.GetData(iItem_level);
+		pItemData = m_pMain->m_MakeWeaponTableMap.GetData(iItem_level);
 	}
 	// 방어구
 	else if (item_type == 2)
 	{
 		iItem_level = m_sLevel / 10;
-		pItemData = m_pMain->m_MakeDefensiveItemArray.GetData(iItem_level);
+		pItemData = m_pMain->m_MakeDefensiveTableMap.GetData(iItem_level);
 	}
 
 	if (pItemData == nullptr)
@@ -7015,7 +7015,7 @@ int CNpc::GetItemCodeNumber(int level, int item_type)
 	int iItemPercent[3];
 
 	int iRandom = myrand(0, 1000);
-	model::MakeItemRareCode* pItemData = m_pMain->m_MakeLareItemArray.GetData(level);
+	model::MakeItemRareCode* pItemData = m_pMain->m_MakeItemRareCodeTableMap.GetData(level);
 	if (pItemData == nullptr)
 		return -1;
 
@@ -7190,10 +7190,10 @@ void CNpc::ChangeMonsterInfo(int iChangeType)
 	{
 		// 다른 몬스터로 변환..
 		if (iChangeType == 1)
-			pNpcTable = m_pMain->m_arMonTable.GetData(m_sChangeSid);
+			pNpcTable = m_pMain->m_MonTableMap.GetData(m_sChangeSid);
 		// 원래의 몬스터로 변환..
 		else if (iChangeType == 2)
-			pNpcTable = m_pMain->m_arMonTable.GetData(m_sSid);
+			pNpcTable = m_pMain->m_MonTableMap.GetData(m_sSid);
 
 		if (pNpcTable == nullptr)
 		{
@@ -7205,10 +7205,10 @@ void CNpc::ChangeMonsterInfo(int iChangeType)
 	{
 		// 다른 몬스터로 변환..
 		if (iChangeType == 1)
-			pNpcTable = m_pMain->m_arNpcTable.GetData(m_sChangeSid);
+			pNpcTable = m_pMain->m_NpcTableMap.GetData(m_sChangeSid);
 		// 원래의 몬스터로 변환..
 		else if (iChangeType == 2)
-			pNpcTable = m_pMain->m_arNpcTable.GetData(m_sSid);
+			pNpcTable = m_pMain->m_NpcTableMap.GetData(m_sSid);
 
 		if (pNpcTable == nullptr)
 		{
@@ -7430,7 +7430,7 @@ void CNpc::NpcHealing(CIOCPort* pIOCP)
 	if (nID >= NPC_BAND
 		&& nID < INVALID_BAND)
 	{
-		pNpc = m_pMain->m_arNpc.GetData(nID - NPC_BAND);
+		pNpc = m_pMain->m_NpcMap.GetData(nID - NPC_BAND);
 
 		// User 가 Invalid 한 경우
 		if (pNpc == nullptr
@@ -7561,7 +7561,7 @@ void CNpc::ChangeAbility(int iChangeType)
 	}
 	else if (m_byInitMoveType >= 100)
 	{
-		pNpcTable = m_pMain->m_arNpcTable.GetData(m_sSid);
+		pNpcTable = m_pMain->m_NpcTableMap.GetData(m_sSid);
 		if (pNpcTable == nullptr)
 		{
 			spdlog::error("Npc::ChangeAbility: invalid npcId [serial={} npcId={} npcName={}]",

--- a/Server/AIServer/NpcMagicProcess.cpp
+++ b/Server/AIServer/NpcMagicProcess.cpp
@@ -178,7 +178,7 @@ model::Magic* CNpcMagicProcess::IsAvailable(int magicid, int tid, BYTE type)
 		return FALSE;
 
 	// Get main magic table.
-	pTable = m_pMain->m_MagictableArray.GetData(magicid);
+	pTable = m_pMain->m_MagicTableMap.GetData(magicid);
 	if (!pTable)
 		goto fail_return;
 
@@ -196,7 +196,7 @@ model::Magic* CNpcMagicProcess::IsAvailable(int magicid, int tid, BYTE type)
 	// Compare morals between source and target NPC.            
 	else if (tid >= NPC_BAND)
 	{
-		pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+		pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 		if (!pNpc
 			|| pNpc->m_NpcState == NPC_DEAD)
 			goto fail_return;
@@ -323,7 +323,7 @@ void CNpcMagicProcess::ExecuteType3(int magicid, int tid, int data1, int data2, 
 	model::Magic* pMagic = nullptr;
 
 	// Get main magic table.
-	pMagic = m_pMain->m_MagictableArray.GetData(magicid);
+	pMagic = m_pMain->m_MagicTableMap.GetData(magicid);
 	if (!pMagic)
 		return;
 
@@ -331,7 +331,7 @@ void CNpcMagicProcess::ExecuteType3(int magicid, int tid, int data1, int data2, 
 	if (tid == -1)
 		goto packet_send;
 
-	pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+	pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 	if (pNpc == nullptr
 		|| pNpc->m_NpcState == NPC_DEAD
 		|| pNpc->m_iHP == 0)
@@ -341,7 +341,7 @@ void CNpcMagicProcess::ExecuteType3(int magicid, int tid, int data1, int data2, 
 	}
 
 	// Get magic skill table type 3.
-	pType = m_pMain->m_Magictype3Array.GetData(magicid);
+	pType = m_pMain->m_MagicType3TableMap.GetData(magicid);
 	if (!pType)
 		return;
 
@@ -459,7 +459,7 @@ short CNpcMagicProcess::GetMagicDamage(int tid, int total_hit, int attribute, in
 		return 0;
 
 	CNpc* pNpc = nullptr;
-	pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+	pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 	if (pNpc == nullptr
 		|| pNpc->m_NpcState == NPC_DEAD
 		|| pNpc->m_iHP == 0)

--- a/Server/AIServer/NpcThread.cpp
+++ b/Server/AIServer/NpcThread.cpp
@@ -165,7 +165,7 @@ UINT ZoneEventThreadProc(LPVOID pParam/* = nullptr */)
 	while (!g_bNpcExit)
 	{
 		float fCurrentTime = TimeGet();
-		for (MAP* pMap : m_pMain->g_arZone)
+		for (MAP* pMap : m_pMain->m_ZoneArray)
 		{
 			if (pMap == nullptr)
 				continue;

--- a/Server/AIServer/Party.cpp
+++ b/Server/AIServer/Party.cpp
@@ -88,7 +88,7 @@ void CParty::PartyCreate(char* pBuf)
 	pParty->wIndex = sPartyIndex;
 	pParty->uid[0] = sUid;
 
-	if (m_pMain->m_arParty.PutData(pParty->wIndex, pParty))
+	if (m_pMain->m_PartyMap.PutData(pParty->wIndex, pParty))
 	{
 		spdlog::debug("Party::PartyCreate: success [partyId={} uid0={} uid1={}]",
 			sPartyIndex, pParty->uid[0], pParty->uid[1]);
@@ -113,7 +113,7 @@ void CParty::PartyInsert(char* pBuf)
 	//byLevel = GetByte(pBuf, index);
 	//sClass = GetShort(pBuf, index);
 
-	pParty = m_pMain->m_arParty.GetData(sPartyIndex);
+	pParty = m_pMain->m_PartyMap.GetData(sPartyIndex);
 
 	// 이상한 경우
 	if (!pParty)
@@ -151,7 +151,7 @@ void CParty::PartyRemove(char* pBuf)
 	if (sPartyIndex <= -1)
 		return;
 
-	pParty = m_pMain->m_arParty.GetData(sPartyIndex);
+	pParty = m_pMain->m_PartyMap.GetData(sPartyIndex);
 
 	// 이상한 경우
 	if (!pParty)
@@ -188,7 +188,7 @@ void CParty::PartyDelete(char* pBuf)
 	if (sPartyIndex <= -1)
 		return;
 
-	pParty = m_pMain->m_arParty.GetData(sPartyIndex);
+	pParty = m_pMain->m_PartyMap.GetData(sPartyIndex);
 
 	// 이상한 경우
 	if (!pParty)
@@ -209,7 +209,7 @@ void CParty::PartyDelete(char* pBuf)
 
 	EnterCriticalSection(&g_region_critical);
 
-	m_pMain->m_arParty.DeleteData(pParty->wIndex);
+	m_pMain->m_PartyMap.DeleteData(pParty->wIndex);
 
 	LeaveCriticalSection(&g_region_critical);
 }

--- a/Server/AIServer/RoomEvent.cpp
+++ b/Server/AIServer/RoomEvent.cpp
@@ -299,7 +299,7 @@ CNpc* CRoomEvent::GetNpcPtr(int sid)
 		if (nMonsterid < 0)
 			continue;
 
-		pNpc = m_pMain->m_arNpc.GetData(nMonsterid);
+		pNpc = m_pMain->m_NpcMap.GetData(nMonsterid);
 		if (pNpc == nullptr)
 			continue;
 
@@ -361,7 +361,7 @@ BOOL CRoomEvent::CheckMonsterCount(int sid, int count, int type)
 		if (nMonsterid < 0)
 			continue;
 
-		pNpc = m_pMain->m_arNpc.GetData(nMonsterid);
+		pNpc = m_pMain->m_NpcMap.GetData(nMonsterid);
 		if (pNpc == nullptr)
 			continue;
 

--- a/Server/AIServer/ServerDlg.h
+++ b/Server/AIServer/ServerDlg.h
@@ -52,17 +52,17 @@ public:
 // CServerDlg dialog
 
 typedef std::vector <CNpcThread*>			NpcThreadArray;
-typedef CSTLMap <model::Npc>				NpcTableArray;
-typedef CSTLMap <CNpc>						NpcArray;
-typedef CSTLMap <model::Magic>				MagictableArray;
-typedef CSTLMap <model::MagicType1>			Magictype1Array;
-typedef CSTLMap <model::MagicType2>			Magictype2Array;
-typedef CSTLMap <model::MagicType3>			Magictype3Array;
-typedef CSTLMap	<model::MagicType4>			Magictype4Array;
-typedef CSTLMap <_PARTY_GROUP>				PartyArray;
-typedef CSTLMap <model::MakeWeapon>			MakeWeaponItemTableArray;
-typedef CSTLMap <model::MakeItemGradeCode>	MakeGradeItemTableArray;
-typedef CSTLMap <model::MakeItemRareCode>	MakeLareItemTableArray;
+typedef CSTLMap <model::Npc>				NpcTableMap;
+typedef CSTLMap <CNpc>						NpcMap;
+typedef CSTLMap <model::Magic>				MagicTableMap;
+typedef CSTLMap <model::MagicType1>			MagicType1TableMap;
+typedef CSTLMap <model::MagicType2>			MagicType2TableMap;
+typedef CSTLMap <model::MagicType3>			MagicType3TableMap;
+typedef CSTLMap	<model::MagicType4>			MagicType4TableMap;
+typedef CSTLMap <_PARTY_GROUP>				PartyMap;
+typedef CSTLMap <model::MakeWeapon>			MakeWeaponTableMap;
+typedef CSTLMap <model::MakeItemGradeCode>	MakeGradeItemCodeTableMap;
+typedef CSTLMap <model::MakeItemRareCode>	MakeItemRareCodeTableMap;
 typedef std::list <int>						ZoneNpcInfoList;
 typedef std::vector <MAP*>					ZoneArray;
 
@@ -131,24 +131,23 @@ protected:
 	//}}AFX_VIRTUAL
 
 public:
-//	ZoneArray			m_arZone;
-	NpcArray			m_arNpc;
-	NpcTableArray		m_arMonTable;
-	NpcTableArray		m_arNpcTable;
-	NpcThreadArray		m_arNpcThread;
-	NpcThreadArray		m_arEventNpcThread;	// Event Npc Logic
-	PartyArray			m_arParty;
-	ZoneNpcInfoList		m_ZoneNpcList;
-	MagictableArray		m_MagictableArray;
-	Magictype1Array		m_Magictype1Array;
-	Magictype2Array		m_Magictype2Array;
-	Magictype3Array		m_Magictype3Array;
-	Magictype4Array		m_Magictype4Array;
-	MakeWeaponItemTableArray	m_MakeWeaponItemArray;
-	MakeWeaponItemTableArray	m_MakeDefensiveItemArray;
-	MakeGradeItemTableArray  m_MakeGradeItemArray;
-	MakeLareItemTableArray  m_MakeLareItemArray;
-	ZoneArray g_arZone;
+	NpcMap						m_NpcMap;
+	NpcTableMap					m_MonTableMap;
+	NpcTableMap					m_NpcTableMap;
+	NpcThreadArray				m_NpcThreadArray;
+	NpcThreadArray				m_EventNpcThreadArray;	// Event Npc Logic
+	PartyMap					m_PartyMap;
+	ZoneNpcInfoList				m_ZoneNpcList;
+	MagicTableMap				m_MagicTableMap;
+	MagicType1TableMap			m_MagicType1TableMap;
+	MagicType2TableMap			m_MagicType2TableMap;
+	MagicType3TableMap			m_MagicType3TableMap;
+	MagicType4TableMap			m_MagicType4TableMap;
+	MakeWeaponTableMap			m_MakeWeaponTableMap;
+	MakeWeaponTableMap			m_MakeDefensiveTableMap;
+	MakeGradeItemCodeTableMap	m_MakeGradeItemArray;
+	MakeItemRareCodeTableMap	m_MakeItemRareCodeTableMap;
+	ZoneArray					m_ZoneArray;
 
 	CWinThread* m_pZoneEventThread;		// zone
 

--- a/Server/AIServer/User.cpp
+++ b/Server/AIServer/User.cpp
@@ -116,7 +116,7 @@ void CUser::Initialize()
 
 void CUser::Attack(int sid, int tid)
 {
-	CNpc* pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 	if (pNpc == nullptr)
 		return;
 
@@ -514,7 +514,7 @@ short CUser::GetDamage(int tid, int magicid)
 		|| tid > INVALID_BAND)
 		return damage;
 
-	CNpc* pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 	if (pNpc == nullptr)
 		return damage;
 
@@ -535,7 +535,7 @@ short CUser::GetDamage(int tid, int magicid)
 	if (magicid > 0)
 	{
 		// Get main magic table.
-		pTable = m_pMain->m_MagictableArray.GetData(magicid);
+		pTable = m_pMain->m_MagicTableMap.GetData(magicid);
 		if (pTable == nullptr)
 			return -1;
 
@@ -543,7 +543,7 @@ short CUser::GetDamage(int tid, int magicid)
 		if (pTable->Type1 == 1)
 		{
 			// Get magic skill table type 1.
-			pType1 = m_pMain->m_Magictype1Array.GetData(magicid);
+			pType1 = m_pMain->m_MagicType1TableMap.GetData(magicid);
 			if (!pType1)
 				return -1;
 
@@ -579,7 +579,7 @@ short CUser::GetDamage(int tid, int magicid)
 		else if (pTable->Type1 == 2)
 		{
 			// Get magic skill table type 2.
-			pType2 = m_pMain->m_Magictype2Array.GetData(magicid);
+			pType2 = m_pMain->m_MagicType2TableMap.GetData(magicid);
 			if (pType2 == nullptr)
 				return -1;
 
@@ -663,7 +663,7 @@ short CUser::GetMagicDamage(int damage, short tid)
 {
 	short total_r = 0, temp_damage = 0;
 
-	CNpc* pNpc = m_pMain->m_arNpc.GetData(tid - NPC_BAND);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
 	if (pNpc == nullptr)
 		return damage;
 
@@ -1024,7 +1024,7 @@ void CUser::HealAreaCheck(int rx, int rz)
 		return;
 	}
 
-	// 자신의 region에 있는 NpcArray을 먼저 검색하여,, 가까운 거리에 Monster가 있는지를 판단..
+	// 자신의 region에 있는 NpcMap을 먼저 검색하여,, 가까운 거리에 Monster가 있는지를 판단..
 	if (rx < 0
 		|| rz < 0
 		|| rx > pMap->GetXRegionMax()
@@ -1067,7 +1067,7 @@ void CUser::HealAreaCheck(int rx, int rz)
 		if (nid < NPC_BAND)
 			continue;
 
-		pNpc = m_pMain->m_arNpc.GetData(nid - NPC_BAND);
+		pNpc = m_pMain->m_NpcMap.GetData(nid - NPC_BAND);
 
 		if (pNpc != nullptr
 			&& pNpc->m_NpcState != NPC_DEAD)

--- a/Server/Ebenezer/AISocket.cpp
+++ b/Server/Ebenezer/AISocket.cpp
@@ -419,9 +419,9 @@ void CAISocket::RecvNpcInfoAll(char* pBuf)
 
 		// TRACE(_T("Recv --> NpcUserInfoAll : uid=%d, sid=%d, name=%hs, x=%f, z=%f. gate=%d, objecttype=%d \n"), nid, sPid, szName, fPosX, fPosZ, byGateOpen, byObjectType);
 
-		if (!m_pMain->m_arNpcArray.PutData(pNpc->m_sNid, pNpc))
+		if (!m_pMain->m_NpcMap.PutData(pNpc->m_sNid, pNpc))
 		{
-			spdlog::error("AISocket::RecvNpcInfoAll: NpcArray put failed [serial={} npcId={} npcName={} zoneId={} x={} z={}]",
+			spdlog::error("AISocket::RecvNpcInfoAll: NpcMap put failed [serial={} npcId={} npcName={} zoneId={} x={} z={}]",
 				instanceId, npcId, npcName, pMap->m_nZoneNumber, fPosX, fPosZ);
 			delete pNpc;
 			pNpc = nullptr;
@@ -459,7 +459,7 @@ void CAISocket::RecvNpcMoveResult(char* pBuf)
 	fPosY = Getfloat(pBuf, index);
 	fSecForMetor = Getfloat(pBuf, index);
 
-	CNpc* pNpc = m_pMain->m_arNpcArray.GetData(nid);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(nid);
 	if (pNpc == nullptr)
 		return;
 
@@ -506,7 +506,7 @@ void CAISocket::RecvNpcAttack(char* pBuf)
 	// user attack -> npc
 	if (type == 0x01)
 	{
-		pNpc = m_pMain->m_arNpcArray.GetData(tid);
+		pNpc = m_pMain->m_NpcMap.GetData(tid);
 		if (pNpc == nullptr)
 			return;
 
@@ -620,7 +620,7 @@ void CAISocket::RecvNpcAttack(char* pBuf)
 	// npc attack -> user
 	else if (type == 0x02)
 	{
-		pNpc = m_pMain->m_arNpcArray.GetData(sid);
+		pNpc = m_pMain->m_NpcMap.GetData(sid);
 		if (pNpc == nullptr)
 			return;
 
@@ -730,7 +730,7 @@ void CAISocket::RecvNpcAttack(char* pBuf)
 		// npc attack -> monster
 		else if (tid >= NPC_BAND)
 		{
-			pMon = m_pMain->m_arNpcArray.GetData(tid);
+			pMon = m_pMain->m_NpcMap.GetData(tid);
 			if (pMon == nullptr)
 				return;
 
@@ -809,7 +809,7 @@ void CAISocket::RecvMagicAttackResult(char* pBuf)
 	// casting
 	if (byCommand == MAGIC_CASTING)
 	{
-		pNpc = m_pMain->m_arNpcArray.GetData(sid);
+		pNpc = m_pMain->m_NpcMap.GetData(sid);
 		if (pNpc == nullptr)
 			return;
 
@@ -836,7 +836,7 @@ void CAISocket::RecvMagicAttackResult(char* pBuf)
 		{
 			if (tid >= NPC_BAND)
 			{
-				pNpc = m_pMain->m_arNpcArray.GetData(tid);
+				pNpc = m_pMain->m_NpcMap.GetData(tid);
 				if (pNpc == nullptr)
 					return;
 
@@ -927,7 +927,7 @@ void CAISocket::RecvNpcInfo(char* pBuf)
 	sHitRate = GetShort(pBuf, index);
 	byObjectType = GetByte(pBuf, index);
 
-	CNpc* pNpc = m_pMain->m_arNpcArray.GetData(instanceId);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(instanceId);
 	if (pNpc == nullptr)
 		return;
 
@@ -1024,7 +1024,7 @@ void CAISocket::RecvNpcInfo(char* pBuf)
 
 	pMap->RegionNpcAdd(pNpc->m_sRegion_X, pNpc->m_sRegion_Z, pNpc->m_sNid);
 
-//	int nTotMon = m_pMain->m_arNpcArray.GetSize();
+//	int nTotMon = m_pMain->m_NpcMap.GetSize();
 //	TRACE(_T("Recv --> NpcUserInfo : uid = %d, x=%f, z=%f.. ,, tot = %d\n"), nid, fPosX, fPosZ, nTotMon);
 }
 
@@ -1050,7 +1050,7 @@ void CAISocket::RecvUserHP(char* pBuf)
 	}
 	else if (nid >= NPC_BAND)
 	{
-		CNpc* pNpc = m_pMain->m_arNpcArray.GetData(nid);
+		CNpc* pNpc = m_pMain->m_NpcMap.GetData(nid);
 		if (pNpc == nullptr)
 			return;
 
@@ -1192,7 +1192,7 @@ void CAISocket::RecvNpcGiveItem(char* pBuf)
 
 	for (int i = 0; i < byCount; i++)
 	{
-		if (m_pMain->m_ItemtableArray.GetData(nItemNumber[i]) != nullptr)
+		if (m_pMain->m_ItemTableMap.GetData(nItemNumber[i]) != nullptr)
 		{
 			pItem->itemid[i] = nItemNumber[i];
 			pItem->count[i] = sCount[i];
@@ -1326,15 +1326,15 @@ void CAISocket::InitEventMonster(int instanceId)
 		pNpc->m_sNid = i + NPC_BAND;
 		//TRACE(_T("InitEventMonster : uid = %d\n"), pNpc->m_sNid);
 
-		if (!m_pMain->m_arNpcArray.PutData(pNpc->m_sNid, pNpc))
+		if (!m_pMain->m_NpcMap.PutData(pNpc->m_sNid, pNpc))
 		{
-			spdlog::error("AISocket::InitEventMonster: NpcArray Put failed for serial={}", pNpc->m_sNid);
+			spdlog::error("AISocket::InitEventMonster: NpcMap Put failed for serial={}", pNpc->m_sNid);
 			delete pNpc;
 			pNpc = nullptr;
 		}
 	}
 	
-	spdlog::debug("AISocket::InitEventMonster: TotalMonster = {}", m_pMain->m_arNpcArray.GetSize());
+	spdlog::debug("AISocket::InitEventMonster: TotalMonster = {}", m_pMain->m_NpcMap.GetSize());
 }
 
 void CAISocket::RecvCheckAlive(char* pBuf)
@@ -1362,7 +1362,7 @@ void CAISocket::RecvGateDestroy(char* pBuf)
 
 	if (instanceId >= NPC_BAND)
 	{
-		CNpc* pNpc = m_pMain->m_arNpcArray.GetData(instanceId);
+		CNpc* pNpc = m_pMain->m_NpcMap.GetData(instanceId);
 		if (pNpc == nullptr)
 		{
 			spdlog::error("AISocket::RecvGateDestroy: NPC not found serial={}", instanceId);
@@ -1393,7 +1393,7 @@ void CAISocket::RecvNpcDead(char* pBuf)
 
 	if (nid >= NPC_BAND)
 	{
-		CNpc* pNpc = m_pMain->m_arNpcArray.GetData(nid);
+		CNpc* pNpc = m_pMain->m_NpcMap.GetData(nid);
 		if (pNpc == nullptr)
 			return;
 
@@ -1438,7 +1438,7 @@ void CAISocket::RecvNpcInOut(char* pBuf)
 
 	if (nid >= NPC_BAND)
 	{
-		CNpc* pNpc = m_pMain->m_arNpcArray.GetData(nid);
+		CNpc* pNpc = m_pMain->m_NpcMap.GetData(nid);
 		if (pNpc == nullptr)
 			return;
 
@@ -1559,7 +1559,7 @@ void CAISocket::RecvBattleEvent(char* pBuf)
 			pUser = m_pMain->GetUserPtr(strMaxUserName, NameType::Character);
 			if (pUser != nullptr)
 			{
-				pKnights = m_pMain->m_KnightsArray.GetData(pUser->m_pUserData->m_bKnights);
+				pKnights = m_pMain->m_KnightsMap.GetData(pUser->m_pUserData->m_bKnights);
 				if (pKnights != nullptr)
 					strcpy(strKnightsName, pKnights->m_strName);
 			}
@@ -1685,7 +1685,7 @@ void CAISocket::RecvGateOpen(char* pBuf)
 	npcId = GetShort(pBuf, index);
 	nGateFlag = GetByte(pBuf, index);
 
-	pNpc = m_pMain->m_arNpcArray.GetData(instanceId);
+	pNpc = m_pMain->m_NpcMap.GetData(instanceId);
 	if (pNpc == nullptr)
 	{
 		spdlog::error("AISocket::RecvGateOpen: Npc not found [serial={} npcId={}]",

--- a/Server/Ebenezer/EbenezerDlg.cpp
+++ b/Server/Ebenezer/EbenezerDlg.cpp
@@ -614,44 +614,44 @@ BOOL CEbenezerDlg::DestroyWindow()
 		CloseHandle(m_hMMFile);
 	}
 
-	if (!m_ItemtableArray.IsEmpty())
-		m_ItemtableArray.DeleteAllData();
+	if (!m_ItemTableMap.IsEmpty())
+		m_ItemTableMap.DeleteAllData();
 
-	if (!m_MagictableArray.IsEmpty())
-		m_MagictableArray.DeleteAllData();
+	if (!m_MagicTableMap.IsEmpty())
+		m_MagicTableMap.DeleteAllData();
 
-	if (!m_Magictype1Array.IsEmpty())
-		m_Magictype1Array.DeleteAllData();
+	if (!m_MagicType1TableMap.IsEmpty())
+		m_MagicType1TableMap.DeleteAllData();
 
-	if (!m_Magictype2Array.IsEmpty())
-		m_Magictype2Array.DeleteAllData();
+	if (!m_MagicType2TableMap.IsEmpty())
+		m_MagicType2TableMap.DeleteAllData();
 
-	if (!m_Magictype3Array.IsEmpty())
-		m_Magictype3Array.DeleteAllData();
+	if (!m_MagicType3TableMap.IsEmpty())
+		m_MagicType3TableMap.DeleteAllData();
 
-	if (!m_Magictype4Array.IsEmpty())
-		m_Magictype4Array.DeleteAllData();
+	if (!m_MagicType4TableMap.IsEmpty())
+		m_MagicType4TableMap.DeleteAllData();
 
-	if (!m_Magictype5Array.IsEmpty())
-		m_Magictype5Array.DeleteAllData();
+	if (!m_MagicType5TableMap.IsEmpty())
+		m_MagicType5TableMap.DeleteAllData();
 
-	if (!m_Magictype8Array.IsEmpty())
-		m_Magictype8Array.DeleteAllData();
+	if (!m_MagicType8TableMap.IsEmpty())
+		m_MagicType8TableMap.DeleteAllData();
 
-	if (!m_arNpcArray.IsEmpty())
-		m_arNpcArray.DeleteAllData();
+	if (!m_NpcMap.IsEmpty())
+		m_NpcMap.DeleteAllData();
 
-	if (!m_AISocketArray.IsEmpty())
-		m_AISocketArray.DeleteAllData();
+	if (!m_AISocketMap.IsEmpty())
+		m_AISocketMap.DeleteAllData();
 
-	if (!m_PartyArray.IsEmpty())
-		m_PartyArray.DeleteAllData();
+	if (!m_PartyMap.IsEmpty())
+		m_PartyMap.DeleteAllData();
 
-	if (!m_CoefficientArray.IsEmpty())
-		m_CoefficientArray.DeleteAllData();
+	if (!m_CoefficientTableMap.IsEmpty())
+		m_CoefficientTableMap.DeleteAllData();
 
-	if (!m_KnightsArray.IsEmpty())
-		m_KnightsArray.DeleteAllData();
+	if (!m_KnightsMap.IsEmpty())
+		m_KnightsMap.DeleteAllData();
 
 	if (!m_ServerArray.IsEmpty())
 		m_ServerArray.DeleteAllData();
@@ -659,22 +659,22 @@ BOOL CEbenezerDlg::DestroyWindow()
 	if (!m_ServerGroupArray.IsEmpty())
 		m_ServerGroupArray.DeleteAllData();
 
-	if (!m_HomeArray.IsEmpty())
-		m_HomeArray.DeleteAllData();
+	if (!m_HomeTableMap.IsEmpty())
+		m_HomeTableMap.DeleteAllData();
 
-	if (!m_StartPositionMap.IsEmpty())
-		m_StartPositionMap.DeleteAllData();
+	if (!m_StartPositionTableMap.IsEmpty())
+		m_StartPositionTableMap.DeleteAllData();
 
 	for (C3DMap* pMap : m_ZoneArray)
 		delete pMap;
 	m_ZoneArray.clear();
 
-	for (model::LevelUp* pLevelUp : m_LevelUpArray)
+	for (model::LevelUp* pLevelUp : m_LevelUpTableArray)
 		delete pLevelUp;
-	m_LevelUpArray.clear();
+	m_LevelUpTableArray.clear();
 
-	if (!m_Event.IsEmpty())
-		m_Event.DeleteAllData();
+	if (!m_EventMap.IsEmpty())
+		m_EventMap.DeleteAllData();
 
 	delete m_pUdpSocket;
 	m_pUdpSocket = nullptr;
@@ -757,7 +757,7 @@ void CEbenezerDlg::OnTimer(UINT nIDEvent)
 				int count = 0;
 				for (int i = 0; i < MAX_AI_SOCKET; i++)
 				{
-					CAISocket* pAISock = m_AISocketArray.GetData(i);
+					CAISocket* pAISock = m_AISocketMap.GetData(i);
 					if (pAISock != nullptr
 						&& pAISock->GetState() == STATE_DISCONNECTED)
 						AISocketConnect(i, 1);
@@ -824,13 +824,13 @@ BOOL CEbenezerDlg::AISocketConnect(int zone, int flag)
 
 	//if( m_nServerNo == 3 ) return FALSE;
 
-	pAISock = m_AISocketArray.GetData(zone);
+	pAISock = m_AISocketMap.GetData(zone);
 	if (pAISock != nullptr)
 	{
 		if (pAISock->GetState() != STATE_DISCONNECTED)
 			return TRUE;
 
-		m_AISocketArray.DeleteData(zone);
+		m_AISocketMap.DeleteData(zone);
 	}
 
 	pAISock = new CAISocket(zone);
@@ -881,7 +881,7 @@ BOOL CEbenezerDlg::AISocketConnect(int zone, int flag)
 	// 해야할일 :이 부분 처리.....
 	//SendAllUserInfo();
 	//m_sSocketCount = zone;
-	m_AISocketArray.PutData(zone, pAISock);
+	m_AISocketMap.PutData(zone, pAISock);
 
 	spdlog::debug("EbenezerDlg::AISocketConnect: connected to zone {}", zone);
 	return TRUE;
@@ -1055,7 +1055,7 @@ void CEbenezerDlg::Send_PartyMember(int party, char* pBuf, int len)
 	if (party < 0)
 		return;
 
-	_PARTY_GROUP* pParty = m_PartyArray.GetData(party);
+	_PARTY_GROUP* pParty = m_PartyMap.GetData(party);
 	if (pParty == nullptr)
 		return;
 
@@ -1076,7 +1076,7 @@ void CEbenezerDlg::Send_KnightsMember(int index, char* pBuf, int len, int zone)
 	if (index <= 0)
 		return;
 
-	CKnights* pKnights = m_KnightsArray.GetData(index);
+	CKnights* pKnights = m_KnightsMap.GetData(index);
 	if (pKnights == nullptr)
 		return;
 
@@ -1102,7 +1102,7 @@ void CEbenezerDlg::Send_AIServer(int zone, char* pBuf, int len)
 {
 	for (int i = 0; i < MAX_AI_SOCKET; i++)
 	{
-		CAISocket* pSocket = m_AISocketArray.GetData(i);
+		CAISocket* pSocket = m_AISocketMap.GetData(i);
 		if (pSocket == nullptr)
 		{
 			m_sSendSocket++;
@@ -1237,7 +1237,7 @@ BOOL CEbenezerDlg::MapFileLoad()
 				continue;
 			}
 
-			if (!m_Event.PutData(pEvent->m_Zone, pEvent))
+			if (!m_EventMap.PutData(pEvent->m_Zone, pEvent))
 				delete pEvent;
 		}
 		while (recordset.next());
@@ -1265,7 +1265,7 @@ void CEbenezerDlg::ReportTableLoadError(const recordset_loader::Error& err, cons
 
 BOOL CEbenezerDlg::LoadItemTable()
 {
-	recordset_loader::STLMap loader(m_ItemtableArray);
+	recordset_loader::STLMap loader(m_ItemTableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -1277,7 +1277,7 @@ BOOL CEbenezerDlg::LoadItemTable()
 
 BOOL CEbenezerDlg::LoadMagicTable()
 {
-	recordset_loader::STLMap loader(m_MagictableArray);
+	recordset_loader::STLMap loader(m_MagicTableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -1289,7 +1289,7 @@ BOOL CEbenezerDlg::LoadMagicTable()
 
 BOOL CEbenezerDlg::LoadMagicType1()
 {
-	recordset_loader::STLMap loader(m_Magictype1Array);
+	recordset_loader::STLMap loader(m_MagicType1TableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -1301,7 +1301,7 @@ BOOL CEbenezerDlg::LoadMagicType1()
 
 BOOL CEbenezerDlg::LoadMagicType2()
 {
-	recordset_loader::STLMap loader(m_Magictype2Array);
+	recordset_loader::STLMap loader(m_MagicType2TableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -1313,7 +1313,7 @@ BOOL CEbenezerDlg::LoadMagicType2()
 
 BOOL CEbenezerDlg::LoadMagicType3()
 {
-	recordset_loader::STLMap loader(m_Magictype3Array);
+	recordset_loader::STLMap loader(m_MagicType3TableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -1325,7 +1325,7 @@ BOOL CEbenezerDlg::LoadMagicType3()
 
 BOOL CEbenezerDlg::LoadMagicType4()
 {
-	recordset_loader::STLMap loader(m_Magictype4Array);
+	recordset_loader::STLMap loader(m_MagicType4TableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -1337,7 +1337,7 @@ BOOL CEbenezerDlg::LoadMagicType4()
 
 BOOL CEbenezerDlg::LoadMagicType5()
 {
-	recordset_loader::STLMap loader(m_Magictype5Array);
+	recordset_loader::STLMap loader(m_MagicType5TableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -1349,7 +1349,7 @@ BOOL CEbenezerDlg::LoadMagicType5()
 
 BOOL CEbenezerDlg::LoadMagicType8()
 {
-	recordset_loader::STLMap loader(m_Magictype8Array);
+	recordset_loader::STLMap loader(m_MagicType8TableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -1361,7 +1361,7 @@ BOOL CEbenezerDlg::LoadMagicType8()
 
 BOOL CEbenezerDlg::LoadCoefficientTable()
 {
-	recordset_loader::STLMap loader(m_CoefficientArray);
+	recordset_loader::STLMap loader(m_CoefficientTableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -1373,7 +1373,7 @@ BOOL CEbenezerDlg::LoadCoefficientTable()
 
 BOOL CEbenezerDlg::LoadLevelUpTable()
 {
-	recordset_loader::Vector<model::LevelUp> loader(m_LevelUpArray);
+	recordset_loader::Vector<model::LevelUp> loader(m_LevelUpTableArray);
 	if (!loader.Load_ForbidEmpty(true))
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -1970,7 +1970,7 @@ int CEbenezerDlg::GetRegionNpcIn(C3DMap* pMap, int region_x, int region_z, char*
 		if (nid < 0)
 			continue;
 
-		CNpc* pNpc = m_arNpcArray.GetData(nid);
+		CNpc* pNpc = m_NpcMap.GetData(nid);
 		if (pNpc == nullptr)
 			continue;
 
@@ -2118,7 +2118,7 @@ int CEbenezerDlg::GetRegionNpcList(C3DMap* pMap, int region_x, int region_z, cha
 		if (npcId < 0)
 			continue;
 
-		CNpc* pNpc = m_arNpcArray.GetData(npcId);
+		CNpc* pNpc = m_NpcMap.GetData(npcId);
 		//if( pNpc && (pNpc->m_NpcState == NPC_LIVE ) ) {  // 수정할 것,,
 		if (pNpc != nullptr)
 		{
@@ -2384,7 +2384,7 @@ void CEbenezerDlg::SyncTest(int nType)
 		if (pMap == nullptr)
 			continue;
 
-		CAISocket* pSocket = m_AISocketArray.GetData(pMap->m_nZoneNumber);
+		CAISocket* pSocket = m_AISocketMap.GetData(pMap->m_nZoneNumber);
 		if (pSocket == nullptr)
 			continue;
 
@@ -2461,7 +2461,7 @@ void CEbenezerDlg::SyncRegionTest(C3DMap* pMap, int rx, int rz, FILE* pfile, int
 		}
 		else if (nType == 2)
 		{
-			CNpc* pNpc = m_arNpcArray.GetData(nid);
+			CNpc* pNpc = m_NpcMap.GetData(nid);
 			if (pNpc == nullptr)
 			{
 				spdlog::error("EbenezerDlg::SyncRegionTest: npcId={} not found", nid);
@@ -2536,9 +2536,9 @@ void CEbenezerDlg::SendAllUserInfo()
 	// 파티에 대한 정보도 보내도록 한다....
 	EnterCriticalSection(&g_region_critical);
 
-	for (int i = 0; i < m_PartyArray.GetSize(); i++)
+	for (int i = 0; i < m_PartyMap.GetSize(); i++)
 	{
-		_PARTY_GROUP* pParty = m_PartyArray.GetData(i);
+		_PARTY_GROUP* pParty = m_PartyMap.GetData(i);
 		if (pParty == nullptr)
 			continue;
 
@@ -2645,8 +2645,8 @@ void CEbenezerDlg::DeleteAllNpcList(int flag)
 	}
 
 	// Npc Array Delete
-	if (!m_arNpcArray.IsEmpty())
-		m_arNpcArray.DeleteAllData();
+	if (!m_NpcMap.IsEmpty())
+		m_NpcMap.DeleteAllData();
 
 	m_bServerCheckFlag = FALSE;
 
@@ -2672,7 +2672,7 @@ CNpc* CEbenezerDlg::GetNpcPtr(int sid, int cur_zone)
 	if (!m_bPointCheckFlag)
 		return nullptr;
 
-	for (const auto& [_, pNpc] : m_arNpcArray)
+	for (const auto& [_, pNpc] : m_NpcMap)
 	{
 		if (pNpc == nullptr)
 			continue;
@@ -3049,7 +3049,7 @@ void CEbenezerDlg::Announcement(BYTE type, int nation, int chat_type)
 
 BOOL CEbenezerDlg::LoadStartPositionTable()
 {
-	recordset_loader::STLMap loader(m_StartPositionMap);
+	recordset_loader::STLMap loader(m_StartPositionTableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -3061,7 +3061,7 @@ BOOL CEbenezerDlg::LoadStartPositionTable()
 
 BOOL CEbenezerDlg::LoadHomeTable()
 {
-	recordset_loader::STLMap loader(m_HomeArray);
+	recordset_loader::STLMap loader(m_HomeTableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);
@@ -3130,9 +3130,9 @@ BOOL CEbenezerDlg::LoadAllKnights()
 				strcpy(pKnights->m_arKnightsUser[i].strUserName, "");
 			}
 
-			if (!m_KnightsArray.PutData(pKnights->m_sIndex, pKnights))
+			if (!m_KnightsMap.PutData(pKnights->m_sIndex, pKnights))
 			{
-				spdlog::error("EbenezerDlg::LoadAllKnights: failed to put into KnightsArray [knightsId={}]",
+				spdlog::error("EbenezerDlg::LoadAllKnights: failed to put into KnightsMap [knightsId={}]",
 					pKnights->m_sIndex);
 				delete pKnights;
 			}
@@ -3205,7 +3205,7 @@ int CEbenezerDlg::GetKnightsAllMembers(int knightsindex, char* temp_buff, int& b
 	}
 	else if (type == 1)
 	{
-		CKnights* pKnights = m_KnightsArray.GetData(knightsindex);
+		CKnights* pKnights = m_KnightsMap.GetData(knightsindex);
 		if (pKnights == nullptr)
 			return 0;
 
@@ -3508,6 +3508,9 @@ BOOL CEbenezerDlg::LoadBattleTable()
 	return TRUE;
 }
 
+
+
+
 void CEbenezerDlg::Send_CommandChat(char* pBuf, int len, int nation, CUser* pExceptUser)
 {
 	for (int i = 0; i < MAX_USER; i++)
@@ -3542,7 +3545,7 @@ BOOL CEbenezerDlg::LoadKnightsRankTable()
 			ModelType row = {};
 			recordset.get_ref(row);
 		
-			CKnights* pKnights = m_KnightsArray.GetData(row.Index);
+			CKnights* pKnights = m_KnightsMap.GetData(row.Index);
 
 			rtrim(row.Name);
 

--- a/Server/Ebenezer/EbenezerDlg.h
+++ b/Server/Ebenezer/EbenezerDlg.h
@@ -50,24 +50,24 @@ public:
 // CEbenezerDlg dialog
 
 typedef std::vector <C3DMap*>				ZoneArray;
-typedef std::vector <model::LevelUp*>		LevelUpArray;
-typedef CSTLMap <model::Coefficient>		CoefficientArray;
-typedef CSTLMap <model::Item>				ItemtableArray;
-typedef CSTLMap <model::Magic>				MagictableArray;
-typedef CSTLMap <model::MagicType1>			Magictype1Array;
-typedef CSTLMap <model::MagicType2>			Magictype2Array;
-typedef CSTLMap <model::MagicType3>			Magictype3Array;
-typedef CSTLMap	<model::MagicType4>			Magictype4Array;
-typedef CSTLMap <model::MagicType5>			Magictype5Array;
-typedef CSTLMap <model::MagicType8>			Magictype8Array;
-typedef CSTLMap <CNpc>						NpcArray;
-typedef CSTLMap <CAISocket>					AISocketArray;
-typedef CSTLMap <_PARTY_GROUP>				PartyArray;
-typedef CSTLMap <CKnights>					KnightsArray;
-typedef CSTLMap <_ZONE_SERVERINFO>			ServerArray;
-typedef CSTLMap <model::Home>				HomeArray;
-typedef CSTLMap <model::StartPosition>		StartPositionMap;
-typedef	CSTLMap	<EVENT>						QuestArray;
+typedef std::vector <model::LevelUp*>		LevelUpTableArray;
+typedef CSTLMap <model::Coefficient>		CoefficientTableMap;
+typedef CSTLMap <model::Item>				ItemTableMap;
+typedef CSTLMap <model::Magic>				MagicTableMap;
+typedef CSTLMap <model::MagicType1>			MagicType1TableMap;
+typedef CSTLMap <model::MagicType2>			MagicType2TableMap;
+typedef CSTLMap <model::MagicType3>			MagicType3TableMap;
+typedef CSTLMap	<model::MagicType4>			MagicType4TableMap;
+typedef CSTLMap <model::MagicType5>			MagicType5TableMap;
+typedef CSTLMap <model::MagicType8>			MagicType8TableMap;
+typedef CSTLMap <CNpc>						NpcMap;
+typedef CSTLMap <CAISocket>					AISocketMap;
+typedef CSTLMap <_PARTY_GROUP>				PartyMap;
+typedef CSTLMap <CKnights>					KnightsMap;
+typedef CSTLMap <_ZONE_SERVERINFO>			ServerMap;
+typedef CSTLMap <model::Home>				HomeTableMap;
+typedef CSTLMap <model::StartPosition>		StartPositionTableMap;
+typedef	CSTLMap	<EVENT>						EventMap;
 
 enum class NameType
 {
@@ -190,24 +190,24 @@ public:
 	char	m_ppNotice[20][128];
 	char	m_AIServerIP[20];
 
-	AISocketArray			m_AISocketArray;
-	NpcArray				m_arNpcArray;
+	AISocketMap				m_AISocketMap;
+	NpcMap					m_NpcMap;
 	ZoneArray				m_ZoneArray;
-	ItemtableArray			m_ItemtableArray;
-	MagictableArray			m_MagictableArray;
-	Magictype1Array			m_Magictype1Array;
-	Magictype2Array         m_Magictype2Array;
-	Magictype3Array			m_Magictype3Array;
-	Magictype4Array			m_Magictype4Array;
-	Magictype5Array         m_Magictype5Array;
-	Magictype8Array         m_Magictype8Array;
-	CoefficientArray		m_CoefficientArray;		// 공식 계산 계수데이타 테이블
-	LevelUpArray			m_LevelUpArray;
-	PartyArray				m_PartyArray;
-	KnightsArray			m_KnightsArray;
-	HomeArray				m_HomeArray;
-	StartPositionMap		m_StartPositionMap;
-	QuestArray				m_Event;
+	ItemTableMap			m_ItemTableMap;
+	MagicTableMap			m_MagicTableMap;
+	MagicType1TableMap		m_MagicType1TableMap;
+	MagicType2TableMap		m_MagicType2TableMap;
+	MagicType3TableMap		m_MagicType3TableMap;
+	MagicType4TableMap		m_MagicType4TableMap;
+	MagicType5TableMap		m_MagicType5TableMap;
+	MagicType8TableMap		m_MagicType8TableMap;
+	CoefficientTableMap		m_CoefficientTableMap;		// 공식 계산 계수데이타 테이블
+	LevelUpTableArray		m_LevelUpTableArray;
+	PartyMap				m_PartyMap;
+	KnightsMap				m_KnightsMap;
+	HomeTableMap			m_HomeTableMap;
+	StartPositionTableMap	m_StartPositionTableMap;
+	EventMap				m_EventMap;
 
 	CKnightsManager			m_KnightsManager;
 
@@ -276,8 +276,8 @@ public:
 	// zone server info
 	int					m_nServerNo, m_nServerGroupNo;
 	int					m_nServerGroup;	// server의 번호(0:서버군이 없다, 1:서버1군, 2:서버2군)
-	ServerArray			m_ServerArray;
-	ServerArray			m_ServerGroupArray;
+	ServerMap			m_ServerArray;
+	ServerMap			m_ServerGroupArray;
 	CUdpSocket*			m_pUdpSocket;
 
 // Dialog Data

--- a/Server/Ebenezer/KnightsManager.cpp
+++ b/Server/Ebenezer/KnightsManager.cpp
@@ -192,7 +192,7 @@ fail_return:
 
 BOOL CKnightsManager::IsAvailableName(const char* strname)
 {
-	for (const auto& [_, pKnights] : m_pMain->m_KnightsArray)
+	for (const auto& [_, pKnights] : m_pMain->m_KnightsMap)
 	{
 		if (_strnicmp(pKnights->m_strName, strname, MAX_ID_SIZE) == 0)
 			return FALSE;
@@ -211,7 +211,7 @@ int CKnightsManager::GetKnightsIndex(int nation)
 		knightindex = 15000;
 	// ~sungyong tw
 
-	for (const auto& [_, pKnights] : m_pMain->m_KnightsArray)
+	for (const auto& [_, pKnights] : m_pMain->m_KnightsMap)
 	{
 		if (knightindex < pKnights->m_sIndex)
 		{
@@ -241,7 +241,7 @@ int CKnightsManager::GetKnightsIndex(int nation)
 	}
 
 	// 확인 사살..
-	if (m_pMain->m_KnightsArray.GetData(knightindex))
+	if (m_pMain->m_KnightsMap.GetData(knightindex))
 		return -1;
 
 	return knightindex;
@@ -272,7 +272,7 @@ void CKnightsManager::JoinKnights(CUser* pUser, char* pBuf)
 	}
 
 	knightsindex = pUser->m_pUserData->m_bKnights;
-	pKnights = m_pMain->m_KnightsArray.GetData(knightsindex);
+	pKnights = m_pMain->m_KnightsMap.GetData(knightsindex);
 	if (pKnights == nullptr)
 	{
 		ret_value = 7;
@@ -388,7 +388,7 @@ void CKnightsManager::JoinKnightsReq(CUser* pUser, char* pBuf)
 	}
 
 	knightsindex = GetShort(pBuf, index);
-	pKnights = m_pMain->m_KnightsArray.GetData(knightsindex);
+	pKnights = m_pMain->m_KnightsMap.GetData(knightsindex);
 	if (pKnights == nullptr)
 	{
 		ret_value = 7;
@@ -611,7 +611,7 @@ void CKnightsManager::ModifyKnightsMember(CUser* pUser, char* pBuf, BYTE command
 			goto fail_return;
 		}
 
-		CKnights* pKnights = m_pMain->m_KnightsArray.GetData(pUser->m_pUserData->m_bKnights);
+		CKnights* pKnights = m_pMain->m_KnightsMap.GetData(pUser->m_pUserData->m_bKnights);
 		if (pKnights == nullptr)
 		{
 			ret_value = 7;
@@ -658,7 +658,7 @@ void CKnightsManager::AllKnightsList(CUser* pUser, char* pBuf)
 	page = GetShort(pBuf, index);
 	start = page * 10;			// page : 0 ~
 
-	for (const auto& [_, pKnights] : m_pMain->m_KnightsArray)
+	for (const auto& [_, pKnights] : m_pMain->m_KnightsMap)
 	{
 		if (pKnights == nullptr)
 			continue;
@@ -715,7 +715,7 @@ void CKnightsManager::AllKnightsMember(CUser* pUser, char* pBuf)
 		goto fail_return;
 	}
 
-	pKnights = m_pMain->m_KnightsArray.GetData(pUser->m_pUserData->m_bKnights);
+	pKnights = m_pMain->m_KnightsMap.GetData(pUser->m_pUserData->m_bKnights);
 	if (pKnights == nullptr)
 	{
 		ret_value = 7;
@@ -786,7 +786,7 @@ void CKnightsManager::CurrentKnightsMember(CUser* pUser, char* pBuf)
 	if (pUser->m_pUserData->m_bKnights <= 0)
 		goto fail_return;
 
-	pKnights = m_pMain->m_KnightsArray.GetData(pUser->m_pUserData->m_bKnights);
+	pKnights = m_pMain->m_KnightsMap.GetData(pUser->m_pUserData->m_bKnights);
 	if (pKnights == nullptr)
 		goto fail_return;
 
@@ -888,7 +888,7 @@ void CKnightsManager::ReceiveKnightsProcess(CUser* pUser, char* pBuf, BYTE comma
 
 		case KNIGHTS_MEMBER_REQ + 0x10:
 		{
-			CKnights* pKnights = m_pMain->m_KnightsArray.GetData(pUser->m_pUserData->m_bKnights);
+			CKnights* pKnights = m_pMain->m_KnightsMap.GetData(pUser->m_pUserData->m_bKnights);
 			if (pKnights == nullptr)
 				break;
 
@@ -967,7 +967,7 @@ void CKnightsManager::RecvCreateKnights(CUser* pUser, char* pBuf)
 		strcpy(pKnights->m_arKnightsUser[i].strUserName, "");
 	}
 
-	m_pMain->m_KnightsArray.PutData(pKnights->m_sIndex, pKnights);
+	m_pMain->m_KnightsMap.PutData(pKnights->m_sIndex, pKnights);
 
 	// 클랜정보에 추가
 	AddKnightsUser(knightsindex, chiefname);
@@ -1027,7 +1027,7 @@ void CKnightsManager::RecvJoinKnights(CUser* pUser, char* pBuf, BYTE command)
 		return;
 
 	knightsindex = GetShort(pBuf, index);
-	pKnights = m_pMain->m_KnightsArray.GetData(knightsindex);
+	pKnights = m_pMain->m_KnightsMap.GetData(knightsindex);
 
 	if (command == KNIGHTS_JOIN + 0x10)
 	{
@@ -1124,7 +1124,7 @@ void CKnightsManager::RecvModifyFame(CUser* pUser, char* pBuf, BYTE command)
 	vicechief = GetByte(pBuf, index);
 
 	pTUser = m_pMain->GetUserPtr(userid, NameType::Character);
-	pKnights = m_pMain->m_KnightsArray.GetData(knightsindex);
+	pKnights = m_pMain->m_KnightsMap.GetData(knightsindex);
 
 	switch (command)
 	{
@@ -1269,7 +1269,7 @@ void CKnightsManager::RecvDestroyKnights(CUser* pUser, char* pBuf)
 
 	knightsindex = GetShort(pBuf, index);
 
-	pKnights = m_pMain->m_KnightsArray.GetData(knightsindex);
+	pKnights = m_pMain->m_KnightsMap.GetData(knightsindex);
 	if (pKnights == nullptr)
 	{
 		//TRACE(_T("### RecvDestoryKnights  Fail == index = %d ###\n"), knightsindex);
@@ -1320,7 +1320,7 @@ void CKnightsManager::RecvDestroyKnights(CUser* pUser, char* pBuf)
 		}
 	}
 
-	m_pMain->m_KnightsArray.DeleteData(knightsindex);
+	m_pMain->m_KnightsMap.DeleteData(knightsindex);
 	//TRACE(_T("RecvDestoryKnights - nid=%d, name=%hs, index=%d, fame=%d\n"), pUser->GetSocketID(), pUser->m_pUserData->m_id, knightsindex, pUser->m_pUserData->m_bFame);
 
 	memset(send_buff, 0, sizeof(send_buff));
@@ -1366,7 +1366,7 @@ void CKnightsManager::RecvKnightsList(char* pBuf)
 
 	if (m_pMain->m_nServerNo == BATTLE)
 	{
-		pKnights = m_pMain->m_KnightsArray.GetData(knightsindex);
+		pKnights = m_pMain->m_KnightsMap.GetData(knightsindex);
 		if (pKnights != nullptr)
 		{
 			pKnights->m_sIndex = knightsindex;
@@ -1394,9 +1394,9 @@ void CKnightsManager::RecvKnightsList(char* pBuf)
 			pKnights->m_byGrade = m_pMain->GetKnightsGrade(points);
 			pKnights->m_byRanking = ranking;
 
-			if (!m_pMain->m_KnightsArray.PutData(pKnights->m_sIndex, pKnights))
+			if (!m_pMain->m_KnightsMap.PutData(pKnights->m_sIndex, pKnights))
 			{
-				spdlog::error("KnightsManager::RecvKnightsList: KnightsArray put failed [knightsId={}]",
+				spdlog::error("KnightsManager::RecvKnightsList: KnightsMap put failed [knightsId={}]",
 					pKnights->m_sIndex);
 				delete pKnights;
 				pKnights = nullptr;
@@ -1407,7 +1407,7 @@ void CKnightsManager::RecvKnightsList(char* pBuf)
 
 BOOL CKnightsManager::AddKnightsUser(int knightsId, const char* charId)
 {
-	CKnights* pKnights = m_pMain->m_KnightsArray.GetData(knightsId);
+	CKnights* pKnights = m_pMain->m_KnightsMap.GetData(knightsId);
 	if (pKnights == nullptr)
 	{
 		spdlog::error("KnightsManager::AddKnightsUser: knightsId={} not found",
@@ -1432,7 +1432,7 @@ BOOL CKnightsManager::AddKnightsUser(int knightsId, const char* charId)
 
 BOOL CKnightsManager::ModifyKnightsUser(int knightsId, const char* charId)
 {
-	CKnights* pKnights = m_pMain->m_KnightsArray.GetData(knightsId);
+	CKnights* pKnights = m_pMain->m_KnightsMap.GetData(knightsId);
 	if (pKnights == nullptr)
 	{
 		spdlog::error("KnightsManager::ModifyKnightsUser: knightsId={} not found",
@@ -1459,7 +1459,7 @@ BOOL CKnightsManager::ModifyKnightsUser(int knightsId, const char* charId)
 
 BOOL CKnightsManager::RemoveKnightsUser(int knightsId, const char* charId)
 {
-	CKnights* pKnights = m_pMain->m_KnightsArray.GetData(knightsId);
+	CKnights* pKnights = m_pMain->m_KnightsMap.GetData(knightsId);
 	if (pKnights == nullptr)
 	{
 		spdlog::error("KnightsManager::RemoveKnightsUser: knightsId={} not found",
@@ -1487,7 +1487,7 @@ BOOL CKnightsManager::RemoveKnightsUser(int knightsId, const char* charId)
 
 void CKnightsManager::SetKnightsUser(int knightsId, const char* charId)
 {
-	CKnights* pKnights = m_pMain->m_KnightsArray.GetData(knightsId);
+	CKnights* pKnights = m_pMain->m_KnightsMap.GetData(knightsId);
 	if (pKnights == nullptr)
 	{
 		spdlog::error("KnightsManager::SetKnightsUser: knightsId={} not found",
@@ -1531,7 +1531,7 @@ void CKnightsManager::RecvKnightsAllList(char* pBuf)
 		points = GetDWORD(pBuf, index);
 		ranking = GetByte(pBuf, index);
 
-		pKnights = m_pMain->m_KnightsArray.GetData(knightsId);
+		pKnights = m_pMain->m_KnightsMap.GetData(knightsId);
 		if (pKnights == nullptr)
 		{
 			spdlog::error("KnightsManager::RecvKnightsAllList: knightsId={} not found",

--- a/Server/Ebenezer/MagicProcess.cpp
+++ b/Server/Ebenezer/MagicProcess.cpp
@@ -108,13 +108,13 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 		return;
 	}
 
-	model::Magic* pMagic = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
+	model::Magic* pMagic = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pMagic == nullptr)
 		return;
 
 	if (sid >= NPC_BAND)
 	{
-		pMon = m_pMain->m_arNpcArray.GetData(sid);
+		pMon = m_pMain->m_NpcMap.GetData(sid);
 		if (pMon == nullptr
 			|| pMon->m_NpcState == NPC_DEAD)
 			return;
@@ -148,7 +148,7 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 				if (pTUser == nullptr)
 					return;
 
-				model::MagicType4* pType4 = m_pMain->m_Magictype4Array.GetData(magicid);     // Get magic skill table type 4.
+				model::MagicType4* pType4 = m_pMain->m_MagicType4TableMap.GetData(magicid);     // Get magic skill table type 4.
 				if (pType4 == nullptr)
 					return;
 
@@ -194,7 +194,7 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 				if (pTUser == nullptr)
 					return;
 
-				model::MagicType3* pType3 = m_pMain->m_Magictype3Array.GetData(magicid);     // Get magic skill table type 4.
+				model::MagicType3* pType3 = m_pMain->m_MagicType3TableMap.GetData(magicid);     // Get magic skill table type 4.
 				if (pType3 == nullptr)
 					return;
 
@@ -299,7 +299,7 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 	{
 		if (pMagic->Type1 == 2)
 		{
-			model::MagicType2* pType = m_pMain->m_Magictype2Array.GetData(magicid);     // Get magic skill table type 2.
+			model::MagicType2* pType = m_pMain->m_MagicType2TableMap.GetData(magicid);     // Get magic skill table type 2.
 			if (pType == nullptr)
 				return;
 
@@ -369,7 +369,7 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 				// Does the magic user have a staff?
 				if (m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum != 0)
 				{
-					model::Item* pRightHand = m_pMain->m_ItemtableArray.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+					model::Item* pRightHand = m_pMain->m_ItemTableMap.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 
 					if (pRightHand != nullptr
 						&& m_pSrcUser->m_pUserData->m_sItemArray[LEFTHAND].nNum == 0
@@ -384,7 +384,7 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 							total_magic_damage += ((pRightHand->Damage * 0.8f) + (pRightHand->Damage * m_pSrcUser->m_pUserData->m_bLevel) / 60);
 //
 
-							model::MagicType3* pType3 = m_pMain->m_Magictype3Array.GetData(magicid);     // Get magic skill table type 4.
+							model::MagicType3* pType3 = m_pMain->m_MagicType3TableMap.GetData(magicid);     // Get magic skill table type 4.
 							if (pType3 == nullptr)
 								return;
 
@@ -556,7 +556,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 	char send_buff[128] = {};
 	int skill_mod = 0;
 
-	model::Magic* pTable = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
+	model::Magic* pTable = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pTable == nullptr)
 		goto fail_return;
 
@@ -574,7 +574,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 	else if (sid >= NPC_BAND)
 	{
 		bFlag = TRUE;
-		pMon = m_pMain->m_arNpcArray.GetData(sid);
+		pMon = m_pMain->m_NpcMap.GetData(sid);
 		if (pMon == nullptr
 			|| pMon->m_NpcState == NPC_DEAD)
 			goto fail_return;
@@ -600,7 +600,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 		}
 		else if (pTable->Type1 == 5)
 		{
-			pType = m_pMain->m_Magictype5Array.GetData(magicid);
+			pType = m_pMain->m_MagicType5TableMap.GetData(magicid);
 			if (pType == nullptr)
 				goto fail_return;
 
@@ -625,7 +625,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 		if (!m_pMain->m_bPointCheckFlag)
 			goto fail_return;
 
-		pNpc = m_pMain->m_arNpcArray.GetData(tid);
+		pNpc = m_pMain->m_NpcMap.GetData(tid);
 		if (pNpc == nullptr
 			//... Assuming NPCs can't be resurrected.
 			|| pNpc->m_NpcState == NPC_DEAD)
@@ -853,12 +853,12 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 				|| pTable->Skill == 2055)
 			{
 				// Get item info for left hand.
-				model::Item* pLeftHand = m_pMain->m_ItemtableArray.GetData(m_pSrcUser->m_pUserData->m_sItemArray[LEFTHAND].nNum);
+				model::Item* pLeftHand = m_pMain->m_ItemTableMap.GetData(m_pSrcUser->m_pUserData->m_sItemArray[LEFTHAND].nNum);
 				if (pLeftHand == nullptr)
 					return nullptr;
 
 				// Get item info for right hand.
-				model::Item* pRightHand = m_pMain->m_ItemtableArray.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+				model::Item* pRightHand = m_pMain->m_ItemTableMap.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 				if (pRightHand == nullptr)
 					return nullptr;
 
@@ -874,7 +874,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 				|| pTable->Skill == 2056)
 			{
 				// Get item info for right hand.
-				model::Item* pRightHand = m_pMain->m_ItemtableArray.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+				model::Item* pRightHand = m_pMain->m_ItemTableMap.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 				if (pRightHand == nullptr)
 					return nullptr;
 
@@ -954,7 +954,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 					{
 						// 이것두 성래씨 요청에 의해 하는 짓입니다 --;
 						// This checks if such an item exists.
-						model::Item* pItem = m_pMain->m_ItemtableArray.GetData(pTable->UseItem);
+						model::Item* pItem = m_pMain->m_ItemTableMap.GetData(pTable->UseItem);
 						if (pItem == nullptr)
 							return FALSE;
 
@@ -1001,7 +1001,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 				{
 					if (pTable->UseItem != 0)
 					{
-						pType = m_pMain->m_Magictype5Array.GetData(magicid);
+						pType = m_pMain->m_MagicType5TableMap.GetData(magicid);
 						if (pType == nullptr)
 							goto fail_return;
 
@@ -1106,11 +1106,11 @@ BYTE CMagicProcess::ExecuteType1(int magicid, int sid, int tid, int data1, int d
 	int damage = 0, send_index = 0, result = 1;     // Variable initialization. result == 1 : success, 0 : fail
 	char send_buff[128] = {};
 
-	model::Magic* pMagic = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
+	model::Magic* pMagic = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pMagic == nullptr)
 		return 0;
 
-	model::MagicType1* pType = m_pMain->m_Magictype1Array.GetData(magicid);     // Get magic skill table type 1.
+	model::MagicType1* pType = m_pMain->m_MagicType1TableMap.GetData(magicid);     // Get magic skill table type 1.
 	if (pType == nullptr)
 	{
 		result = 0;
@@ -1198,20 +1198,20 @@ BYTE CMagicProcess::ExecuteType2(int magicid, int sid, int tid, int data1, int d
 	int total_range = 0;	// These variables are used for range verification!
 	int sx, sz, tx, tz;
 
-	model::Magic* pMagic = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
+	model::Magic* pMagic = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pMagic == nullptr)
 		return 0;
 
 	model::Item* pTable = nullptr;		// Get item info.
 	if (m_pSrcUser->m_pUserData->m_sItemArray[LEFTHAND].nNum)
-		pTable = m_pMain->m_ItemtableArray.GetData(m_pSrcUser->m_pUserData->m_sItemArray[LEFTHAND].nNum);
+		pTable = m_pMain->m_ItemTableMap.GetData(m_pSrcUser->m_pUserData->m_sItemArray[LEFTHAND].nNum);
 	else
-		pTable = m_pMain->m_ItemtableArray.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+		pTable = m_pMain->m_ItemTableMap.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 
 	if (pTable == nullptr)
 		return 0;
 
-	model::MagicType2* pType = m_pMain->m_Magictype2Array.GetData(magicid);     // Get magic skill table type 2.
+	model::MagicType2* pType = m_pMain->m_MagicType2TableMap.GetData(magicid);     // Get magic skill table type 2.
 	if (pType == nullptr)
 		return 0;
 
@@ -1322,11 +1322,11 @@ void CMagicProcess::ExecuteType3(int magicid, int sid, int tid, int data1, int d
 	for (int h = 0; h < MAX_USER; h++)
 		casted_member[h] = -1;
 
-	model::Magic* pMagic = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
+	model::Magic* pMagic = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pMagic == nullptr)
 		return;
 
-	model::MagicType3* pType = m_pMain->m_Magictype3Array.GetData(magicid);      // Get magic skill table type 3.
+	model::MagicType3* pType = m_pMain->m_MagicType3TableMap.GetData(magicid);      // Get magic skill table type 3.
 	if (pType == nullptr)
 		return;
 
@@ -1334,7 +1334,7 @@ void CMagicProcess::ExecuteType3(int magicid, int sid, int tid, int data1, int d
 	{
 		bFlag = TRUE;
 	
-		pMon = m_pMain->m_arNpcArray.GetData(sid);
+		pMon = m_pMain->m_NpcMap.GetData(sid);
 		if (pMon == nullptr
 			|| pMon->m_NpcState == NPC_DEAD)
 			return;
@@ -1703,11 +1703,11 @@ void CMagicProcess::ExecuteType4(int magicid, int sid, int tid, int data1, int d
 	for (int h = 0; h < MAX_USER; h++)
 		casted_member[h] = -1;
 
-	model::Magic* pMagic = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
+	model::Magic* pMagic = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pMagic == nullptr)
 		return;
 
-	model::MagicType4* pType = m_pMain->m_Magictype4Array.GetData(magicid);     // Get magic skill table type 4.
+	model::MagicType4* pType = m_pMain->m_MagicType4TableMap.GetData(magicid);     // Get magic skill table type 4.
 	if (pType == nullptr)
 		return;
 
@@ -2002,11 +2002,11 @@ void CMagicProcess::ExecuteType5(int magicid, int sid, int tid, int data1, int d
 	int i = 0, j = 0, k = 0, buff_test = 0;
 	BOOL bType3Test = TRUE, bType4Test = TRUE;
 
-	model::Magic* pMagic = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
+	model::Magic* pMagic = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pMagic == nullptr)
 		return;
 
-	model::MagicType5* pType = m_pMain->m_Magictype5Array.GetData(magicid);     // Get magic skill table type 4.
+	model::MagicType5* pType = m_pMain->m_MagicType5TableMap.GetData(magicid);     // Get magic skill table type 4.
 	if (pType == nullptr)
 		return;
 
@@ -2362,7 +2362,7 @@ void CMagicProcess::ExecuteType8(int magicid, int sid, int tid, int data1, int d
 	for (int h = 0; h < MAX_USER; h++)
 		casted_member[h] = -1;
 
-	model::MagicType8* pType = m_pMain->m_Magictype8Array.GetData(magicid);      // Get magic skill table type 8.
+	model::MagicType8* pType = m_pMain->m_MagicType8TableMap.GetData(magicid);      // Get magic skill table type 8.
 	if (pType == nullptr)
 		return;
 
@@ -2428,7 +2428,7 @@ void CMagicProcess::ExecuteType8(int magicid, int sid, int tid, int data1, int d
 			continue;
 
 		// 비러머글 대만 써비스 >.<
-		model::Home* pHomeInfo = m_pMain->m_HomeArray.GetData(pTUser->m_pUserData->m_bNation);
+		model::Home* pHomeInfo = m_pMain->m_HomeTableMap.GetData(pTUser->m_pUserData->m_bNation);
 		if (pHomeInfo == nullptr)
 			return;
 
@@ -2760,7 +2760,7 @@ short CMagicProcess::GetMagicDamage(int sid, int tid, int total_hit, int attribu
 	// If the source is a monster.
 	if (sid >= NPC_BAND)
 	{
-		pMon = m_pMain->m_arNpcArray.GetData(sid);
+		pMon = m_pMain->m_NpcMap.GetData(sid);
 		if (pMon == nullptr
 			|| pMon->m_NpcState == NPC_DEAD)
 			return 0;
@@ -2823,7 +2823,7 @@ short CMagicProcess::GetMagicDamage(int sid, int tid, int total_hit, int attribu
 			if (m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum != 0)
 			{
 				model::Item* pRightHand
-					= m_pMain->m_ItemtableArray.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+					= m_pMain->m_ItemTableMap.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 
 				if (pRightHand != nullptr
 					&& m_pSrcUser->m_pUserData->m_sItemArray[LEFTHAND].nNum == 0
@@ -2880,7 +2880,7 @@ BOOL CMagicProcess::UserRegionCheck(int sid, int tid, int magicid, int radius, s
 
 	if (sid >= NPC_BAND)
 	{
-		pMon = m_pMain->m_arNpcArray.GetData(sid);
+		pMon = m_pMain->m_NpcMap.GetData(sid);
 		if (pMon == nullptr
 			|| pMon->m_NpcState == NPC_DEAD)
 			return FALSE;
@@ -2888,7 +2888,7 @@ BOOL CMagicProcess::UserRegionCheck(int sid, int tid, int magicid, int radius, s
 		bFlag = TRUE;
 	}
 
-	model::Magic* pMagic = m_pMain->m_MagictableArray.GetData(magicid);   // Get main magic table.
+	model::Magic* pMagic = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pMagic == nullptr)
 		return FALSE;
 
@@ -3038,7 +3038,7 @@ void CMagicProcess::Type4Cancel(int magicid, short tid)
 	if (pTUser == nullptr)
 		return;
 
-	model::MagicType4* pType = m_pMain->m_Magictype4Array.GetData(magicid);     // Get magic skill table type 4.
+	model::MagicType4* pType = m_pMain->m_MagicType4TableMap.GetData(magicid);     // Get magic skill table type 4.
 	if (pType == nullptr)
 		return;
 
@@ -3228,7 +3228,7 @@ void CMagicProcess::Type3Cancel(int magicid, short tid)
 	if (pTUser == nullptr)
 		return;
 
-	model::MagicType3* pType = m_pMain->m_Magictype3Array.GetData(magicid);     // Get magic skill table type 3.
+	model::MagicType3* pType = m_pMain->m_MagicType3TableMap.GetData(magicid);     // Get magic skill table type 3.
 	if (pType == nullptr)
 		return;
 

--- a/Server/Ebenezer/Npc.cpp
+++ b/Server/Ebenezer/Npc.cpp
@@ -282,7 +282,7 @@ int CNpc::GetRegionNpcList(int region_x, int region_z, char* buff, int& t_count)
 		if (nid < 0)
 			continue;
 
-		CNpc* pNpc = m_pMain->m_arNpcArray.GetData(nid);
+		CNpc* pNpc = m_pMain->m_NpcMap.GetData(nid);
 		if (pNpc != nullptr)
 		{
 			SetShort(buff, pNpc->m_sNid, buff_index);

--- a/Server/Ebenezer/UdpSocket.cpp
+++ b/Server/Ebenezer/UdpSocket.cpp
@@ -444,7 +444,7 @@ void CUdpSocket::RecvCreateKnights(char* pBuf)
 	pKnights->m_byGrade = 5;
 	pKnights->m_byRanking = 0;
 
-	m_pMain->m_KnightsArray.PutData(pKnights->m_sIndex, pKnights);
+	m_pMain->m_KnightsMap.PutData(pKnights->m_sIndex, pKnights);
 
 	// 클랜정보에 추가
 	m_pMain->m_KnightsManager.AddKnightsUser(knightsindex, chiefname);
@@ -464,7 +464,7 @@ void CUdpSocket::RecvJoinKnights(char* pBuf, BYTE command)
 	idlen = GetShort(pBuf, index);
 	GetString(charId, pBuf, idlen, index);
 
-	pKnights = m_pMain->m_KnightsArray.GetData(knightsId);
+	pKnights = m_pMain->m_KnightsMap.GetData(knightsId);
 
 	if (command == KNIGHTS_JOIN)
 	{
@@ -514,7 +514,7 @@ void CUdpSocket::RecvModifyFame(char* pBuf, BYTE command)
 	GetString(userid, pBuf, idlen, index);
 
 	pTUser = m_pMain->GetUserPtr(userid, NameType::Character);
-	pKnights = m_pMain->m_KnightsArray.GetData(knightsindex);
+	pKnights = m_pMain->m_KnightsMap.GetData(knightsindex);
 
 	switch (command)
 	{
@@ -633,7 +633,7 @@ void CUdpSocket::RecvDestroyKnights(char* pBuf)
 
 	knightsId = GetShort(pBuf, index);
 
-	pKnights = m_pMain->m_KnightsArray.GetData(knightsId);
+	pKnights = m_pMain->m_KnightsMap.GetData(knightsId);
 	if (pKnights == nullptr)
 	{
 		spdlog::error("UdpSocket::RecvDestroyKnights: knightsId={} not found",
@@ -684,7 +684,7 @@ void CUdpSocket::RecvDestroyKnights(char* pBuf)
 		}
 	}
 
-	m_pMain->m_KnightsArray.DeleteData(knightsId);
+	m_pMain->m_KnightsMap.DeleteData(knightsId);
 	//TRACE(_T("UDP - RecvDestoryKnights - index=%d\n"), knightsindex);
 }
 

--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -189,7 +189,7 @@ void CUser::CloseProcess()
 	if (!m_bZoneChangeFlag) {
 		if (m_pUserData->m_bZone == ZONE_BATTLE || (m_pUserData->m_bZone != m_pUserData->m_bNation && m_pUserData->m_bZone < 3) ) {
 			model::Home* pHomeInfo = nullptr;	// Send user back home in case it was the battlezone.
-			pHomeInfo = m_pMain->m_HomeArray.GetData(m_pUserData->m_bNation);
+			pHomeInfo = m_pMain->m_HomeTableMap.GetData(m_pUserData->m_bNation);
 			if (!pHomeInfo) return;
 
 			m_pUserData->m_bZone = m_pUserData->m_bNation;
@@ -625,7 +625,7 @@ void CUser::NewCharToAgent(char* pBuf)
 		goto fail_return;
 	}
 
-	p_TableCoefficient = m_pMain->m_CoefficientArray.GetData(Class);
+	p_TableCoefficient = m_pMain->m_CoefficientTableMap.GetData(Class);
 	if (p_TableCoefficient == nullptr)
 	{
 		result = 0x02;
@@ -1032,7 +1032,7 @@ void CUser::SelectCharacter(char* pBuf)
 				m_pMain->m_StatusList.AddString(_T("KNIGHTS_LIST_REQ Packet Drop!!!"));
 			}	*/
 
-			pKnights = m_pMain->m_KnightsArray.GetData(m_pUserData->m_bKnights);
+			pKnights = m_pMain->m_KnightsMap.GetData(m_pUserData->m_bKnights);
 			if (pKnights != nullptr)
 			{
 				m_pMain->m_KnightsManager.SetKnightsUser(m_pUserData->m_bKnights, m_pUserData->m_id);
@@ -1053,7 +1053,7 @@ void CUser::SelectCharacter(char* pBuf)
 					m_pMain->AddOutputMessage(_T("KNIGHTS_LIST_REQ Packet Drop!!!"));
 				}
 
-				pKnights = m_pMain->m_KnightsArray.GetData(m_pUserData->m_bKnights);
+				pKnights = m_pMain->m_KnightsMap.GetData(m_pUserData->m_bKnights);
 				if (pKnights != nullptr)
 				{
 					//TRACE(_T("SelectCharacter - 기사단 리스트 추가,, id=%hs, knights=%d, fame=%d\n"), m_pUserData->m_id, m_pUserData->m_bKnights, m_pUserData->m_bFame);
@@ -1078,7 +1078,7 @@ void CUser::SelectCharacter(char* pBuf)
 		
 		if (m_pUserData->m_bKnights != 0)
 		{
-			pKnights = m_pMain->m_KnightsArray.GetData(m_pUserData->m_bKnights);
+			pKnights = m_pMain->m_KnightsMap.GetData(m_pUserData->m_bKnights);
 			if (pKnights != nullptr)
 			{
 				m_pMain->m_KnightsManager.SetKnightsUser(m_pUserData->m_bKnights, m_pUserData->m_id);
@@ -1480,7 +1480,7 @@ void CUser::Attack(char* pBuf)
 
 // 비러머글 해킹툴 유저 --;
 	// This checks if such an item exists.
-	pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+	pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 	if (pTable == nullptr
 		&& m_pUserData->m_sItemArray[RIGHTHAND].nNum != 0)
 		return;
@@ -1612,7 +1612,7 @@ void CUser::Attack(char* pBuf)
 		if (!m_pMain->m_bPointCheckFlag)
 			return;
 
-		pNpc = m_pMain->m_arNpcArray.GetData(tid);
+		pNpc = m_pMain->m_NpcMap.GetData(tid);
 
 		// Npc 상태 체크..
 		if (pNpc != nullptr
@@ -1702,7 +1702,7 @@ void CUser::SendMyInfo(int type)
 
 	if (!pMap->IsValidPosition(m_pUserData->m_curx, m_pUserData->m_curz, 0.0f))
 	{
-		model::Home* pHomeInfo = m_pMain->m_HomeArray.GetData(m_pUserData->m_bNation);
+		model::Home* pHomeInfo = m_pMain->m_HomeTableMap.GetData(m_pUserData->m_bNation);
 		if (pHomeInfo == nullptr)
 			return;
 
@@ -1778,7 +1778,7 @@ void CUser::SendMyInfo(int type)
 	SetByte(send_buff, m_pUserData->m_bFame, send_index);
 
 	if (m_pUserData->m_bKnights != 0)
-		pKnights = m_pMain->m_KnightsArray.GetData(m_pUserData->m_bKnights);
+		pKnights = m_pMain->m_KnightsMap.GetData(m_pUserData->m_bKnights);
 
 	if (pKnights != nullptr)
 	{
@@ -1999,7 +1999,7 @@ void CUser::Chat(char* pBuf)
 void CUser::SetMaxHp(int iFlag)
 {
 	model::Coefficient* p_TableCoefficient
-		= m_pMain->m_CoefficientArray.GetData(m_pUserData->m_sClass);
+		= m_pMain->m_CoefficientTableMap.GetData(m_pUserData->m_sClass);
 	if (p_TableCoefficient == nullptr)
 		return;
 
@@ -2040,7 +2040,7 @@ void CUser::SetMaxHp(int iFlag)
 void CUser::SetMaxMp()
 {
 	model::Coefficient* p_TableCoefficient
-		= m_pMain->m_CoefficientArray.GetData(m_pUserData->m_sClass);
+		= m_pMain->m_CoefficientTableMap.GetData(m_pUserData->m_sClass);
 	if (p_TableCoefficient == nullptr)
 		return;
 
@@ -2110,7 +2110,7 @@ void CUser::Regene(char* pBuf, int magicid)
 			return;
 	}
 
-	pHomeInfo = m_pMain->m_HomeArray.GetData(m_pUserData->m_bNation);
+	pHomeInfo = m_pMain->m_HomeTableMap.GetData(m_pUserData->m_bNation);
 	if (pHomeInfo == nullptr)
 		return;
 
@@ -2234,7 +2234,7 @@ void CUser::Regene(char* pBuf, int magicid)
 // Clerical Resurrection.
 	if (magicid > 0)
 	{
-		pType = m_pMain->m_Magictype5Array.GetData(magicid);
+		pType = m_pMain->m_MagicType5TableMap.GetData(magicid);
 		if (pType == nullptr)
 			return;
 
@@ -2617,7 +2617,7 @@ void CUser::SetDetailData()
 	if (m_pUserData->m_bLevel >= MAX_LEVEL)
 		Close();
 
-	m_iMaxExp = m_pMain->m_LevelUpArray[m_pUserData->m_bLevel - 1]->RequiredExp;
+	m_iMaxExp = m_pMain->m_LevelUpTableArray[m_pUserData->m_bLevel - 1]->RequiredExp;
 	m_iMaxWeight = (m_pUserData->m_bStr + m_sItemStr) * 50;
 
 	m_iZoneIndex = m_pMain->GetZoneIndex(m_pUserData->m_bZone);
@@ -2827,7 +2827,7 @@ void CUser::RequestNpcIn(char* pBuf)
 		if (i > 1000)
 			break;
 
-		CNpc* pNpc = m_pMain->m_arNpcArray.GetData(nid);
+		CNpc* pNpc = m_pMain->m_NpcMap.GetData(nid);
 		if (pNpc == nullptr)
 			continue;
 
@@ -2990,7 +2990,7 @@ void CUser::SetSlotItemValue()
 		if (m_pUserData->m_sItemArray[i].nNum <= 0)
 			continue;
 
-		pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[i].nNum);
+		pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[i].nNum);
 		if (pTable == nullptr)
 			continue;
 
@@ -3049,7 +3049,7 @@ void CUser::SetSlotItemValue()
 		if (m_pUserData->m_sItemArray[i].nNum <= 0)
 			continue;
 
-		pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[i].nNum);
+		pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[i].nNum);
 		if (pTable == nullptr)
 			continue;
 
@@ -3068,7 +3068,7 @@ void CUser::SetSlotItemValue()
 
 	// Get item info for left hand.
 	model::Item* pLeftHand
-		= m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
+		= m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
 	if (pLeftHand != nullptr)
 	{
 		if (pLeftHand->FireDamage != 0)
@@ -3122,7 +3122,7 @@ void CUser::SetSlotItemValue()
 
 	// Get item info for right hand.
 	model::Item* pRightHand
-		= m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+		= m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 	if (pRightHand != nullptr)
 	{
 		if (pRightHand->FireDamage != 0)
@@ -3202,14 +3202,14 @@ short CUser::GetDamage(short tid, int magicid)
 	// Skill/Arrow hit.    
 	if (magicid > 0)
 	{
-		pTable = m_pMain->m_MagictableArray.GetData(magicid);		// Get main magic table.
+		pTable = m_pMain->m_MagicTableMap.GetData(magicid);		// Get main magic table.
 		if (pTable == nullptr)
 			return -1;
 
 		// SKILL HIT!
 		if (pTable->Type1 == 1)
 		{
-			pType1 = m_pMain->m_Magictype1Array.GetData(magicid);	// Get magic skill table type 1.
+			pType1 = m_pMain->m_MagicType1TableMap.GetData(magicid);	// Get magic skill table type 1.
 			if (pType1 == nullptr)
 				return -1;
 
@@ -3233,7 +3233,7 @@ short CUser::GetDamage(short tid, int magicid)
 		// ARROW HIT!
 		else if (pTable->Type1 == 2)
 		{
-			pType2 = m_pMain->m_Magictype2Array.GetData(magicid);	// Get magic skill table type 1.
+			pType2 = m_pMain->m_MagicType2TableMap.GetData(magicid);	// Get magic skill table type 1.
 			if (pType2 == nullptr)
 				return -1;
 
@@ -3453,7 +3453,7 @@ short CUser::GetACDamage(int damage, short tid)
 
 	if (m_pUserData->m_sItemArray[RIGHTHAND].nNum != 0)
 	{
-		pRightHand = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+		pRightHand = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 		if (pRightHand != nullptr)
 		{
 			// Weapon Type Right Hand....
@@ -3488,7 +3488,7 @@ short CUser::GetACDamage(int damage, short tid)
 
 	if (m_pUserData->m_sItemArray[LEFTHAND].nNum != 0)
 	{
-		pLeftHand = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
+		pLeftHand = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
 		if (pLeftHand != nullptr)
 		{
 			// Weapon Type Right Hand....
@@ -3551,7 +3551,7 @@ void CUser::ExpChange(int iExp)
 		if (m_pUserData->m_bLevel > 5)
 		{
 			--m_pUserData->m_bLevel;
-			m_pUserData->m_iExp += m_pMain->m_LevelUpArray[m_pUserData->m_bLevel - 1]->RequiredExp;
+			m_pUserData->m_iExp += m_pMain->m_LevelUpTableArray[m_pUserData->m_bLevel - 1]->RequiredExp;
 			LevelChange(m_pUserData->m_bLevel, FALSE);
 			return;
 		}
@@ -3599,7 +3599,7 @@ void CUser::LevelChange(short level, BYTE type)
 			m_pUserData->m_bstrSkill[0] += 2;	// Skill Points up
 	}
 
-	m_iMaxExp = m_pMain->m_LevelUpArray[level - 1]->RequiredExp;
+	m_iMaxExp = m_pMain->m_LevelUpTableArray[level - 1]->RequiredExp;
 
 	SetSlotItemValue();
 	SetUserAbility();
@@ -3840,14 +3840,14 @@ void CUser::SetUserAbility()
 	model::Item* pItem = nullptr;
 	BOOL bHaveBow = FALSE;
 
-	p_TableCoefficient = m_pMain->m_CoefficientArray.GetData(m_pUserData->m_sClass);
+	p_TableCoefficient = m_pMain->m_CoefficientTableMap.GetData(m_pUserData->m_sClass);
 	if (p_TableCoefficient == nullptr)
 		return;
 
 	float hitcoefficient = 0.0f;
 	if (m_pUserData->m_sItemArray[RIGHTHAND].nNum != 0)
 	{
-		pItem = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+		pItem = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 		if (pItem != nullptr)
 		{
 			// 무기 타입....
@@ -3891,7 +3891,7 @@ void CUser::SetUserAbility()
 		&& hitcoefficient == 0.0f)
 	{
 		// 왼손 무기 : 활 적용을 위해
-		pItem = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
+		pItem = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
 		if (pItem != nullptr)
 		{
 			// 무기 타입....
@@ -3958,7 +3958,7 @@ void CUser::ItemMove(char* pBuf)
 	if (m_sExchangeUser != -1)
 		goto fail_return;
 
-	pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 		goto fail_return;
 
@@ -4017,7 +4017,7 @@ void CUser::ItemMove(char* pBuf)
 			{
 				if (m_pUserData->m_sItemArray[LEFTHAND].nNum != 0)
 				{
-					model::Item* pTable2 = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
+					model::Item* pTable2 = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
 					if (pTable2 != nullptr)
 					{
 						if (pTable2->Slot == 0x04)
@@ -4101,7 +4101,7 @@ void CUser::ItemMove(char* pBuf)
 			{
 				if (m_pUserData->m_sItemArray[RIGHTHAND].nNum != 0)
 				{
-					model::Item* pTable2 = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+					model::Item* pTable2 = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 					if (pTable2 != nullptr)
 					{
 						if (pTable2->Slot == 0x03)
@@ -4347,7 +4347,7 @@ void CUser::ItemMove(char* pBuf)
 
 			if (m_pUserData->m_sItemArray[SLOT_MAX + srcpos].nSerialNum == 0)
 			{
-				pTable2 = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[SLOT_MAX + srcpos].nNum);
+				pTable2 = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[SLOT_MAX + srcpos].nNum);
 				if (pTable2 != nullptr
 					&& pTable2->Countable == 0)
 					m_pUserData->m_sItemArray[SLOT_MAX + srcpos].nSerialNum = m_pMain->GenerateItemSerial();
@@ -4360,7 +4360,7 @@ void CUser::ItemMove(char* pBuf)
 
 			if (m_pUserData->m_sItemArray[SLOT_MAX + destpos].nSerialNum == 0)
 			{
-				pTable2 = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[SLOT_MAX + destpos].nNum);
+				pTable2 = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[SLOT_MAX + destpos].nNum);
 				if (pTable2 != nullptr
 					&& pTable2->Countable == 0)
 					m_pUserData->m_sItemArray[SLOT_MAX + destpos].nSerialNum = m_pMain->GenerateItemSerial();
@@ -4377,7 +4377,7 @@ void CUser::ItemMove(char* pBuf)
 			if (m_pUserData->m_sItemArray[destpos].nNum != 0)
 			{
 				// dest slot exist some item
-				model::Item* pTable2 = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[destpos].nNum);
+				model::Item* pTable2 = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[destpos].nNum);
 				if (pTable2 != nullptr)
 				{
 					if (pTable2->Slot != 0x00)
@@ -4590,7 +4590,7 @@ void CUser::NpcEvent(char* pBuf)
 
 	nid = GetShort(pBuf, index);
 
-	pNpc = m_pMain->m_arNpcArray.GetData(nid);
+	pNpc = m_pMain->m_NpcMap.GetData(nid);
 	if (pNpc == nullptr)
 		return;
 
@@ -4790,7 +4790,7 @@ void CUser::ItemTrade(char* pBuf)
 	if (m_sExchangeUser != -1)
 		goto fail_return;
 
-	pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 	{
 		result = 0x01;
@@ -4819,7 +4819,7 @@ void CUser::ItemTrade(char* pBuf)
 			goto fail_return;
 		}
 
-		pNpc = m_pMain->m_arNpcArray.GetData(npcid);
+		pNpc = m_pMain->m_NpcMap.GetData(npcid);
 		if (pNpc == nullptr)
 		{
 			result = 0x01;
@@ -4972,7 +4972,7 @@ void CUser::SendTargetHP(BYTE echo, int tid, int damage)
 		if (!m_pMain->m_bPointCheckFlag)
 			return;
 
-		pNpc = m_pMain->m_arNpcArray.GetData(tid);
+		pNpc = m_pMain->m_NpcMap.GetData(tid);
 		if (pNpc == nullptr)
 			return;
 
@@ -5126,7 +5126,7 @@ void CUser::ItemGet(char* pBuf)
 	if (!pMap->RegionItemRemove(m_RegionX, m_RegionZ, bundle_index, pItem->itemid[i], pItem->count[i]))
 		goto fail_return;
 
-	pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 		goto fail_return;
 
@@ -5226,7 +5226,7 @@ void CUser::ItemGet(char* pBuf)
 			}
 			else
 			{
-				pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
+				pParty = m_pMain->m_PartyMap.GetData(m_sPartyIndex);
 				if (pParty == nullptr)
 					goto fail_return;
 
@@ -5590,7 +5590,7 @@ void CUser::PartyCancel()
 	if (m_sPartyIndex == -1)
 		return;
 
-	pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
+	pParty = m_pMain->m_PartyMap.GetData(m_sPartyIndex);
 
 	// 이상한 경우
 	if (pParty == nullptr)
@@ -5663,7 +5663,7 @@ void CUser::PartyRequest(int memberid, BOOL bCreate)
 	// 기존의 파티에 추가하는 경우
 	if (!bCreate)
 	{
-		pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
+		pParty = m_pMain->m_PartyMap.GetData(m_sPartyIndex);
 		if (pParty == nullptr)
 			goto fail_return;
 
@@ -5698,7 +5698,7 @@ void CUser::PartyRequest(int memberid, BOOL bCreate)
 		pParty->bLevel[0] = m_pUserData->m_bLevel;
 		pParty->sClass[0] = m_pUserData->m_sClass;
 
-		if (!m_pMain->m_PartyArray.PutData(pParty->wIndex, pParty))
+		if (!m_pMain->m_PartyMap.PutData(pParty->wIndex, pParty))
 		{
 			delete pParty;
 			m_sPartyIndex = -1;
@@ -5769,7 +5769,7 @@ void CUser::PartyInsert()	// 본인이 추가 된다.  리더에게 패킷이 �
 	if (m_sPartyIndex == -1)
 		return;
 
-	pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
+	pParty = m_pMain->m_PartyMap.GetData(m_sPartyIndex);
 
 	// 이상한 경우
 	if (pParty == nullptr)
@@ -5905,7 +5905,7 @@ void CUser::PartyRemove(int memberid)
 	if (pUser == nullptr)
 		return;
 
-	pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
+	pParty = m_pMain->m_PartyMap.GetData(m_sPartyIndex);
 
 	// 이상한 경우
 	if (pParty == nullptr)
@@ -5985,7 +5985,7 @@ void CUser::PartyDelete()
 	if (m_sPartyIndex == -1)
 		return;
 
-	pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
+	pParty = m_pMain->m_PartyMap.GetData(m_sPartyIndex);
 	if (pParty == nullptr)
 	{
 		m_sPartyIndex = -1;
@@ -6019,7 +6019,7 @@ void CUser::PartyDelete()
 
 	EnterCriticalSection(&g_region_critical);
 
-	m_pMain->m_PartyArray.DeleteData(pParty->wIndex);
+	m_pMain->m_PartyMap.DeleteData(pParty->wIndex);
 
 	LeaveCriticalSection(&g_region_critical);
 }
@@ -6168,7 +6168,7 @@ void CUser::ExchangeAdd(char* pBuf)
 	itemid = GetDWORD(pBuf, index);
 	count = GetDWORD(pBuf, index);
 
-	pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 		goto add_fail;
 
@@ -6545,7 +6545,7 @@ BOOL CUser::ExecuteExchange()
 		}
 		else
 		{
-			pTable = m_pMain->m_ItemtableArray.GetData((*Iter)->itemid);
+			pTable = m_pMain->m_ItemTableMap.GetData((*Iter)->itemid);
 			if (pTable == nullptr)
 				continue;
 
@@ -6654,7 +6654,7 @@ int CUser::ExchangeDone()
 		m_pUserData->m_sItemArray[SLOT_MAX + i].sCount = m_MirrorItem[i].sCount;
 		m_pUserData->m_sItemArray[SLOT_MAX + i].nSerialNum = m_MirrorItem[i].nSerialNum;
 
-		pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[SLOT_MAX + i].nNum);
+		pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[SLOT_MAX + i].nNum);
 		if (pTable == nullptr)
 			continue;
 
@@ -7036,7 +7036,7 @@ void CUser::LoyaltyDivide(short tid)
 	if (m_sPartyIndex < 0)
 		return;
 
-	_PARTY_GROUP* pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
+	_PARTY_GROUP* pParty = m_pMain->m_PartyMap.GetData(m_sPartyIndex);
 	if (pParty == nullptr)
 		return;
 
@@ -7229,7 +7229,7 @@ void CUser::Dead()
 		m_pMain->Send_Region(send_buff, send_index, m_pUserData->m_bZone, m_RegionX, m_RegionZ);
 		Send(send_buff, send_index);
 
-		pKnights = m_pMain->m_KnightsArray.GetData(m_pUserData->m_bKnights);
+		pKnights = m_pMain->m_KnightsMap.GetData(m_pUserData->m_bKnights);
 		if (pKnights != nullptr)
 			strcpy(strKnightsName, pKnights->m_strName);
 		else
@@ -7269,7 +7269,7 @@ void CUser::ItemWoreOut(int type, int damage)
 		if (m_pUserData->m_sItemArray[RIGHTHAND].nNum != 0
 			&& m_pUserData->m_sItemArray[RIGHTHAND].sDuration != 0)
 		{
-			pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+			pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 			if (pTable != nullptr
 				// 2 == DEFENCE ITEM
 				&& pTable->Slot != 2)
@@ -7282,7 +7282,7 @@ void CUser::ItemWoreOut(int type, int damage)
 		if (m_pUserData->m_sItemArray[LEFTHAND].nNum != 0
 			&& m_pUserData->m_sItemArray[LEFTHAND].sDuration != 0)
 		{
-			pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
+			pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
 			if (pTable != nullptr
 				// 2 == DEFENCE ITEM
 				&& pTable->Slot != 2)
@@ -7297,7 +7297,7 @@ void CUser::ItemWoreOut(int type, int damage)
 		if (m_pUserData->m_sItemArray[HEAD].nNum != 0
 			&& m_pUserData->m_sItemArray[HEAD].sDuration != 0)
 		{
-			pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[HEAD].nNum);
+			pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[HEAD].nNum);
 			if (pTable != nullptr)
 			{
 				m_pUserData->m_sItemArray[HEAD].sDuration -= worerate;
@@ -7308,7 +7308,7 @@ void CUser::ItemWoreOut(int type, int damage)
 		if (m_pUserData->m_sItemArray[BREAST].nNum != 0
 			&& m_pUserData->m_sItemArray[BREAST].sDuration != 0)
 		{
-			pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[BREAST].nNum);
+			pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[BREAST].nNum);
 			if (pTable != nullptr)
 			{
 				m_pUserData->m_sItemArray[BREAST].sDuration -= worerate;
@@ -7319,7 +7319,7 @@ void CUser::ItemWoreOut(int type, int damage)
 		if (m_pUserData->m_sItemArray[LEG].nNum != 0
 			&& m_pUserData->m_sItemArray[LEG].sDuration != 0)
 		{
-			pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[LEG].nNum);
+			pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[LEG].nNum);
 			if (pTable != nullptr)
 			{
 				m_pUserData->m_sItemArray[LEG].sDuration -= worerate;
@@ -7330,7 +7330,7 @@ void CUser::ItemWoreOut(int type, int damage)
 		if (m_pUserData->m_sItemArray[GLOVE].nNum != 0
 			&& m_pUserData->m_sItemArray[GLOVE].sDuration != 0)
 		{
-			pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[GLOVE].nNum);
+			pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[GLOVE].nNum);
 			if (pTable != nullptr)
 			{
 				m_pUserData->m_sItemArray[GLOVE].sDuration -= worerate;
@@ -7341,7 +7341,7 @@ void CUser::ItemWoreOut(int type, int damage)
 		if (m_pUserData->m_sItemArray[FOOT].nNum != 0
 			&& m_pUserData->m_sItemArray[FOOT].sDuration != 0)
 		{
-			pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[FOOT].nNum);
+			pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[FOOT].nNum);
 			if (pTable != nullptr)
 			{
 				m_pUserData->m_sItemArray[FOOT].sDuration -= worerate;
@@ -7352,7 +7352,7 @@ void CUser::ItemWoreOut(int type, int damage)
 		if (m_pUserData->m_sItemArray[RIGHTHAND].nNum != 0
 			&& m_pUserData->m_sItemArray[RIGHTHAND].sDuration != 0)
 		{
-			pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
+			pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[RIGHTHAND].nNum);
 			if (pTable != nullptr
 				// 방패?
 				&& pTable->Slot == 2)
@@ -7365,7 +7365,7 @@ void CUser::ItemWoreOut(int type, int damage)
 		if (m_pUserData->m_sItemArray[LEFTHAND].nNum != 0
 			&& m_pUserData->m_sItemArray[LEFTHAND].sDuration != 0)
 		{
-			pTable = m_pMain->m_ItemtableArray.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
+			pTable = m_pMain->m_ItemTableMap.GetData(m_pUserData->m_sItemArray[LEFTHAND].nNum);
 			if (pTable
 				// 방패?
 				&& pTable->Slot == 2)
@@ -7695,7 +7695,7 @@ void CUser::ItemRepair(char* pBuf)
 			goto fail_return;
 	}
 
-	pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 		goto fail_return;
 
@@ -7938,7 +7938,7 @@ BYTE CUser::ItemCountChange(int itemid, int type, int amount)
 	char send_buff[128] = {};
 
 	// This checks if such an item exists.
-	model::Item* pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	model::Item* pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 	{
 		result = 0;
@@ -8023,7 +8023,7 @@ void CUser::SendAllKnightsID()
 	char send_buff[4096] = {},
 		temp_buff[4096] = {};
 
-	for (const auto& [_, pKnights] : m_pMain->m_KnightsArray)
+	for (const auto& [_, pKnights] : m_pMain->m_KnightsMap)
 	{
 		if (pKnights == nullptr)
 			continue;
@@ -8229,7 +8229,7 @@ void CUser::Type3AreaDuration(float currenttime)
 
 	CMagicProcess magic_process;
 
-	model::MagicType3* pType = m_pMain->m_Magictype3Array.GetData(m_iAreaMagicID);      // Get magic skill table type 3.
+	model::MagicType3* pType = m_pMain->m_MagicType3TableMap.GetData(m_iAreaMagicID);      // Get magic skill table type 3.
 	if (pType == nullptr)
 		return;
 
@@ -8331,7 +8331,7 @@ void CUser::WarehouseProcess(char* pBuf)
 	page = GetByte(pBuf, index);
 	srcpos = GetByte(pBuf, index);
 	destpos = GetByte(pBuf, index);
-	pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 
 	if (pTable == nullptr)
 		goto fail_return;
@@ -8609,7 +8609,7 @@ int CUser::GetEmptySlot(int itemid, int bCountable)
 
 	if (bCountable == -1)
 	{
-		pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+		pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 		if (pTable == nullptr)
 			return pos;
 
@@ -8680,7 +8680,7 @@ void CUser::Home()
 
 bool CUser::GetStartPosition(short* x, short* z)
 {
-	model::StartPosition* startPosition = m_pMain->m_StartPositionMap.GetData(m_pUserData->m_bZone);
+	model::StartPosition* startPosition = m_pMain->m_StartPositionTableMap.GetData(m_pUserData->m_bZone);
 	if (startPosition == nullptr)
 		return false;
 
@@ -8709,14 +8709,14 @@ CUser* CUser::GetItemRoutingUser(int itemid, short itemcount)
 	_PARTY_GROUP* pParty = nullptr;
 	int select_user = -1, count = 0;
 
-	pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
+	pParty = m_pMain->m_PartyMap.GetData(m_sPartyIndex);
 	if (pParty == nullptr)
 		return nullptr;
 
 	if (pParty->bItemRouting > 7)
 		return nullptr;
 
-	model::Item* pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	model::Item* pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 		return nullptr;
 
@@ -9190,7 +9190,7 @@ void CUser::GoldChange(short tid, int gold)
 		// When the source is in a party.
 		else
 		{
-			_PARTY_GROUP* pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
+			_PARTY_GROUP* pParty = m_pMain->m_PartyMap.GetData(m_sPartyIndex);
 			if (pParty == nullptr)
 				return;
 
@@ -9537,7 +9537,7 @@ BOOL CUser::GateObjectEvent(short objectindex, short nid)
 	if (pEvent == nullptr)
 		return FALSE;
 
-	CNpc* pNpc = m_pMain->m_arNpcArray.GetData(nid);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(nid);
 	if (pNpc == nullptr)
 		return FALSE;
 
@@ -9589,7 +9589,7 @@ BOOL CUser::GateLeverObjectEvent(short objectindex, short nid)
 	if (pEvent == nullptr)
 		return FALSE;
 
-	CNpc* pNpc = m_pMain->m_arNpcArray.GetData(nid);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(nid);
 	if (pNpc == nullptr)
 		return FALSE;
 
@@ -9677,7 +9677,7 @@ BOOL CUser::FlagObjectEvent(short objectindex, short nid)
 	if (pEvent == nullptr)
 		return FALSE;
 
-	CNpc* pNpc = m_pMain->m_arNpcArray.GetData(nid);
+	CNpc* pNpc = m_pMain->m_NpcMap.GetData(nid);
 	if (pNpc == nullptr)
 		return FALSE;
 
@@ -10996,7 +10996,7 @@ void CUser::ClientEvent(char* pBuf)
 	int eventid = -1;
 
 	nid = GetShort(pBuf, index);
-	pNpc = m_pMain->m_arNpcArray.GetData(nid);
+	pNpc = m_pMain->m_NpcMap.GetData(nid);
 
 	// Better to check than not to check ;)
 	if (pNpc == nullptr)
@@ -11008,7 +11008,7 @@ void CUser::ClientEvent(char* pBuf)
 	// if (pNpc->m_byEvent < 0)
 	//	return;
 
-	pEvent = m_pMain->m_Event.GetData(m_pUserData->m_bZone);
+	pEvent = m_pMain->m_EventMap.GetData(m_pUserData->m_bZone);
 	if (pEvent == nullptr)
 		return;
 
@@ -11434,7 +11434,7 @@ BOOL CUser::RunNpcEvent(CNpc* pNpc, EXEC* pExec)
 			EVENT* pEvent = nullptr;
 			EVENT_DATA* pEventData = nullptr;
 
-			pEvent = m_pMain->m_Event.GetData(m_pUserData->m_bZone);
+			pEvent = m_pMain->m_EventMap.GetData(m_pUserData->m_bZone);
 			if (pEvent == nullptr)
 				break;
 
@@ -11510,7 +11510,7 @@ BOOL CUser::RunEvent(EVENT_DATA* pEventData)
 				EVENT* pEvent = nullptr;
 				EVENT_DATA* pEventData = nullptr;
 
-				pEvent = m_pMain->m_Event.GetData(m_pUserData->m_bZone);
+				pEvent = m_pMain->m_EventMap.GetData(m_pUserData->m_bZone);
 				if (pEvent == nullptr)
 					break;
 
@@ -11657,7 +11657,7 @@ BOOL CUser::CheckSkillPoint(BYTE skillnum, BYTE min, BYTE max)
 
 BOOL CUser::CheckWeight(int itemid, short count)
 {
-	model::Item* pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	model::Item* pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 		return FALSE;
 
@@ -11688,7 +11688,7 @@ BOOL CUser::CheckWeight(int itemid, short count)
 BOOL CUser::CheckExistItem(int itemid, short count)
 {
 	// This checks if such an item exists.
-	model::Item* pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	model::Item* pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 		return FALSE;
 
@@ -11719,7 +11719,7 @@ BOOL CUser::RobItem(int itemid, short count)
 	BYTE type = 1;
 
 	// This checks if such an item exists.
-	model::Item* pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	model::Item* pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 		return FALSE;
 
@@ -11773,7 +11773,7 @@ BOOL CUser::GiveItem(int itemid, short count)
 	char send_buff[128] = {};
 
 	// This checks if such an item exists.
-	model::Item* pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	model::Item* pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 		return FALSE;
 
@@ -11880,7 +11880,7 @@ void CUser::RecvSelectMsg(char* pBuf)
 	// Get the event number that needs to be processed next.
 	selevent = m_iSelMsgEvent[selnum];
 
-	pEvent = m_pMain->m_Event.GetData(m_pUserData->m_bZone);
+	pEvent = m_pMain->m_EventMap.GetData(m_pUserData->m_bZone);
 	if (pEvent == nullptr)
 		goto fail_return;
 
@@ -12171,7 +12171,7 @@ void CUser::EventMoneyItemGet(int itemid, int count)
 void CUser::NativeZoneReturn()
 {
 	// Send user back home in case it was the battlezone.
-	model::Home* pHomeInfo = m_pMain->m_HomeArray.GetData(m_pUserData->m_bNation);
+	model::Home* pHomeInfo = m_pMain->m_HomeTableMap.GetData(m_pUserData->m_bNation);
 	if (pHomeInfo == nullptr)
 		return;
 
@@ -12274,7 +12274,7 @@ void CUser::RecvEditBox(char* pBuf)
 
 	selevent = m_iEditBoxEvent;
 
-	pEvent = m_pMain->m_Event.GetData(m_pUserData->m_bZone);	// 여기서 부터 중요함 --;
+	pEvent = m_pMain->m_EventMap.GetData(m_pUserData->m_bZone);	// 여기서 부터 중요함 --;
 	if (pEvent == nullptr)
 		goto fail_return;
 
@@ -12355,7 +12355,7 @@ void CUser::CouponEvent(char* pBuf)
 BOOL CUser::CheckItemCount(int itemid, short min, short max)
 {
 	// This checks if such an item exists.
-	model::Item* pTable = m_pMain->m_ItemtableArray.GetData(itemid);
+	model::Item* pTable = m_pMain->m_ItemTableMap.GetData(itemid);
 	if (pTable == nullptr)
 		return FALSE;
 
@@ -12456,7 +12456,7 @@ void CUser::GetUserInfo(char* buff, int& buff_index)
 	SetByte(buff, m_pUserData->m_bFame, buff_index);
 
 	if (m_pUserData->m_bKnights != 0)
-		pKnights = m_pMain->m_KnightsArray.GetData(m_pUserData->m_bKnights);
+		pKnights = m_pMain->m_KnightsMap.GetData(m_pUserData->m_bKnights);
 
 	if (pKnights != nullptr)
 	{
@@ -12559,7 +12559,7 @@ void CUser::GameStart(
 			if (m_pUserData->m_bCity <= 100)
 				--level;
 
-			m_iLostExp = m_pMain->m_LevelUpArray[level]->RequiredExp;
+			m_iLostExp = m_pMain->m_LevelUpTableArray[level]->RequiredExp;
 			m_iLostExp = m_iLostExp * (m_pUserData->m_bCity % 10) / 100;
 
 			if (((m_pUserData->m_bCity % 100) / 10) == 1)


### PR DESCRIPTION
It's a little verbose, but we no longer use 'Array' to denote maps (we use 'Map' instead, and only continue to use 'Array' for vectors since it's the same basic concept), but we always explicitly indicate whether it's a table container or not via 'Table'.

This is because of cases like the NPC map; there's an NPC table (i.e. the NPC table map) and then there's the regular NPC (instance) map.