### PR TITLE
UITreeSkillDlg - Update to tooltip on skill hover - show skill_item2 

### DIFF
--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -1064,6 +1064,8 @@ void CUISkillTreeDlg::TooltipRenderEnable(__IconItemSkill* spSkill)
 	szStr.clear();
 
 	// Tooltip - item consumed
+	if (!m_pStr_skill_item2->IsVisible())
+		m_pStr_skill_item2->SetVisible(true);
 	uint32_t requiredItemID = spSkill->pSkill->dwExhaustItem;
 	uint32_t consumedItemID = 0;
 	


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
The code committed to https://github.com/Open-KO/KnightOnline/pull/311 during my clean up was not the correct one due to commits being wrong

## What is the new behaviour?
Fixes a bug introduced in my code clean up where the bottom row (m_pStr_skill_item2) was not displayed

## Why and how did I change this?
Render m_pStr_skill_item2 to show the bottom line of the hover-over skill tips.

## Demo
Line is highlighted in yellow on demo below.

<img width="370" height="526" alt="image" src="https://github.com/user-attachments/assets/34877362-2063-481b-bb4f-65371d8e6629" />

## Checklist
- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
