### PR TITLE
PartyUI - HP Bars, MP Bars and Names

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -446,6 +446,8 @@ struct __InfoPartyOrForce
 	e_Class		eClass;				// Class
 	int			iHP;				// Hit Points
 	int			iHPMax;				// Max Hit Points
+	int			iMP;				// Mana Points
+	int			iMPMax;				// Max Mana Points
 	bool		bSufferDown_HP;		// Status - HP debuffed.
 	bool		bSufferDown_Etc;	// Status - Cursed.
 	std::string szID;				// Player's name
@@ -457,6 +459,8 @@ struct __InfoPartyOrForce
 		eClass = CLASS_UNKNOWN;
 		iHP = 0;
 		iHPMax = 0;
+		iMP = 0;
+		iMPMax = 0;
 		szID.clear();
 
 		bSufferDown_HP = false;			

--- a/Client/WarFare/PacketDef.h
+++ b/Client/WarFare/PacketDef.h
@@ -38,14 +38,14 @@ const int SOCKET_PORT_LOGIN = 15100;
 
 	// Sub Packet
 	enum e_SubPacket_Party {	N3_SP_PARTY_OR_FORCE_CREATE			= 0x01,	// Send - s1(ID)	| Recv b1(YesNoErr)
-							N3_SP_PARTY_OR_FORCE_PERMIT			= 0x02,	// Send - b1(YesNo) | Recv - s1(ID)
-							N3_SP_PARTY_OR_FORCE_INSERT			= 0x03,	// Send - s1(ID) | Recv - s3(ID, HPMax, HP) b2(Level, Class) - 문자열은 ID 로 알아낸다.. ID 가 -1 이면.. 파티에 들어오는것을 상대방이 거절한거다..
-							N3_SP_PARTY_OR_FORCE_REMOVE			= 0x04,	// Send - s1(ID) | Recv - s1(ID) - 자기 자신이면 파티를 깨야 한다..
-							N3_SP_PARTY_OR_FORCE_DESTROY			= 0x05,	// Send
-							N3_SP_PARTY_OR_FORCE_HP_CHANGE		= 0x06,	// Recv - s3(ID, HPMax, HP)
-							N3_SP_PARTY_OR_FORCE_LEVEL_CHANGE	= 0x07,	// Recv - s1(ID), b1(Level)
-							N3_SP_PARTY_OR_FORCE_CLASS_CHANGE	= 0x08,	// Recv - s1(ID), b1(Class)드물지만 전직할때...
-							N3_SP_PARTY_OR_FORCE_STATUS_CHANGE	= 0x09 };	// Recv - s1(ID), b1(Status)독, 저주, 지속성마법, 축복
+								N3_SP_PARTY_OR_FORCE_PERMIT			= 0x02,	// Send - b1(YesNo) | Recv - s1(ID)
+								N3_SP_PARTY_OR_FORCE_INSERT			= 0x03,	// Send - s1(ID) | Recv - s3(ID, HPMax, HP) b2(Level, Class) - 문자열은 ID 로 알아낸다.. ID 가 -1 이면.. 파티에 들어오는것을 상대방이 거절한거다..
+								N3_SP_PARTY_OR_FORCE_REMOVE			= 0x04,	// Send - s1(ID) | Recv - s1(ID) - 자기 자신이면 파티를 깨야 한다..
+								N3_SP_PARTY_OR_FORCE_DESTROY		= 0x05,	// Send
+								N3_SP_PARTY_OR_FORCE_HP_CHANGE		= 0x06,	// Recv - s3(ID, HPMax, HP, iMPMax, MP)
+								N3_SP_PARTY_OR_FORCE_LEVEL_CHANGE	= 0x07,	// Recv - s1(ID), b1(Level)
+								N3_SP_PARTY_OR_FORCE_CLASS_CHANGE	= 0x08,	// Recv - s1(ID), b1(Class)드물지만 전직할때...
+								N3_SP_PARTY_OR_FORCE_STATUS_CHANGE	= 0x09 };	// Recv - s1(ID), b1(Status)독, 저주, 지속성마법, 축복
 
 	// Sub Packet
 	enum e_SubPacket_PerTrade {	N3_SP_PER_TRADE_REQ =			0x01, 

--- a/Client/WarFare/PlayerBase.h
+++ b/Client/WarFare/PlayerBase.h
@@ -41,6 +41,8 @@ struct __InfoPlayerBase
 	int			iLevel;			// 레벨
 	int			iHPMax;
 	int			iHP;
+	int			iMP;
+	int			iMPMax;
 	int			iAuthority;		// 권한 - 0 관리자, 1 - 일반유저, 255 - 블럭당한 유저...
 
 	bool		bRenderID;		// 화면에 ID 를 찍는지..
@@ -56,6 +58,8 @@ struct __InfoPlayerBase
 		iLevel = 0;					// 레벨
 		iHPMax = 0;
 		iHP = 0;
+		iMP = 0;
+		iMPMax = 0;
 		iAuthority = 1;				// 권한 - 0 관리자, 1 - 일반유저, 255 - 블럭당한 유저...
 		bRenderID = true;
 	}

--- a/Client/WarFare/UIPartyOrForce.cpp
+++ b/Client/WarFare/UIPartyOrForce.cpp
@@ -246,7 +246,7 @@ CPlayerOther* CUIPartyOrForce::MemberGetByNearst(const __Vector3& vPosPlayer)
 	return pTarget;
 }
 
-const __InfoPartyOrForce* CUIPartyOrForce::MemberAdd(int iID, const std::string szID, int iLevel, e_Class eClass, int iHP, int iHPMax, int iMP, int iMPMax)
+const __InfoPartyOrForce* CUIPartyOrForce::MemberAdd(int iID, const std::string& szID, int iLevel, e_Class eClass, int iHP, int iHPMax, int iMP, int iMPMax)
 {
 	__InfoPartyOrForce InfoTmp;
 	InfoTmp.iID = iID;
@@ -258,12 +258,12 @@ const __InfoPartyOrForce* CUIPartyOrForce::MemberAdd(int iID, const std::string 
 	InfoTmp.iMPMax = iMPMax;
 	InfoTmp.eClass = eClass;
 
-	m_Members.push_back(InfoTmp);
+	m_Members.push_back(std::move(InfoTmp));
 
-	it_PartyOrForce it = m_Members.end();
+	auto it = m_Members.end();
 	it--;
 	
-	this->MemberInfoReInit();
+	MemberInfoReInit();
 
 	return &(*it);
 }

--- a/Client/WarFare/UIPartyOrForce.cpp
+++ b/Client/WarFare/UIPartyOrForce.cpp
@@ -25,18 +25,18 @@ static char THIS_FILE[]=__FILE__;
 
 CUIPartyOrForce::CUIPartyOrForce()
 {
-	for(int i = 0; i < MAX_PARTY_OR_FORCE; i++)
+	for (int i = 0; i < MAX_PARTY_OR_FORCE; i++)
 	{
-		m_pProgress_HPs[i]			= NULL;	// 부대원갯수 만큼... HP Gauge
-		m_pProgress_HPReduce[i]		= NULL;	// 부대원갯수 만큼... HP Reduce
-		m_pProgress_HPSlow[i]		= NULL;	// HP Slow
-		m_pProgress_HPLasting[i]	= NULL;	// HP Lasting
-		m_pProgress_MP[i]			= NULL;	// MP Bar
-		m_pStatic_IDs[i]			= NULL;	// Names for each party member
-		m_pAreas[i]					= NULL;
+		m_pProgress_HPs[i]			= nullptr;	// 부대원갯수 만큼... HP Gauge
+		m_pProgress_HPReduce[i]		= nullptr;	// 부대원갯수 만큼... HP Reduce
+		m_pProgress_HPSlow[i]		= nullptr;	// HP Slow
+		m_pProgress_HPLasting[i]	= nullptr;	// HP Lasting
+		m_pProgress_MP[i]			= nullptr;	// MP Bar
+		m_pStatic_IDs[i]			= nullptr;	// Names for each party member
+		m_pAreas[i]					= nullptr;
 	}
 
-	m_iIndexSelected = ((size_t)~0); // 현재 선택된 멤버인덱스..
+	m_iIndexSelected = ((size_t) ~0); // 현재 선택된 멤버인덱스..
 }
 
 CUIPartyOrForce::~CUIPartyOrForce()
@@ -49,15 +49,16 @@ void CUIPartyOrForce::Release()
 
 	m_Members.clear();
 	m_iIndexSelected = -1; // 현재 선택된 멤버인덱스..
-	for(int i = 0; i < MAX_PARTY_OR_FORCE; i++)
+
+	for (int i = 0; i < MAX_PARTY_OR_FORCE; i++)
 	{
-		m_pProgress_HPs[i]			= NULL;	// 부대원갯수 만큼... HP Gauge
-		m_pProgress_HPReduce[i]		= NULL;	// 부대원갯수 만큼... HP Reduce
-		m_pProgress_HPSlow[i]		= NULL;	// HP Slow
-		m_pProgress_HPLasting[i]	= NULL;	// HP Lasting
-		m_pProgress_MP[i]			= NULL;	// MP Bar
-		m_pStatic_IDs[i]			= NULL;	// Names for each party member
-		m_pAreas[i]					= NULL;
+		m_pProgress_HPs[i]			= nullptr;	// 부대원갯수 만큼... HP Gauge
+		m_pProgress_HPReduce[i]		= nullptr;	// 부대원갯수 만큼... HP Reduce
+		m_pProgress_HPSlow[i]		= nullptr;	// HP Slow
+		m_pProgress_HPLasting[i]	= nullptr;	// HP Lasting
+		m_pProgress_MP[i]			= nullptr;	// MP Bar
+		m_pStatic_IDs[i]			= nullptr;	// Names for each party member
+		m_pAreas[i]					= nullptr;
 	}
 
 }
@@ -288,53 +289,72 @@ bool CUIPartyOrForce::MemberRemove(int iID)
 void CUIPartyOrForce::MemberDestroy()
 {
 	m_Members.clear();
-	for(int i = 0; i < MAX_PARTY_OR_FORCE; i++) // 빈곳을 찾자..
+
+	// 빈곳을 찾자..
+	for (int i = 0; i < MAX_PARTY_OR_FORCE; i++)
 	{
-		if(m_pProgress_HPs[i])			m_pProgress_HPs[i]->SetVisible(false);
-		if(m_pProgress_HPReduce[i])		m_pProgress_HPReduce[i]->SetVisible(false);
-		if(m_pProgress_MP[i])			m_pProgress_MP[i]->SetVisible(false);
-		if(m_pProgress_HPSlow[i])		m_pProgress_HPSlow[i]->SetVisible(false);
-		if(m_pProgress_HPLasting[i])	m_pProgress_HPLasting[i]->SetVisible(false);
-		if(m_pStatic_IDs[i])			m_pStatic_IDs[i]->SetVisible(false);
+		if (m_pProgress_HPs[i] != nullptr)
+			m_pProgress_HPs[i]->SetVisible(false);
+
+		if (m_pProgress_HPReduce[i] != nullptr)
+			m_pProgress_HPReduce[i]->SetVisible(false);
+
+		if (m_pProgress_MP[i] != nullptr)
+			m_pProgress_MP[i]->SetVisible(false);
+
+		if (m_pProgress_HPSlow[i] != nullptr)
+			m_pProgress_HPSlow[i]->SetVisible(false);
+
+		if (m_pProgress_HPLasting[i] != nullptr)
+			m_pProgress_HPLasting[i]->SetVisible(false);
+
+		if (m_pStatic_IDs[i] != nullptr)
+			m_pStatic_IDs[i]->SetVisible(false);
 	}
 
-	this->MemberInfoReInit();
+	MemberInfoReInit();
 }
 
 void CUIPartyOrForce::MemberInfoReInit() // 파티원 구성이 변경될때.. 순서 및 각종 정보 업데이트..
 {
-	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
-	__InfoPartyOrForce* pIP = NULL;
-	for(int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
+	auto it = m_Members.begin(), itEnd = m_Members.end();
+	for (int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
 	{
-		pIP = &(*it); // 디버깅 하기 쉬우라고 이렇게 했다..
-		if(pIP->iHPMax <= 0)
+		__InfoPartyOrForce* pIP = &(*it); // 디버깅 하기 쉬우라고 이렇게 했다..
+		if (pIP->iHPMax <= 0)
 		{
 			__ASSERT(0, "Invalid Party memeber HP");
 			continue;
 		}
 
-		if(m_pProgress_HPs[i])
-		{
-			m_pProgress_HPs[i]->SetCurValue(pIP->iHP * 100 / pIP->iHPMax);
-		}
-		if(m_pProgress_HPReduce[i])
-		{
-			m_pProgress_HPReduce[i]->SetCurValue(pIP->iHP * 100 / pIP->iHPMax);
-		}
-		if(m_pProgress_MP[i])
-		{
+		const int iHPPercent = pIP->iHP * 100 / pIP->iHPMax;
+
+		if (m_pProgress_HPs[i] != nullptr)
+			m_pProgress_HPs[i]->SetCurValue(iHPPercent);
+
+		if (m_pProgress_HPReduce[i] != nullptr)
+			m_pProgress_HPReduce[i]->SetCurValue(iHPPercent);
+
+		if (m_pProgress_HPSlow[i] != nullptr)
+			m_pProgress_HPSlow[i]->SetCurValue(iHPPercent);
+
+		if (m_pProgress_HPLasting[i] != nullptr)
+			m_pProgress_HPLasting[i]->SetCurValue(iHPPercent);
+
+		if (m_pProgress_MP[i] != nullptr)
 			m_pProgress_MP[i]->SetCurValue(pIP->iMP * 100 / pIP->iMPMax);
-		}
-		if(m_pStatic_IDs[i])
+
+		if (m_pStatic_IDs[i] != nullptr)
 		{
 			m_pStatic_IDs[i]->SetString(pIP->szID);
 			m_pStatic_IDs[i]->SetVisible(true);
 		}
 	}
 
-	if(m_Members.empty()) this->SetVisible(false); // 멤버가 없으면 숨긴다.
-	else this->SetVisible(true); // 멤버가 있으면 보인다.
+	if (m_Members.empty())
+		SetVisible(false); // 멤버가 없으면 숨긴다.
+	else
+		SetVisible(true); // 멤버가 있으면 보인다.
 }
 
 const __InfoPartyOrForce* CUIPartyOrForce::MemberInfoGetSelected()
@@ -351,21 +371,33 @@ const __InfoPartyOrForce* CUIPartyOrForce::MemberInfoGetSelected()
 
 void CUIPartyOrForce::MemberHPChange(int iID, int iHP, int iHPMax, int iMP, int iMPMax)
 {
-	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
-	__InfoPartyOrForce* pIP = NULL;
-	for(int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
+	auto it = m_Members.begin(), itEnd = m_Members.end();
+	for (int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
 	{
-		pIP = &(*it); // 디버깅 하기 쉬우라고 이렇게 했다..
-		if(pIP->iID == iID)
+		__InfoPartyOrForce* pIP = &(*it); // 디버깅 하기 쉬우라고 이렇게 했다..
+		if (pIP->iID == iID)
 		{
 			pIP->iHP = iHP;
 			pIP->iHPMax = iHPMax;
 			pIP->iMP = iMP;
 			pIP->iMPMax = iMPMax;
 
-			if(m_pProgress_HPs[i])		m_pProgress_HPs[i]->SetCurValue(pIP->iHP * 100 / pIP->iHPMax, 0.7f, 50.0f);
-			if(m_pProgress_HPReduce[i]) m_pProgress_HPReduce[i]->SetCurValue(pIP->iHP * 100 / pIP->iHPMax, 0.7f, 50.0f);
-			if(m_pProgress_MP[i])		m_pProgress_MP[i]->SetCurValue(pIP->iMP * 100 / pIP->iMPMax, 0.7f, 50.0f);
+			const int iHPPercent = pIP->iHP * 100 / pIP->iHPMax;
+
+			if (m_pProgress_HPs[i] != nullptr)
+				m_pProgress_HPs[i]->SetCurValue(iHPPercent, 0.7f, 50.0f);
+
+			if (m_pProgress_HPReduce[i] != nullptr)
+				m_pProgress_HPReduce[i]->SetCurValue(iHPPercent, 0.7f, 50.0f);
+
+			if (m_pProgress_HPSlow[i] != nullptr)
+				m_pProgress_HPSlow[i]->SetCurValue(iHPPercent, 0.7f, 50.0f);
+
+			if (m_pProgress_HPLasting[i] != nullptr)
+				m_pProgress_HPLasting[i]->SetCurValue(iHPPercent, 0.7f, 50.0f);
+
+			if (m_pProgress_MP[i] != nullptr)
+				m_pProgress_MP[i]->SetCurValue(pIP->iMP * 100 / pIP->iMPMax, 0.7f, 50.0f);
 			break;
 		}
 	}
@@ -424,58 +456,64 @@ void CUIPartyOrForce::Tick()
 	bool bBlink = false;
 	uint32_t dwTime = GetTickCount();
 
-	dwTime = dwTime/1000;
+	dwTime = dwTime / 1000;
 	dwTime %= 2;
 
-	if(dwTime == 1)	bBlink = true;
+	if (dwTime == 1)
+		bBlink = true;
 
-	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
-	__InfoPartyOrForce* pIP = NULL;
-	for(int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
+	auto it = m_Members.begin(), itEnd = m_Members.end();
+	for (int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
 	{
-		pIP = &(*it); // 디버깅 하기 쉬우라고 이렇게 했다..
-		if(m_pProgress_HPs[i])
+		__InfoPartyOrForce* pIP = &(*it); // 디버깅 하기 쉬우라고 이렇게 했다..
+		if (m_pProgress_HPs[i] != nullptr)
 		{
-			if( pIP->bSufferDown_HP || pIP->bSufferDown_Etc )
+			if (pIP->bSufferDown_HP || pIP->bSufferDown_Etc)
 				m_pProgress_HPs[i]->SetVisible(false);
 			else
 				m_pProgress_HPs[i]->SetVisible(true);
 		}
 
-		if( pIP->bSufferDown_HP && pIP->bSufferDown_Etc )
+		if (pIP->bSufferDown_HP && pIP->bSufferDown_Etc)
 		{
-			if(bBlink)
+			if (bBlink)
 			{
-				if(m_pProgress_HPReduce[i])	m_pProgress_HPReduce[i]->SetVisible(true);
-				if(m_pProgress_MP[i])		m_pProgress_MP[i]->SetVisible(false);
+				if (m_pProgress_HPReduce[i] != nullptr)
+					m_pProgress_HPReduce[i]->SetVisible(true);
+
+				if (m_pProgress_MP[i] != nullptr)
+					m_pProgress_MP[i]->SetVisible(false);
 			}
 			else
 			{
-				if(m_pProgress_HPReduce[i])	m_pProgress_HPReduce[i]->SetVisible(false);
-				if(m_pProgress_MP[i])		m_pProgress_MP[i]->SetVisible(true);
+				if (m_pProgress_HPReduce[i] != nullptr)
+					m_pProgress_HPReduce[i]->SetVisible(false);
+
+				if (m_pProgress_MP[i] != nullptr)
+					m_pProgress_MP[i]->SetVisible(true);
 			}
 		}
 		else
 		{
-			if(m_pProgress_HPReduce[i])
+			if (m_pProgress_HPReduce[i] != nullptr)
 			{
-				if( pIP->bSufferDown_HP )
+				if (pIP->bSufferDown_HP)
 					m_pProgress_HPReduce[i]->SetVisible(true);
 				else
 					m_pProgress_HPReduce[i]->SetVisible(false);
 			}
-			if(m_pProgress_MP[i])
+
+			if (m_pProgress_MP[i] != nullptr)
 			{
-				if( pIP->bSufferDown_Etc )
+				if (pIP->bSufferDown_Etc)
 					m_pProgress_MP[i]->SetVisible(true);
 				else
 					m_pProgress_MP[i]->SetVisible(false);
 			}
 		}
-		if (m_pProgress_MP[i])
-		{
+
+		if (m_pProgress_MP[i] != nullptr)
 			m_pProgress_MP[i]->SetVisible(true);
-		}
 	}
 }
 

--- a/Client/WarFare/UIPartyOrForce.cpp
+++ b/Client/WarFare/UIPartyOrForce.cpp
@@ -27,11 +27,13 @@ CUIPartyOrForce::CUIPartyOrForce()
 {
 	for(int i = 0; i < MAX_PARTY_OR_FORCE; i++)
 	{
-		m_pProgress_HPs[i]		= NULL;	// 부대원갯수 만큼... HP Gauge
-		m_pProgress_HPReduce[i] = NULL;	// 부대원갯수 만큼... HP Reduce
-		m_pProgress_ETC[i]		= NULL;	// 부대원갯수 만큼... 상태이상
-		m_pStatic_IDs[i]		= NULL;	// 부대원갯수 만큼... 이름들..
-		m_pAreas[i]				= NULL;
+		m_pProgress_HPs[i]			= NULL;	// 부대원갯수 만큼... HP Gauge
+		m_pProgress_HPReduce[i]		= NULL;	// 부대원갯수 만큼... HP Reduce
+		m_pProgress_HPSlow[i]		= NULL;	// HP Slow
+		m_pProgress_HPLasting[i]	= NULL;	// HP Lasting
+		m_pProgress_MP[i]			= NULL;	// MP Bar
+		m_pStatic_IDs[i]			= NULL;	// Names for each party member
+		m_pAreas[i]					= NULL;
 	}
 
 	m_iIndexSelected = ((size_t)~0); // 현재 선택된 멤버인덱스..
@@ -49,11 +51,13 @@ void CUIPartyOrForce::Release()
 	m_iIndexSelected = -1; // 현재 선택된 멤버인덱스..
 	for(int i = 0; i < MAX_PARTY_OR_FORCE; i++)
 	{
-		m_pProgress_HPs[i]		= NULL;	// 부대원갯수 만큼... HP Gauge
-		m_pProgress_HPReduce[i] = NULL;	// 부대원갯수 만큼... HP Reduce
-		m_pProgress_ETC[i]		= NULL;	// 부대원갯수 만큼... 상태이상
-		m_pStatic_IDs[i]		= NULL;	// 부대원갯수 만큼... 이름들..
-		m_pAreas[i]				= NULL;
+		m_pProgress_HPs[i]			= NULL;	// 부대원갯수 만큼... HP Gauge
+		m_pProgress_HPReduce[i]		= NULL;	// 부대원갯수 만큼... HP Reduce
+		m_pProgress_HPSlow[i]		= NULL;	// HP Slow
+		m_pProgress_HPLasting[i]	= NULL;	// HP Lasting
+		m_pProgress_MP[i]			= NULL;	// MP Bar
+		m_pStatic_IDs[i]			= NULL;	// Names for each party member
+		m_pAreas[i]					= NULL;
 	}
 
 }
@@ -74,7 +78,15 @@ bool CUIPartyOrForce::Load(HANDLE hFile)
 			m_pProgress_HPs[i]->SetRange(0, 100);
 		}
 
-		szID = fmt::format("progress_hp_{}_poison", i);
+		szID = fmt::format("progress_hp_{}_slow", i);
+		N3_VERIFY_UI_COMPONENT(m_pProgress_HPSlow[i], (CN3UIProgress*) GetChildByID(szID));
+		if (m_pProgress_HPSlow[i] != nullptr)
+		{
+			m_pProgress_HPSlow[i]->SetVisible(false);
+			m_pProgress_HPSlow[i]->SetRange(0, 100);
+		}
+
+		szID = fmt::format("progress_hp_{}_drop", i);
 		N3_VERIFY_UI_COMPONENT(m_pProgress_HPReduce[i], (CN3UIProgress*) GetChildByID(szID));
 		if (m_pProgress_HPReduce[i] != nullptr)
 		{
@@ -82,12 +94,20 @@ bool CUIPartyOrForce::Load(HANDLE hFile)
 			m_pProgress_HPReduce[i]->SetRange(0, 100);
 		}
 
-		szID = fmt::format("progress_hp_{}_curse", i); 
-		N3_VERIFY_UI_COMPONENT(m_pProgress_ETC[i], (CN3UIProgress*) GetChildByID(szID));
-		if (m_pProgress_ETC[i] != nullptr)
+		szID = fmt::format("progress_hp_{}_lasting", i);
+		N3_VERIFY_UI_COMPONENT(m_pProgress_HPLasting[i], (CN3UIProgress*) GetChildByID(szID));
+		if (m_pProgress_HPLasting[i] != nullptr)
 		{
-			m_pProgress_ETC[i]->SetVisible(false);
-			m_pProgress_ETC[i]->SetRange(0, 100);
+			m_pProgress_HPLasting[i]->SetVisible(false);
+			m_pProgress_HPLasting[i]->SetRange(0, 100);
+		}
+
+		szID = fmt::format("progress_mp_{}_curse", i); 
+		N3_VERIFY_UI_COMPONENT(m_pProgress_MP[i], (CN3UIProgress*) GetChildByID(szID));
+		if (m_pProgress_MP[i] != nullptr)
+		{
+			m_pProgress_MP[i]->SetVisible(false);
+			m_pProgress_MP[i]->SetRange(0, 100);
 		}
 
 		szID = fmt::format("static_name_{}", i);
@@ -225,7 +245,7 @@ CPlayerOther* CUIPartyOrForce::MemberGetByNearst(const __Vector3& vPosPlayer)
 	return pTarget;
 }
 
-const __InfoPartyOrForce* CUIPartyOrForce::MemberAdd(int iID, const std::string szID, int iLevel, e_Class eClass, int iHP, int iHPMax)
+const __InfoPartyOrForce* CUIPartyOrForce::MemberAdd(int iID, const std::string szID, int iLevel, e_Class eClass, int iHP, int iHPMax, int iMP, int iMPMax)
 {
 	__InfoPartyOrForce InfoTmp;
 	InfoTmp.iID = iID;
@@ -233,6 +253,8 @@ const __InfoPartyOrForce* CUIPartyOrForce::MemberAdd(int iID, const std::string 
 	InfoTmp.iLevel = iLevel;
 	InfoTmp.iHP = iHP;
 	InfoTmp.iHPMax = iHPMax;
+	InfoTmp.iMP = iMP;
+	InfoTmp.iMPMax = iMPMax;
 	InfoTmp.eClass = eClass;
 
 	m_Members.push_back(InfoTmp);
@@ -268,11 +290,12 @@ void CUIPartyOrForce::MemberDestroy()
 	m_Members.clear();
 	for(int i = 0; i < MAX_PARTY_OR_FORCE; i++) // 빈곳을 찾자..
 	{
-		if(m_pProgress_HPs[i])		m_pProgress_HPs[i]->SetVisible(false);
-		if(m_pProgress_HPReduce[i]) m_pProgress_HPReduce[i]->SetVisible(false);
-		if(m_pProgress_ETC[i])		m_pProgress_ETC[i]->SetVisible(false);
-
-		if(m_pStatic_IDs[i]) m_pStatic_IDs[i]->SetVisible(false);
+		if(m_pProgress_HPs[i])			m_pProgress_HPs[i]->SetVisible(false);
+		if(m_pProgress_HPReduce[i])		m_pProgress_HPReduce[i]->SetVisible(false);
+		if(m_pProgress_MP[i])			m_pProgress_MP[i]->SetVisible(false);
+		if(m_pProgress_HPSlow[i])		m_pProgress_HPSlow[i]->SetVisible(false);
+		if(m_pProgress_HPLasting[i])	m_pProgress_HPLasting[i]->SetVisible(false);
+		if(m_pStatic_IDs[i])			m_pStatic_IDs[i]->SetVisible(false);
 	}
 
 	this->MemberInfoReInit();
@@ -294,31 +317,20 @@ void CUIPartyOrForce::MemberInfoReInit() // 파티원 구성이 변경될때.. �
 		if(m_pProgress_HPs[i])
 		{
 			m_pProgress_HPs[i]->SetCurValue(pIP->iHP * 100 / pIP->iHPMax);
-//			m_pProgress_HPs[i]->SetVisible(true);
 		}
 		if(m_pProgress_HPReduce[i])
 		{
 			m_pProgress_HPReduce[i]->SetCurValue(pIP->iHP * 100 / pIP->iHPMax);
-//			m_pProgress_HPReduce[i]->SetVisible(false);
 		}
-		if(m_pProgress_ETC[i])
+		if(m_pProgress_MP[i])
 		{
-			m_pProgress_ETC[i]->SetCurValue(pIP->iHP * 100 / pIP->iHPMax);
-//			m_pProgress_ETC[i]->SetVisible(false);
+			m_pProgress_MP[i]->SetCurValue(pIP->iMP * 100 / pIP->iMPMax);
 		}
 		if(m_pStatic_IDs[i])
 		{
 			m_pStatic_IDs[i]->SetString(pIP->szID);
 			m_pStatic_IDs[i]->SetVisible(true);
 		}
-	}
-
-	for(int i=0; i < MAX_PARTY_OR_FORCE; i++)
-	{
-		if(m_pProgress_HPs[i])		m_pProgress_HPs[i]->SetVisible(false);
-		if(m_pProgress_HPReduce[i]) m_pProgress_HPReduce[i]->SetVisible(false);
-		if(m_pProgress_ETC[i])		m_pProgress_ETC[i]->SetVisible(false);
-		if(m_pStatic_IDs[i])		m_pStatic_IDs[i]->SetVisible(false);
 	}
 
 	if(m_Members.empty()) this->SetVisible(false); // 멤버가 없으면 숨긴다.
@@ -337,7 +349,7 @@ const __InfoPartyOrForce* CUIPartyOrForce::MemberInfoGetSelected()
 	return &(*it);
 }
 
-void CUIPartyOrForce::MemberHPChange(int iID, int iHP, int iHPMax)
+void CUIPartyOrForce::MemberHPChange(int iID, int iHP, int iHPMax, int iMP, int iMPMax)
 {
 	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
 	__InfoPartyOrForce* pIP = NULL;
@@ -348,10 +360,12 @@ void CUIPartyOrForce::MemberHPChange(int iID, int iHP, int iHPMax)
 		{
 			pIP->iHP = iHP;
 			pIP->iHPMax = iHPMax;
+			pIP->iMP = iMP;
+			pIP->iMPMax = iMPMax;
 
 			if(m_pProgress_HPs[i])		m_pProgress_HPs[i]->SetCurValue(pIP->iHP * 100 / pIP->iHPMax, 0.7f, 50.0f);
 			if(m_pProgress_HPReduce[i]) m_pProgress_HPReduce[i]->SetCurValue(pIP->iHP * 100 / pIP->iHPMax, 0.7f, 50.0f);
-			if(m_pProgress_ETC[i])		m_pProgress_ETC[i]->SetCurValue(pIP->iHP * 100 / pIP->iHPMax, 0.7f, 50.0f);
+			if(m_pProgress_MP[i])		m_pProgress_MP[i]->SetCurValue(pIP->iMP * 100 / pIP->iMPMax, 0.7f, 50.0f);
 			break;
 		}
 	}
@@ -433,12 +447,12 @@ void CUIPartyOrForce::Tick()
 			if(bBlink)
 			{
 				if(m_pProgress_HPReduce[i])	m_pProgress_HPReduce[i]->SetVisible(true);
-				if(m_pProgress_ETC[i])		m_pProgress_ETC[i]->SetVisible(false);
+				if(m_pProgress_MP[i])		m_pProgress_MP[i]->SetVisible(false);
 			}
 			else
 			{
 				if(m_pProgress_HPReduce[i])	m_pProgress_HPReduce[i]->SetVisible(false);
-				if(m_pProgress_ETC[i])		m_pProgress_ETC[i]->SetVisible(true);
+				if(m_pProgress_MP[i])		m_pProgress_MP[i]->SetVisible(true);
 			}
 		}
 		else
@@ -450,13 +464,17 @@ void CUIPartyOrForce::Tick()
 				else
 					m_pProgress_HPReduce[i]->SetVisible(false);
 			}
-			if(m_pProgress_ETC[i])
+			if(m_pProgress_MP[i])
 			{
 				if( pIP->bSufferDown_Etc )
-					m_pProgress_ETC[i]->SetVisible(true);
+					m_pProgress_MP[i]->SetVisible(true);
 				else
-					m_pProgress_ETC[i]->SetVisible(false);
+					m_pProgress_MP[i]->SetVisible(false);
 			}
+		}
+		if (m_pProgress_MP[i])
+		{
+			m_pProgress_MP[i]->SetVisible(true);
 		}
 	}
 }

--- a/Client/WarFare/UIPartyOrForce.h
+++ b/Client/WarFare/UIPartyOrForce.h
@@ -47,7 +47,7 @@ public:
 	const __InfoPartyOrForce*	MemberInfoGetByID(int iID, int& iIndexResult);
 	const __InfoPartyOrForce*	MemberInfoGetByIndex(size_t iIndex);
 	const __InfoPartyOrForce*	MemberInfoGetSelected(); // 현재 선택된 멤버인덱스..
-	const __InfoPartyOrForce*	MemberAdd(int iID, const std::string szID, int iLevel, e_Class eClass, int iHP, int iHPMax, int iMP, int iMPMax);
+	const __InfoPartyOrForce*	MemberAdd(int iID, const std::string& szID, int iLevel, e_Class eClass, int iHP, int iHPMax, int iMP, int iMPMax);
 	class CPlayerOther*			MemberGetByNearst(const __Vector3& vPosPlayer);
 	bool						MemberRemove(int iID);
 	void						MemberDestroy();

--- a/Client/WarFare/UIPartyOrForce.h
+++ b/Client/WarFare/UIPartyOrForce.h
@@ -19,13 +19,13 @@ typedef std::list<__InfoPartyOrForce>::iterator it_PartyOrForce;
 class CUIPartyOrForce : public CN3UIBase // 파티에 관한 UI, 부대와 같은 클래스로 쓴다..
 {
 protected:
-	class CN3UIProgress*	m_pProgress_HPs[MAX_PARTY_OR_FORCE];		// 부대원갯수 만큼... HP Gauge
-	class CN3UIProgress*	m_pProgress_HPReduce[MAX_PARTY_OR_FORCE];	// 부대원갯수 만큼... HP Reduce
-	class CN3UIProgress*	m_pProgress_HPSlow[MAX_PARTY_OR_FORCE];		// HP Slow
-	class CN3UIProgress*	m_pProgress_HPLasting[MAX_PARTY_OR_FORCE];	// HP Lasting
-	class CN3UIProgress*	m_pProgress_MP[MAX_PARTY_OR_FORCE];			// MP Bar
-	class CN3UIStatic*		m_pStatic_IDs[MAX_PARTY_OR_FORCE];			// 부대원갯수 만큼... 이름들..
-	class CN3UIArea*		m_pAreas[MAX_PARTY_OR_FORCE];				// 부대원갯수 만큼... 이름들..
+	CN3UIProgress*	m_pProgress_HPs[MAX_PARTY_OR_FORCE];		// 부대원갯수 만큼... HP Gauge
+	CN3UIProgress*	m_pProgress_HPReduce[MAX_PARTY_OR_FORCE];	// 부대원갯수 만큼... HP Reduce
+	CN3UIProgress*	m_pProgress_HPSlow[MAX_PARTY_OR_FORCE];		// HP Slow
+	CN3UIProgress*	m_pProgress_HPLasting[MAX_PARTY_OR_FORCE];	// HP Lasting
+	CN3UIProgress*	m_pProgress_MP[MAX_PARTY_OR_FORCE];			// MP Bar
+	CN3UIStatic*	m_pStatic_IDs[MAX_PARTY_OR_FORCE];			// 부대원갯수 만큼... 이름들..
+	CN3UIArea*		m_pAreas[MAX_PARTY_OR_FORCE];				// 부대원갯수 만큼... 이름들..
 
 	std::list<__InfoPartyOrForce>	m_Members; // 파티 멤버
 	size_t		m_iIndexSelected; // 현재 선택된 멤버인덱스..

--- a/Client/WarFare/UIPartyOrForce.h
+++ b/Client/WarFare/UIPartyOrForce.h
@@ -21,9 +21,11 @@ class CUIPartyOrForce : public CN3UIBase // 파티에 관한 UI, 부대와 같�
 protected:
 	class CN3UIProgress*	m_pProgress_HPs[MAX_PARTY_OR_FORCE];		// 부대원갯수 만큼... HP Gauge
 	class CN3UIProgress*	m_pProgress_HPReduce[MAX_PARTY_OR_FORCE];	// 부대원갯수 만큼... HP Reduce
-	class CN3UIProgress*	m_pProgress_ETC[MAX_PARTY_OR_FORCE];		// 부대원갯수 만큼... 상태이상
-	class CN3UIStatic*		m_pStatic_IDs[MAX_PARTY_OR_FORCE];		// 부대원갯수 만큼... 이름들..
-	class CN3UIArea*		m_pAreas[MAX_PARTY_OR_FORCE];		// 부대원갯수 만큼... 이름들..
+	class CN3UIProgress*	m_pProgress_HPSlow[MAX_PARTY_OR_FORCE];		// HP Slow
+	class CN3UIProgress*	m_pProgress_HPLasting[MAX_PARTY_OR_FORCE];	// HP Lasting
+	class CN3UIProgress*	m_pProgress_MP[MAX_PARTY_OR_FORCE];			// MP Bar
+	class CN3UIStatic*		m_pStatic_IDs[MAX_PARTY_OR_FORCE];			// 부대원갯수 만큼... 이름들..
+	class CN3UIArea*		m_pAreas[MAX_PARTY_OR_FORCE];				// 부대원갯수 만큼... 이름들..
 
 	std::list<__InfoPartyOrForce>	m_Members; // 파티 멤버
 	size_t		m_iIndexSelected; // 현재 선택된 멤버인덱스..
@@ -36,7 +38,7 @@ public:
 	void Tick();
 	void		MemberClassChange(int iID, e_Class eClass);
 	void		MemberLevelChange(int iID, int iLevel);
-	void		MemberHPChange(int iID, int iHP, int iHPMax);
+	void		MemberHPChange(int iID, int iHP, int iHPMax, int iMP, int iMPMax);
 	void		MemberStatusChange(int iID, e_PartyStatus ePS, bool bSuffer);
 
 	void		MemberInfoReInit(); // 파티원 구성이 변경될때.. 순서 및 각종 정보 업데이트..
@@ -45,7 +47,7 @@ public:
 	const __InfoPartyOrForce*	MemberInfoGetByID(int iID, int& iIndexResult);
 	const __InfoPartyOrForce*	MemberInfoGetByIndex(size_t iIndex);
 	const __InfoPartyOrForce*	MemberInfoGetSelected(); // 현재 선택된 멤버인덱스..
-	const __InfoPartyOrForce*	MemberAdd(int iID, const std::string szID, int iLevel, e_Class eClass, int iHP, int iHPMax);
+	const __InfoPartyOrForce*	MemberAdd(int iID, const std::string szID, int iLevel, e_Class eClass, int iHP, int iHPMax, int iMP, int iMPMax);
 	class CPlayerOther*			MemberGetByNearst(const __Vector3& vPosPlayer);
 	bool						MemberRemove(int iID);
 	void						MemberDestroy();


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
The Party UI is bugged #46 

## What is the new behaviour?
The party UI only displayed the information for the party members and MP bars are operating.

Future work needed to align with official for party UI:
- Check the curses, slows, DOTs etc are working as per official client
- Change party user names to yellow
- Provide party icon to leader
- Make user names in party UI have a black outline
- Possible others but have not tested every part, just started on this.

## Why and how did I change this?
1. The UIF data was not referenced correctly.
2. Hide/ show of the data was not configured correctly
3. Linked up the MP part of the packet for N3_SP_PARTY_OR_FORCE_HP_CHANGE
4. Changed some typos in the comments that referred to the wrong codes

## Demo
Screen shot of working party UI
<img width="1013" height="560" alt="Party" src="https://github.com/user-attachments/assets/8325205b-8373-486b-9033-758c4b2995a8" />

## Checklist

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
