### PR TITLE
Revert index/size types back to official signed types

### DIFF
--- a/Client/N3Base/N3AnimControl.cpp
+++ b/Client/N3Base/N3AnimControl.cpp
@@ -80,7 +80,9 @@ __AnimData* CN3AnimControl::Add()
 #ifdef _N3TOOL
 __AnimData* CN3AnimControl::Insert(int nIndex)
 {
-	if(nIndex < 0 || nIndex >= m_Datas.size()) return NULL;
+	if (nIndex < 0
+		|| nIndex >= static_cast<int>(m_Datas.size()))
+		return nullptr;
 	
 	it_Ani it = m_Datas.begin();
 	for(int i = 0; i < nIndex; i++, it++);
@@ -96,9 +98,16 @@ __AnimData* CN3AnimControl::Insert(int nIndex)
 #ifdef _N3TOOL
 void CN3AnimControl::Swap(int nAni1, int nAni2)
 {
-	if(nAni1 == nAni2) return;
-	if(nAni1 < 0 || nAni1 >= m_Datas.size()) return;
-	if(nAni2 < 0 || nAni2 >= m_Datas.size()) return;
+	if (nAni1 == nAni2)
+		return;
+
+	if (nAni1 < 0
+		|| nAni1 >= static_cast<int>(m_Datas.size()))
+		return;
+
+	if (nAni2 < 0
+		|| nAni2 >= static_cast<int>(m_Datas.size()))
+		return;
 
 	__AnimData Tmp = m_Datas[nAni2];
 	m_Datas[nAni2] = m_Datas[nAni1];
@@ -109,7 +118,9 @@ void CN3AnimControl::Swap(int nAni1, int nAni2)
 #ifdef _N3TOOL
 void CN3AnimControl::Delete(int nIndex)
 {
-	if(nIndex < 0 || nIndex >= m_Datas.size()) return;
+	if (nIndex < 0
+		|| nIndex >= static_cast<int>(m_Datas.size()))
+		return;
 
 	it_Ani it = m_Datas.begin();
 	for(int i = 0; i < nIndex; i++, it++);

--- a/Client/N3Base/N3AnimControl.h
+++ b/Client/N3Base/N3AnimControl.h
@@ -163,14 +163,26 @@ protected:
 	std::vector<__AnimData>		m_Datas; // animation Data List
 
 public:
-	__AnimData* DataGet(size_t index) { if (index >= m_Datas.size()) return NULL; return &(m_Datas[index]); }
+	__AnimData* DataGet(int index)
+	{
+		if (index < 0
+			|| index >= static_cast<int>(m_Datas.size()))
+			return nullptr;
+
+		return &m_Datas[index];
+	}
+
 	bool Load(HANDLE hFile);
-	int Count() { return m_Datas.size(); }
+
+	int Count() const
+	{
+		return static_cast<int>(m_Datas.size());
+	}
 
 #ifdef _N3TOOL
 	__AnimData*		DataGet(const std::string& szName)
 	{
-		int iADC = m_Datas.size();
+		int iADC = static_cast<int>(m_Datas.size());
 		for(int i = 0; i < iADC; i++)
 		{
 			if(szName == m_Datas[i].szName) return &(m_Datas[i]);

--- a/Client/N3Base/N3AnimatedTexures.h
+++ b/Client/N3Base/N3AnimatedTexures.h
@@ -22,8 +22,21 @@ protected:
 
 public:
 	void Tick();
-	CN3Texture* Tex(int iIndex) { if(iIndex < 0 || iIndex >= m_TexRefs.size()) return NULL; return m_TexRefs[iIndex]; }
-	CN3Texture* TexCur() { return this->Tex((int)m_fTexIndex); }
+
+	CN3Texture* Tex(int iIndex)
+	{
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_TexRefs.size()))
+			return nullptr;
+
+		return m_TexRefs[iIndex];
+	}
+
+	CN3Texture* TexCur()
+	{
+		return Tex((int) m_fTexIndex);
+	}
+
 	void Release();
 	bool Load(HANDLE hFile);
 #ifdef _N3TOOL

--- a/Client/N3Base/N3Board.h
+++ b/Client/N3Base/N3Board.h
@@ -26,14 +26,18 @@ protected:
 	std::vector<CN3Texture*> m_TexRefs; // 텍스처 포인터 리스트..
 
 public:
-	uint32_t		m_dwBoardType; // Board Type
+	uint32_t	m_dwBoardType; // Board Type
 	float		m_fTexFPS; // Frame Per Second
 	__Material	m_Mtl; // 재질..
 
 public:
+	int TexCount() const
+	{
+		return static_cast<int>(m_TexRefs.size());
+	}
+
 	void		TexSet(int index, const std::string& szFN);
 	void		TexAlloc(int nCount);
-	int			TexCount() { m_TexRefs.size(); }
 	CN3Texture* Tex(int index) { if(m_TexRefs.empty() || index < 0 || index >= m_TexRefs.size()) return NULL; return m_TexRefs[index]; }
 
 	void		Init(__Vector3 vPos, uint32_t dwBoardType, float fW, float fH);

--- a/Client/N3Base/N3Chr.cpp
+++ b/Client/N3Base/N3Chr.cpp
@@ -2004,9 +2004,11 @@ void CN3Chr::PartAlloc(int iCount)
 	}
 }
 
-void CN3Chr::PartDelete(size_t iIndex)
+void CN3Chr::PartDelete(int iIndex)
 {
-	if (iIndex >= m_Parts.size()) return;
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_Parts.size()))
+		return;
 
 	auto it = m_Parts.begin();
 	std::advance(it, iIndex);
@@ -2015,9 +2017,12 @@ void CN3Chr::PartDelete(size_t iIndex)
 	m_Parts.erase(it);
 }
 
-CN3CPart* CN3Chr::PartSet(size_t iIndex, const std::string& szFN)
+CN3CPart* CN3Chr::PartSet(int iIndex, const std::string& szFN)
 {
-	if (iIndex >= m_Parts.size()) return NULL;
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_Parts.size()))
+		return nullptr;
+
 	if (m_Parts[iIndex]->FileName() == szFN) return m_Parts[iIndex];
 
 	if (szFN.empty()) m_Parts[iIndex]->Release();
@@ -2026,9 +2031,10 @@ CN3CPart* CN3Chr::PartSet(size_t iIndex, const std::string& szFN)
 	return m_Parts[iIndex];
 }
 
-void CN3Chr::PlugDelete(size_t iIndex)
+void CN3Chr::PlugDelete(int iIndex)
 {
-	if (iIndex >= m_Plugs.size())
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_Plugs.size()))
 		return;
 
 	auto it = m_Plugs.begin();
@@ -2038,16 +2044,21 @@ void CN3Chr::PlugDelete(size_t iIndex)
 	m_Plugs.erase(it);
 }
 
-CN3CPlug* CN3Chr::PlugSet(size_t iIndex, const std::string& szFN)
+CN3CPlug* CN3Chr::PlugSet(int iIndex, const std::string& szFN)
 {
-	if (iIndex >= m_Plugs.size()) return NULL;
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_Plugs.size()))
+		return nullptr;
 		
-	if (m_Plugs[iIndex]->FileName() == szFN) return m_Plugs[iIndex];
+	if (m_Plugs[iIndex]->FileName() == szFN)
+		return m_Plugs[iIndex];
 
-	 if(szFN.empty()) m_Plugs[iIndex]->Release();
-	else m_Plugs[iIndex]->LoadFromFile(szFN);
-	
-	this->RemakePlugTracePolygons();
+	if (szFN.empty())
+		m_Plugs[iIndex]->Release();
+	else
+		m_Plugs[iIndex]->LoadFromFile(szFN);
+
+	RemakePlugTracePolygons();
 
 	return m_Plugs[iIndex];
 }

--- a/Client/N3Base/N3Chr.h
+++ b/Client/N3Base/N3Chr.h
@@ -295,30 +295,54 @@ public:
 	int				JointPartEnd(int nAniPart) { if(nAniPart < 0 || nAniPart >= MAX_CHR_ANI_PART) return -1; return m_nJointPartEnds[nAniPart]; }
 	void			JointPartSet(int nAniPart, int nJS, int nJE);
 
-	const __Matrix44*	MatrixGet(size_t nJointIndex) const
+	const __Matrix44* MatrixGet(int nJointIndex) const
 	{
-		if (nJointIndex >= m_MtxJoints.size())
-			return NULL;
+		if (nJointIndex < 0
+			|| nJointIndex >= static_cast<int>(m_MtxJoints.size()))
+			return nullptr;
 
-		return &(m_MtxJoints[nJointIndex]);
+		return &m_MtxJoints[nJointIndex];
 	}
 
 //	void		CollisionSkinSet(const std::string& szFN);
 //	CN3Skin*	CollisionSkin() { return m_pSkinCollision; }
 
-	void		PartDelete(size_t iIndex);
-	void		PartAlloc(int nCount);
-	size_t		PartCount() { return m_Parts.size(); }
-	CN3CPart*	PartSet(size_t iIndex, const std::string& szFN);
-	CN3CPart*  	PartAdd() { CN3CPart* pPart = new CN3CPart(); m_Parts.push_back(pPart); return pPart; }
-	CN3CPart*	Part(size_t iIndex) { if (iIndex >= m_Parts.size()) return NULL; return m_Parts[iIndex]; }
+	int PartCount() const
+	{
+		return static_cast<int>(m_Parts.size());
+	}
 
-	void		PlugDelete(size_t iIndex);
+	void		PartDelete(int iIndex);
+	void		PartAlloc(int nCount);
+	CN3CPart*	PartSet(int iIndex, const std::string& szFN);
+	CN3CPart*  	PartAdd() { CN3CPart* pPart = new CN3CPart(); m_Parts.push_back(pPart); return pPart; }
+
+	CN3CPart*	Part(int iIndex)
+	{
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_Parts.size()))
+			return nullptr;
+
+		return m_Parts[iIndex];
+	}
+
+	int PlugCount() const
+	{
+		return static_cast<int>(m_Plugs.size());
+	}
+
+	void		PlugDelete(int iIndex);
 	void		PlugAlloc(int nCount);
-	size_t		PlugCount() { return m_Plugs.size(); }
-	CN3CPlug*	PlugSet(size_t iIndex, const std::string& szFN);
+	CN3CPlug*	PlugSet(int iIndex, const std::string& szFN);
 	CN3CPlug*	PlugAdd(e_PlugType eType=PLUGTYPE_NORMAL) { CN3CPlug* pPlug = new CN3CPlug(); m_Plugs.push_back(pPlug); return pPlug; }
-	CN3CPlug*	Plug(size_t iIndex) { if (iIndex >= m_Plugs.size()) return NULL; return m_Plugs[iIndex]; }
+	CN3CPlug*	Plug(int iIndex)
+	{
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_Plugs.size()))
+			return nullptr;
+
+		return m_Plugs[iIndex];
+	}
 
 	void		Tick(float fFrm = FRAME_SELFPLAY);
 	void		TickAnimationFrame();

--- a/Client/N3Base/N3FXGroup.cpp
+++ b/Client/N3Base/N3FXGroup.cpp
@@ -132,7 +132,9 @@ bool CN3FXGroup::DecodeScriptFile(const char* lpPathName)
 
 __FXBInfo* CN3FXGroup::GetFXBInfo(int idx)
 {
-	if(idx<0 || idx>=FXBList.size()) return NULL;
+	if (idx < 0
+		|| idx >= static_cast<int>(FXBList.size()))
+		return nullptr;
 
 	std::list<__FXBInfo*>::iterator it;
 	it = FXBList.begin();

--- a/Client/N3Base/N3FXPartMesh.cpp
+++ b/Client/N3Base/N3FXPartMesh.cpp
@@ -264,7 +264,7 @@ bool CN3FXPartMesh::Load(HANDLE hFile)
 
 	if (m_pShape != nullptr)
 	{
-		for (size_t i = 0; i < m_pShape->PartCount(); i++)
+		for (int i = 0; i < m_pShape->PartCount(); i++)
 		{
 			CN3FXSPart* part = m_pShape->Part(i);
 			if (part == nullptr)
@@ -733,12 +733,16 @@ void CN3FXPartMesh::Duplicate(CN3FXPartMesh* pSrc)
 	m_bTexLoop = pSrc->m_bTexLoop;
 	m_vUnitScale = pSrc->m_vUnitScale;
 		
-	if(m_pShape)
+	if (m_pShape != nullptr)
 	{
-		for(size_t i=0;i<m_pShape->PartCount();i++)
+		for (int i = 0; i < m_pShape->PartCount(); i++)
 		{
-			m_pShape->Part(i)->m_fTexFPS = m_fTexFPS;
-			m_pShape->Part(i)->m_bTexLoop = m_bTexLoop;
+			CN3FXSPart* part = m_pShape->Part(i);
+			if (part == nullptr)
+				continue;
+
+			part->m_fTexFPS = m_fTexFPS;
+			part->m_bTexLoop = m_bTexLoop;
 		}
 	}
 

--- a/Client/N3Base/N3FXPlug.cpp
+++ b/Client/N3Base/N3FXPlug.cpp
@@ -262,7 +262,9 @@ CN3FXPlugPart* CN3FXPlug::FXPPartAdd()
 
 void CN3FXPlug::FXPPartDelete(int nIndex)
 {
-	if (nIndex<0 || nIndex>m_FXPParts.size()) return;
+	if (nIndex < 0
+		|| nIndex >= static_cast<int>(m_FXPParts.size()))
+		return;
 
 	std::vector<CN3FXPlugPart*>::iterator itor = m_FXPParts.begin();
 	for (int i=0; i<nIndex; ++i) ++itor;

--- a/Client/N3Base/N3FXShape.cpp
+++ b/Client/N3Base/N3FXShape.cpp
@@ -73,23 +73,31 @@ void CN3FXSPart::TexAlloc(int nCount)
 	m_TexRefs.assign(nCount, NULL);
 }
 
-CN3Texture* CN3FXSPart::Tex(size_t iIndex)
+CN3Texture* CN3FXSPart::Tex(int iIndex)
 {
-	if (iIndex >= m_TexRefs.size()) return NULL;
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_TexRefs.size()))
+		return nullptr;
+
 	return m_TexRefs[iIndex];
 }
 
-CN3Texture* CN3FXSPart::TexSet(size_t iIndex, const std::string& szFN)
+CN3Texture* CN3FXSPart::TexSet(int iIndex, const std::string& szFN)
 {
-	if (iIndex >= m_TexRefs.size()) return NULL;
+	if (iIndex >= static_cast<int>(m_TexRefs.size()))
+		return nullptr;
+
 	s_MngTex.Delete(&m_TexRefs[iIndex]);
 	m_TexRefs[iIndex] = s_MngTex.Get(szFN);
 	return m_TexRefs[iIndex];
 }
 
-void CN3FXSPart::TexSet(size_t iIndex, CN3Texture* pTex)
+void CN3FXSPart::TexSet(int iIndex, CN3Texture* pTex)
 {
-	if (iIndex >= m_TexRefs.size()) return;
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_TexRefs.size()))
+		return;
+
 	s_MngTex.Delete(&m_TexRefs[iIndex]);
 }
 
@@ -419,9 +427,10 @@ bool CN3FXShape::Save(HANDLE hFile)
 	return true;
 }
 
-void CN3FXShape::PartDelete(size_t iIndex)
+void CN3FXShape::PartDelete(int iIndex)
 {
-	if (iIndex >= m_Parts.size())
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_Parts.size()))
 		return;
 
 	auto it = m_Parts.begin();

--- a/Client/N3Base/N3FXShape.h
+++ b/Client/N3Base/N3FXShape.h
@@ -40,11 +40,15 @@ public:
 	bool Save(HANDLE hFile);
 	void Duplicate(CN3FXSPart* pSrc);
 		
-	size_t			TexCount() { return m_TexRefs.size(); }
-	CN3Texture* Tex(size_t iIndex);	
+	int TexCount() const
+	{
+		return static_cast<int>(m_TexRefs.size());
+	}
+
+	CN3Texture* Tex(int iIndex);
 	void		TexAlloc(int nCount);
-	CN3Texture*	TexSet(size_t iIndex, const std::string& szFN);
-	void		TexSet(size_t iIndex, CN3Texture* pTex);
+	CN3Texture* TexSet(int iIndex, const std::string& szFN);
+	void		TexSet(int iIndex, CN3Texture* pTex);
 
 	__Vector3 Min() { if(m_FXPMInst.GetMesh()) return m_FXPMInst.GetMesh()->Min() * m_WorldMtx; else return __Vector3(0,0,0); } // 월드 상의 최소값
 	__Vector3 Max() { if(m_FXPMInst.GetMesh()) return m_FXPMInst.GetMesh()->Max() * m_WorldMtx; else return __Vector3(0,0,0); } // 월드 상의 최대값
@@ -76,14 +80,14 @@ public:
 	__Matrix44		m_mtxParent;
 	__Matrix44		m_mtxFinalTransform;
 
-	uint32_t			m_dwSrcBlend;
-	uint32_t			m_dwDestBlend;
+	uint32_t		m_dwSrcBlend;
+	uint32_t		m_dwDestBlend;
 	BOOL			m_bAlpha;
 
-	uint32_t			m_dwZEnable;
-	uint32_t			m_dwZWrite;
-	uint32_t			m_dwLight;
-	uint32_t			m_dwDoubleSide;
+	uint32_t		m_dwZEnable;
+	uint32_t		m_dwZWrite;
+	uint32_t		m_dwLight;
+	uint32_t		m_dwDoubleSide;
 	
 public:
 	void			SetPartsMtl(BOOL bAlpha, uint32_t dwSrcBlend, uint32_t dwDestBlend, uint32_t dwZEnable, uint32_t dwZWrite, uint32_t dwLight, uint32_t dwDoubleSide);
@@ -95,10 +99,28 @@ public:
 
 	void			FindMinMax();
 
-	CN3FXSPart*		Part(size_t iIndex) { if (iIndex >= m_Parts.size()) return NULL; return m_Parts[iIndex]; }
-	CN3FXSPart*		PartAdd() { CN3FXSPart* pPart = new CN3FXSPart(); m_Parts.push_back(pPart); return pPart; }
-	size_t			PartCount() { return m_Parts.size(); }
-	void			PartDelete(size_t iIndex);
+	int PartCount() const
+	{
+		return static_cast<int>(m_Parts.size());
+	}
+
+	CN3FXSPart* Part(int iIndex)
+	{
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_Parts.size()))
+			return nullptr;
+
+		return m_Parts[iIndex];
+	}
+
+	CN3FXSPart* PartAdd()
+	{
+		CN3FXSPart* pPart = new CN3FXSPart();
+		m_Parts.push_back(pPart);
+		return pPart;
+	}
+
+	void	PartDelete(int iIndex);
 	
 	bool	Load(HANDLE hFile);
 	bool	Save(HANDLE hFile);

--- a/Client/N3Base/N3Joint.h
+++ b/Client/N3Base/N3Joint.h
@@ -46,21 +46,33 @@ public:
 	void ReCalcMatrixBlended(float fFrm0, float fFrm1, float fWeight0);
 	void ParentSet(CN3Joint* pParent);
 	void ChildAdd(CN3Joint* pChild);
-	CN3Joint* Parent() { return m_pParent; }
-	int ChildCount() { return m_Children.size(); }
-	CN3Joint* Child(size_t index)
+
+	CN3Joint* Parent()
 	{
-		if (index > m_Children.size()) return NULL;
+		return m_pParent;
+	}
+
+	int ChildCount() const
+	{
+		return static_cast<int>(m_Children.size());
+	}
+
+	CN3Joint* Child(int index)
+	{
+		if (index < 0
+			|| index >= static_cast<int>(m_Children.size()))
+			return nullptr;
+
 		auto it = m_Children.begin();
 		std::advance(it, index);
 		return *it;
 	}
 
-	void NodeCount(int &nCount);
+	void NodeCount(int& nCount);
 	BOOL FindPointerByID(int nID, CN3Joint *&pJoint);
 #ifdef _N3TOOL
-	BOOL FindIndex(const std::string& szName, int &nIndex);
-	BOOL FindPointerByName(const std::string& szName, CN3Joint *&pJoint); // 이름을 넣으면 해당 노드의 포인터를 돌려준다..
+	BOOL FindIndex(const std::string& szName, int& nIndex);
+	BOOL FindPointerByName(const std::string& szName, CN3Joint*& pJoint); // 이름을 넣으면 해당 노드의 포인터를 돌려준다..
 	void RotSet(const __Quaternion& qtRot) { m_qRot = qtRot; this->ReCalcMatrix(); }
 	void RotSet(float x, float y, float z, float w) { m_qRot.x = x; m_qRot.y = y; m_qRot.z = z; m_qRot.w = w; this->ReCalcMatrix(); }
 	void Render(const __Matrix44* pMtxParent = NULL, float fUnitSize = 0.1f);

--- a/Client/N3Base/N3Mng.h
+++ b/Client/N3Base/N3Mng.h
@@ -73,7 +73,9 @@ public:
 
 	T* 	Get(int index, bool bIncreaseRefCount = TRUE)
 	{
-		if(index < 0 || index >= m_Datas.size()) return NULL;
+		if (index < 0
+			|| index >= static_cast<int>(m_Datas.size()))
+			return nullptr;
 
 		if(bIncreaseRefCount)
 		{

--- a/Client/N3Base/N3PMeshInstance.cpp
+++ b/Client/N3Base/N3PMeshInstance.cpp
@@ -352,11 +352,15 @@ int CN3PMeshInstance::GetIndexByiOrder(int iOrder)
 	return m_pIndices[iOrder];
 }
 
-__Vector3 CN3PMeshInstance::GetVertexByIndex(size_t iIndex)
+__Vector3 CN3PMeshInstance::GetVertexByIndex(int iIndex)
 {
-	__Vector3 vec; vec.Zero();
-	if (iIndex > (size_t)GetNumVertices())
+	if (iIndex < 0
+		|| iIndex >= GetNumVertices())
+	{
+		__Vector3 vec;
+		vec.Zero();
 		return vec;
+	}
 
 	return GetMesh()->m_pVertices[iIndex];
 }

--- a/Client/N3Base/N3PMeshInstance.h
+++ b/Client/N3Base/N3PMeshInstance.h
@@ -61,8 +61,8 @@ public:
 //	By : Ecli666 ( On 2002-08-06 오후 4:33:04 )
 //
 	void			PartialRender(int iCount, uint16_t* pIndices);
-	int				 GetIndexByiOrder(int iOrder);
-__Vector3		GetVertexByIndex(size_t iIndex);
+	int				GetIndexByiOrder(int iOrder);
+	__Vector3		GetVertexByIndex(int iIndex);
 //	~(By Ecli666 On 2002-08-06 오후 4:33:04 )
 };
 

--- a/Client/N3Base/N3Scene.cpp
+++ b/Client/N3Base/N3Scene.cpp
@@ -164,64 +164,63 @@ bool CN3Scene::Load(HANDLE hFile)
 
 bool CN3Scene::Save(HANDLE hFile)
 {
-	::CreateDirectory("Data", NULL);
-	::CreateDirectory("Chr", NULL);
-	::CreateDirectory("Object", NULL);
-	::CreateDirectory("Item", NULL);
+	::CreateDirectory("Data", nullptr);
+	::CreateDirectory("Chr", nullptr);
+	::CreateDirectory("Object", nullptr);
+	::CreateDirectory("Item", nullptr);
 
 	DWORD dwRWC = 0;
 	
-	WriteFile(hFile, &m_nCameraActive, 4, &dwRWC, NULL);
-	WriteFile(hFile, &m_fFrmCur, 4, &dwRWC, NULL); // Animation Frame;
-	WriteFile(hFile, &m_fFrmStart, 4, &dwRWC, NULL); // 전체 프레임.
-	WriteFile(hFile, &m_fFrmEnd, 4, &dwRWC, NULL); // 전체 프레임.
-
-	int i = 0, nL = 0;
+	WriteFile(hFile, &m_nCameraActive, 4, &dwRWC, nullptr);
+	WriteFile(hFile, &m_fFrmCur, 4, &dwRWC, nullptr); // Animation Frame;
+	WriteFile(hFile, &m_fFrmStart, 4, &dwRWC, nullptr); // 전체 프레임.
+	WriteFile(hFile, &m_fFrmEnd, 4, &dwRWC, nullptr); // 전체 프레임.
 	
-	WriteFile(hFile, &m_nCameraCount, 4, &dwRWC, NULL); // 카메라..
-	for(i = 0; i < m_nCameraCount; i++)
+	WriteFile(hFile, &m_nCameraCount, 4, &dwRWC, nullptr); // 카메라..
+	for (CN3Camera* camera : m_pCameras)
 	{
-		nL = m_pCameras[i]->FileName().size();
-		WriteFile(hFile, &nL, 4, &dwRWC, NULL);
-		WriteFile(hFile, m_pCameras[i]->FileName().c_str(), nL, &dwRWC, NULL);
-		m_pCameras[i]->SaveToFile();
+		int nL = static_cast<int>(camera->FileName().size());
+		WriteFile(hFile, &nL, 4, &dwRWC, nullptr);
+		WriteFile(hFile, camera->FileName().c_str(), nL, &dwRWC, nullptr);
+		camera->SaveToFile();
 	}
 
-	WriteFile(hFile, &m_nLightCount, 4, &dwRWC, NULL); // 카메라..
-	for(i = 0; i < m_nLightCount; i++) 
+	WriteFile(hFile, &m_nLightCount, 4, &dwRWC, nullptr); // 카메라..
+	for (CN3Light* light : m_pLights)
 	{
-		nL = m_pLights[i]->FileName().size();
-		WriteFile(hFile, &nL, 4, &dwRWC, NULL);
-		WriteFile(hFile, m_pLights[i]->FileName().c_str(), nL, &dwRWC, NULL);
-		m_pLights[i]->SaveToFile();
+		int nL = static_cast<int>(light->FileName().size());
+		WriteFile(hFile, &nL, 4, &dwRWC, nullptr);
+		WriteFile(hFile, light->FileName().c_str(), nL, &dwRWC, nullptr);
+		light->SaveToFile();
 	}
 
-	int iSC = m_Shapes.size();
-	WriteFile(hFile, &iSC, 4, &dwRWC, NULL); // Shapes..
-	for(i = 0; i < iSC; i++)
+	int iSC = static_cast<int>(m_Shapes.size());
+	WriteFile(hFile, &iSC, 4, &dwRWC, nullptr); // Shapes..
+	for (CN3Shape* shape : m_Shapes)
 	{
-		nL = m_Shapes[i]->FileName().size();
-		WriteFile(hFile, &nL, 4, &dwRWC, NULL);
-		if(nL <= 0) continue;
+		int nL = static_cast<int>(shape->FileName().size());
+		WriteFile(hFile, &nL, 4, &dwRWC, nullptr);
+		if (nL <= 0)
+			continue;
 
-		WriteFile(hFile, m_Shapes[i]->FileName().c_str(), nL, &dwRWC, NULL);
-		m_Shapes[i]->SaveToFile();
+		WriteFile(hFile, shape->FileName().c_str(), nL, &dwRWC, nullptr);
+		shape->SaveToFile();
 	}
 
-	int iCC = m_Chrs.size();
-	WriteFile(hFile, &iCC, 4, &dwRWC, NULL); // 캐릭터
-	for(i = 0; i < iCC; i++)
+	int iCC = static_cast<int>(m_Chrs.size());
+	WriteFile(hFile, &iCC, 4, &dwRWC, nullptr); // 캐릭터
+	for (CN3Chr* chr : m_Chrs)
 	{
-		nL = m_Chrs[i]->FileName().size();
-		WriteFile(hFile, &nL, 4, &dwRWC, NULL);
-		if(nL <= 0) continue;
+		int nL = chr->FileName().size();
+		WriteFile(hFile, &nL, 4, &dwRWC, nullptr);
+		if (nL <= 0)
+			continue;
 
-		WriteFile(hFile, m_Chrs[i]->FileName().c_str(), nL, &dwRWC, NULL);
-		m_Chrs[i]->SaveToFile();
+		WriteFile(hFile, chr->FileName().c_str(), nL, &dwRWC, nullptr);
+		chr->SaveToFile();
 	}
 
 	CN3Base::SaveResrc(); // Resource 를 파일로 저장한다..
-
 	return true;
 }
 
@@ -241,61 +240,61 @@ void CN3Scene::Render()
 //	}
 	s_lpD3DDev->SetRenderState(D3DRS_AMBIENT, m_AmbientLightColor);
 
-	int iSC = m_Shapes.size();
-	for(i = 0; i < iSC; i++)
-	{
-		m_Shapes[i]->Render();
-	}
+	for (CN3Shape* shape : m_Shapes)
+		shape->Render();
 
-	int iCC = m_Chrs.size();
-	for(i = 0; i < iCC; i++)
-	{
-		m_Chrs[i]->Render();
-	}
+	for (CN3Chr* chr : m_Chrs)
+		chr->Render();
 }
 
 void CN3Scene::Tick(float fFrm)
 {
-	if(FRAME_SELFPLAY == fFrm || fFrm <  m_fFrmStart || fFrm > m_fFrmEnd)
+	if (FRAME_SELFPLAY == fFrm
+		|| fFrm < m_fFrmStart
+		|| fFrm > m_fFrmEnd)
 	{
 		m_fFrmCur += 30.0f / CN3Base::s_fFrmPerSec; // 일정하게 움직이도록 시간에 따라 움직이는 양을 조절..
-		if(m_fFrmCur > m_fFrmEnd) m_fFrmCur = m_fFrmStart;
+		if (m_fFrmCur > m_fFrmEnd)
+			m_fFrmCur = m_fFrmStart;
 	}
 	else
 	{
 		m_fFrmCur = fFrm;
 	}
 
-	this->TickCameras(m_fFrmCur);
-	this->TickLights(m_fFrmCur);
-	this->TickShapes(m_fFrmCur);
-	this->TickChrs(m_fFrmCur);
+	TickCameras(m_fFrmCur);
+	TickLights(m_fFrmCur);
+	TickShapes(m_fFrmCur);
+	TickChrs(m_fFrmCur);
 }
 
 void CN3Scene::TickCameras(float fFrm)
 {
-	for(int i = 0; i < m_nCameraCount; i++)
+	for (int i = 0; i < m_nCameraCount; i++)
 	{
 		m_pCameras[i]->Tick(m_fFrmCur);
-		if(m_nCameraActive == i) m_pCameras[i]->Apply(); // 카메라 데이터 값을 적용한다..
+		if (m_nCameraActive == i)
+			m_pCameras[i]->Apply(); // 카메라 데이터 값을 적용한다..
 	}
 }
 
 void CN3Scene::TickLights(float fFrm)
 {
-	for(int i = 0; i < 8; i++) s_lpD3DDev->LightEnable(i, FALSE); // 일단 라이트 다 끄고..
-	
-	for(int i = 0; i < m_nLightCount; i++)
+	for (int i = 0; i < 8; i++)
+		s_lpD3DDev->LightEnable(i, FALSE); // 일단 라이트 다 끄고..
+
+	for (int i = 0; i < m_nLightCount; i++)
 	{
 		m_pLights[i]->Tick(m_fFrmCur);
 		m_pLights[i]->Apply(); // 라이트 적용
 	}
 
 	// 라이트가 항상 카메라를 따라오게 만든다..
-	if(false == m_bDisableDefaultLight)
+	if (!m_bDisableDefaultLight)
 	{
 		__Vector3 vDir = s_CameraData.vAt - s_CameraData.vEye;
 		vDir.Normalize();
+
 		D3DCOLORVALUE crLgt = { 1.0f, 1.0f, 1.0f, 1.0f };
 
 		CN3Light::__Light lgt;
@@ -315,28 +314,26 @@ void CN3Scene::TickLights(float fFrm)
 
 void CN3Scene::TickShapes(float fFrm)
 {
-	int iSC = m_Shapes.size();
-	for(int i = 0; i < iSC; i++)
-	{
-		m_Shapes[i]->Tick(m_fFrmCur);
-	}
+	for (CN3Shape* shape : m_Shapes)
+		shape->Tick(m_fFrmCur);
 }
 
 void CN3Scene::TickChrs(float fFrm)
 {
-	int iCC = m_Chrs.size();
-	for(int i = 0; i < iCC; i++)
-	{
-		m_Chrs[i]->Tick(m_fFrmCur);
-	}
+	for (CN3Chr* chr : m_Chrs)
+		chr->Tick(m_fFrmCur);
 }
 
-int CN3Scene::CameraAdd(CN3Camera *pCamera)
+int CN3Scene::CameraAdd(CN3Camera* pCamera)
 {
-	if(m_nCameraCount >= MAX_SCENE_CAMERA) return -1;
-	if(NULL == pCamera) return -1;
+	if (m_nCameraCount < 0
+		|| m_nCameraCount >= MAX_SCENE_CAMERA)
+		return -1;
 
-	if(m_pCameras[m_nCameraCount]) delete m_pCameras[m_nCameraCount];
+	if (pCamera == nullptr)
+		return -1;
+
+	delete m_pCameras[m_nCameraCount];
 	m_pCameras[m_nCameraCount] = pCamera;
 
 	m_nCameraCount++;
@@ -355,13 +352,13 @@ void CN3Scene::CameraDelete(int iIndex)
 	m_pCameras[m_nCameraCount] = NULL;
 }
 
-void CN3Scene::CameraDelete(CN3Camera *pCamera)
+void CN3Scene::CameraDelete(CN3Camera* pCamera)
 {
-	for(int i = 0; i < m_nCameraCount; i++) 
+	for (int i = 0; i < m_nCameraCount; i++)
 	{
-		if(m_pCameras[i] == pCamera) 
+		if (m_pCameras[i] == pCamera)
 		{
-			this->CameraDelete(i);
+			CameraDelete(i);
 			break;
 		}
 	}
@@ -369,16 +366,19 @@ void CN3Scene::CameraDelete(CN3Camera *pCamera)
 
 void CN3Scene::CameraSetActive(int iIndex)
 {
-	if(iIndex < 0 || iIndex >= m_nCameraCount) return;
-	
+	if (iIndex < 0
+		|| iIndex >= m_nCameraCount)
+		return;
+
 	m_nCameraActive = iIndex;
 }
 
-int CN3Scene::LightAdd(CN3Light *pLight)
+int CN3Scene::LightAdd(CN3Light* pLight)
 {
-	if(NULL == pLight) return -1;
+	if (pLight == nullptr)
+		return -1;
 
-	if(m_pLights[m_nLightCount]) delete m_pLights[m_nLightCount];
+	delete m_pLights[m_nLightCount];
 	m_pLights[m_nLightCount] = pLight;
 
 	m_nLightCount++;
@@ -387,39 +387,45 @@ int CN3Scene::LightAdd(CN3Light *pLight)
 
 void CN3Scene::LightDelete(int iIndex)
 {
-	if(iIndex < 0 || iIndex >= m_nLightCount) return;
+	if (iIndex < 0
+		|| iIndex >= m_nLightCount)
+		return;
 
 	delete m_pLights[iIndex];
-	m_pLights[iIndex] = NULL;
-	
+	m_pLights[iIndex] = nullptr;
+
 	m_nLightCount--;
-	for(int i = iIndex; i < m_nLightCount; i++) m_pLights[i] = m_pLights[i+1];
-	m_pLights[m_nLightCount] = NULL;
+	for (int i = iIndex; i < m_nLightCount; i++)
+		m_pLights[i] = m_pLights[i + 1];
+
+	m_pLights[m_nLightCount] = nullptr;
 }
 
-void CN3Scene::LightDelete(CN3Light *pLight)
+void CN3Scene::LightDelete(CN3Light* pLight)
 {
-	for(int i = 0; i < m_nLightCount; i++) 
+	for (int i = 0; i < m_nLightCount; i++)
 	{
-		if(m_pLights[i] == pLight) 
+		if (m_pLights[i] == pLight)
 		{
-			this->LightDelete(i);
+			LightDelete(i);
 			break;
 		}
 	}
 }
 
-int CN3Scene::ShapeAdd(CN3Shape *pShape)
+int CN3Scene::ShapeAdd(CN3Shape* pShape)
 {
-	if(NULL == pShape) return -1;
-	m_Shapes.push_back(pShape);
+	if (pShape == nullptr)
+		return -1;
 
-	return m_Shapes.size();
+	m_Shapes.push_back(pShape);
+	return static_cast<int>(m_Shapes.size());
 }
 
-void CN3Scene::ShapeDelete(size_t iIndex)
+void CN3Scene::ShapeDelete(int iIndex)
 {
-	if (iIndex >= m_Shapes.size())
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_Shapes.size()))
 		return;
 
 	auto it = m_Shapes.begin();
@@ -431,11 +437,11 @@ void CN3Scene::ShapeDelete(size_t iIndex)
 
 void CN3Scene::ShapeDelete(CN3Shape* pShape)
 {
-	it_Shape it = m_Shapes.begin(), itEnd = m_Shapes.end();
-	for(; it != itEnd; it++)
+	auto it = m_Shapes.begin(), itEnd = m_Shapes.end();
+	for (; it != itEnd; it++)
 	{
 		CN3Shape* pShapeSrc = *it;
-		if(pShapeSrc == pShape)
+		if (pShapeSrc == pShape)
 		{
 			delete pShapeSrc;
 			it = m_Shapes.erase(it);
@@ -446,23 +452,25 @@ void CN3Scene::ShapeDelete(CN3Shape* pShape)
 
 void CN3Scene::ShapeRelease()
 {
-	for (auto itr = m_Shapes.begin(); itr != m_Shapes.end(); ++itr)
-		delete *itr;
+	for (CN3Shape* shape : m_Shapes)
+		delete shape;
 
 	m_Shapes.clear();
 }
 
-int CN3Scene::ChrAdd(CN3Chr *pChr)
+int CN3Scene::ChrAdd(CN3Chr* pChr)
 {
-	if(NULL == pChr) return -1;
-	m_Chrs.push_back(pChr);
+	if (pChr == nullptr)
+		return -1;
 
-	return m_Chrs.size();
+	m_Chrs.push_back(pChr);
+	return static_cast<int>(m_Chrs.size());
 }
 
-void CN3Scene::ChrDelete(size_t iIndex)
+void CN3Scene::ChrDelete(int iIndex)
 {
-	if (iIndex >= m_Chrs.size())
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_Chrs.size()))
 		return;
 
 	auto it = m_Chrs.begin();

--- a/Client/N3Base/N3Scene.h
+++ b/Client/N3Base/N3Scene.h
@@ -59,52 +59,74 @@ public:
 	void TickChrs(float fFrm = FRAME_SELFPLAY);
 	void Render();
 	
+	int	CameraCount() const
+	{
+		return m_nCameraCount;
+	}
+
 	int	 CameraAdd(CN3Camera *pCamera);
 	void CameraDelete(CN3Camera* pCamera);
 	void CameraDelete(int iIndex);
-	int	 CameraCount() { return m_nCameraCount; }
 	CN3Camera* CameraGet(int iIndex) { if(iIndex < 0 || iIndex >= m_nCameraCount) return NULL; return m_pCameras[iIndex]; }
 	
 	void CameraSetActive(int iIndex);
 	int	 CameraGetActiveNumber() { return m_nCameraActive; };
 	CN3Camera* CameraGetActive() { if(m_nCameraActive < 0 || m_nCameraActive >= m_nCameraCount) return NULL; return m_pCameras[m_nCameraActive]; }
 
+	int	 LightCount() const
+	{
+		return m_nLightCount;
+	}
+
 	int	 LightAdd(CN3Light* pLight);
 	void LightDelete(CN3Light* pLight);
 	void LightDelete(int iIndex);
-	int	 LightCount() { return m_nLightCount; }
 	CN3Light* LightGet(int iIndex) { if(iIndex < 0 || iIndex >= m_nLightCount) return NULL; return m_pLights[iIndex]; }
+
+	int ShapeCount() const
+	{
+		return static_cast<int>(m_Shapes.size());
+	}
 
 	int	 ShapeAdd(CN3Shape* pShape);
 	void ShapeDelete(CN3Shape* pShape);
-	void ShapeDelete(size_t iIndex);
-	size_t	 ShapeCount() { return m_Shapes.size(); }
-	CN3Shape* ShapeGet(size_t iIndex)
+	void ShapeDelete(int iIndex);
+	CN3Shape* ShapeGet(int iIndex)
 	{
-		if (iIndex >= m_Shapes.size()) return NULL;
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_Shapes.size()))
+			return nullptr;
+
 		return m_Shapes[iIndex];
 	}
-	CN3Shape* ShapeGetByFileName(std::string& str)
+
+	CN3Shape* ShapeGetByFileName(const std::string& str)
 	{
-		for (auto itr = m_Shapes.begin(); itr != m_Shapes.end(); ++itr)
+		for (CN3Shape* shape : m_Shapes)
 		{
-			auto shape = *itr;
 			if (str == shape->FileName())
 				return shape;
 		}
 
-		return NULL;
+		return nullptr;
 	}
 
 	void ShapeRelease();
 
-	int	 ChrAdd(CN3Chr* pChr);
-	void ChrDelete(size_t iIndex);
-	void ChrDelete(CN3Chr* pChr);
-	size_t	 ChrCount() { return m_Chrs.size(); }
-	CN3Chr* ChrGet(size_t iIndex)
+	int ChrCount() const
 	{
-		if (iIndex >= m_Chrs.size()) return NULL;
+		return static_cast<int>(m_Chrs.size());
+	}
+
+	int	 ChrAdd(CN3Chr* pChr);
+	void ChrDelete(int iIndex);
+	void ChrDelete(CN3Chr* pChr);
+	CN3Chr* ChrGet(int iIndex)
+	{
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_Chrs.size()))
+			return nullptr;
+
 		return m_Chrs[iIndex];
 	}
 
@@ -117,7 +139,6 @@ public:
 
 	CN3Scene();
 	virtual ~CN3Scene();
-
 };
 
 #endif // !defined(AFX_N3Scene_h__INCLUDED_)

--- a/Client/N3Base/N3Shape.cpp
+++ b/Client/N3Base/N3Shape.cpp
@@ -683,9 +683,10 @@ bool CN3Shape::Save(HANDLE hFile)
 }
 #endif // end of _N3TOOL
 
-void CN3Shape::PartDelete(size_t iIndex)
+void CN3Shape::PartDelete(int iIndex)
 {
-	if (iIndex >= m_Parts.size())
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_Parts.size()))
 		return;
 
 	auto it = m_Parts.begin();
@@ -697,7 +698,10 @@ void CN3Shape::PartDelete(size_t iIndex)
 #ifdef _N3TOOL
 void CN3Shape::RenderSelected(int iPart, bool bWireFrame)
 {
-	if(iPart < 0 || iPart >= m_Parts.size()) return;
+	if (iPart < 0
+		|| iPart >= static_cast<int>(m_Parts.size()))
+		return;
+
 	m_Parts[iPart]->RenderSelected(bWireFrame);
 }
 #endif // end of _N3TOOL
@@ -1180,33 +1184,35 @@ void CN3Shape::SetMaxLOD()
 	}
 }
 
-__Matrix44	CN3Shape::GetPartMatrix(size_t iPartIndex)
+__Matrix44 CN3Shape::GetPartMatrix(int iPartIndex) const
 {
 	return m_Parts[iPartIndex]->m_Matrix;
 }
 
-void CN3Shape::PartialRender(size_t iPartIndex, int iCount, uint16_t* pIndices)
+void CN3Shape::PartialRender(int iPartIndex, int iCount, uint16_t* pIndices)
 {
-	if (iPartIndex >= m_Parts.size())
+	if (iPartIndex < 0
+		|| iPartIndex >= static_cast<int>(m_Parts.size()))
 		return;
 
 	m_Parts[iPartIndex]->PartialRender(iCount, pIndices);
 }
 
-int	CN3Shape::GetIndexbufferCount(size_t iPartIndex)
+int	CN3Shape::GetIndexbufferCount(int iPartIndex)
 {
-	if (iPartIndex >= m_Parts.size())
+	if (iPartIndex < 0
+		|| iPartIndex >= static_cast<int>(m_Parts.size()))
 		return 0;
 	
 	return m_Parts[iPartIndex]->MeshInstance()->GetNumIndices();
 }
 
-int CN3Shape::GetIndexByiOrder(size_t iPartIndex, int iOrder)
+int CN3Shape::GetIndexByiOrder(int iPartIndex, int iOrder)
 {
 	return m_Parts[iPartIndex]->MeshInstance()->GetIndexByiOrder(iOrder);
 }
 
-__Vector3	CN3Shape::GetVertexByIndex(size_t iPartIndex, int iIndex)
+__Vector3 CN3Shape::GetVertexByIndex(int iPartIndex, int iIndex)
 {
 	return m_Parts[iPartIndex]->MeshInstance()->GetVertexByIndex(iIndex);
 }

--- a/Client/N3Base/N3Shape.h
+++ b/Client/N3Base/N3Shape.h
@@ -48,27 +48,41 @@ public:
 	virtual bool Save(HANDLE hFile);
 #endif // end of _N3TOOL
 	
-	size_t			TexCount() { return m_TexRefs.size(); }
-	CN3Texture* Tex(size_t iIndex)
+	int TexCount() const
 	{
-		if (iIndex >= m_TexRefs.size()) return NULL;
+		return static_cast<int>(m_TexRefs.size());
+	}
+
+	CN3Texture* Tex(int iIndex)
+	{
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_TexRefs.size()))
+			return nullptr;
+
 		return m_TexRefs[iIndex];
 	}
+
 	void		TexAlloc(int nCount);
-	CN3Texture*	TexSet(size_t iIndex, const std::string& szFN)
+	CN3Texture* TexSet(int iIndex, const std::string& szFN)
 	{
-		if (iIndex >= m_TexRefs.size()) return NULL;
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_TexRefs.size()))
+			return nullptr;
+
 		s_MngTex.Delete(&m_TexRefs[iIndex]);
 		m_TexRefs[iIndex] = s_MngTex.Get(szFN, true, s_Options.iTexLOD_Shape);
 		return m_TexRefs[iIndex];
 	}
-	void	TexSet(size_t iIndex, CN3Texture* pTex)
+
+	void TexSet(int iIndex, CN3Texture* pTex)
 	{
-		if (iIndex >= m_TexRefs.size()) return;
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_TexRefs.size()))
+			return;
+
 		s_MngTex.Delete(&m_TexRefs[iIndex]);
 		m_TexRefs[iIndex] = pTex;
 	}
-
 
 	CN3PMeshInstance*	MeshInstance() { return &m_PMInst; } 
 	CN3PMesh*			Mesh() { return m_PMInst.GetMesh(); }
@@ -129,10 +143,22 @@ public:
 	virtual void	Tick(float fFrm = FRAME_SELFPLAY);
 	virtual void	Render();
 
-	CN3SPart*		Part(size_t iIndex) { if (iIndex >= m_Parts.size()) return NULL; return m_Parts[iIndex]; }
+	int PartCount() const
+	{
+		return static_cast<int>(m_Parts.size());
+	}
+
+	CN3SPart* Part(int iIndex)
+	{
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_Parts.size()))
+			return nullptr;
+
+		return m_Parts[iIndex];
+	}
+
 	CN3SPart*		PartAdd() { CN3SPart* pPart = new CN3SPart(); m_Parts.push_back(pPart); return pPart; }
-	size_t			PartCount() { return m_Parts.size(); }
-	void			PartDelete(size_t iIndex);
+	void			PartDelete(int iIndex);
 	
 	bool			Load(HANDLE hFile);
 #ifdef _N3TOOL
@@ -149,14 +175,14 @@ public:
 //	By : Ecli666 ( On 2002-08-06 오후 4:33:04 )
 //
 	void			SetMaxLOD();
-	__Matrix44	GetPartMatrix(size_t iPartIndex);
-	void			PartialRender(size_t iPartIndex, int iCount, uint16_t* pIndices);
-	int				GetIndexbufferCount(size_t iPartIndex);
-	int				GetIndexByiOrder(size_t iPartIndex, int iOrder);
-__Vector3		GetVertexByIndex(size_t iPartIndex, int iIndex);
+	__Matrix44		GetPartMatrix(int iPartIndex) const;
+	void			PartialRender(int iPartIndex, int iCount, uint16_t* pIndices);
+	int				GetIndexbufferCount(int iPartIndex);
+	int				GetIndexByiOrder(int iPartIndex, int iOrder);
+__Vector3			GetVertexByIndex(int iPartIndex, int iIndex);
 	int				GetColIndexbufferCount();
 	int				GetColIndexByiOrder(int iOrder);
-__Vector3	  GetColVertexByIndex(int iIndex); 
+__Vector3			GetColVertexByIndex(int iIndex); 
 	void			PartialColRender(int iCount, int* piIndices);
 	void			PartialGetCollision(int iIndex, __Vector3& vec);
 	bool			LoadTransformOnly(HANDLE hFile);

--- a/Client/N3Base/N3ShapeExtra.cpp
+++ b/Client/N3Base/N3ShapeExtra.cpp
@@ -87,9 +87,10 @@ void CN3ShapeExtra::Tick(float fFrm)
 		this->MakeCollisionMeshByParts(); // 충돌메시를 다시 만든다..
 }
 
-void CN3ShapeExtra::RotateTo(size_t iPart, const __Vector3& vAxis, float fRadianToReach, float fRadianPerSec, bool bImmediately)
+void CN3ShapeExtra::RotateTo(int iPart, const __Vector3& vAxis, float fRadianToReach, float fRadianPerSec, bool bImmediately)
 {
-	if (iPart >= m_Rotations.size())
+	if (iPart < 0
+		|| iPart >= static_cast<int>(m_Rotations.size()))
 		return;
 
 	__Rotation* pRot = &(m_Rotations[iPart]);

--- a/Client/N3Base/N3ShapeExtra.h
+++ b/Client/N3Base/N3ShapeExtra.h
@@ -36,7 +36,7 @@ protected:
 	std::vector<__Rotation>	m_Rotations;
 
 public:
-	void RotateTo(size_t iPart, const __Vector3& vAxis, float fRadianToReach, float fRadianPerSec, bool bImmediately = false); // 원하는 파트를 축에 따라 지정한 각도까지 지정한 속도로 회전시킨다..
+	void RotateTo(int iPart, const __Vector3& vAxis, float fRadianToReach, float fRadianPerSec, bool bImmediately = false); // 원하는 파트를 축에 따라 지정한 각도까지 지정한 속도로 회전시킨다..
 
 	bool Load(HANDLE hFile);
 	void Tick(float fFrm);

--- a/Client/N3Base/N3SkyMng.h
+++ b/Client/N3Base/N3SkyMng.h
@@ -129,10 +129,10 @@ protected:
 	class CN3ColorChange*	m_pLightColorAmbients[MAX_GAME_LIGHT];
 
 	std::vector<__SKY_DAYCHANGE> m_DayChanges;		// 정보입력후에 qsort하자
-	size_t					m_iDayChangeCurPos;
+	int						m_iDayChangeCurPos;
 
 	std::vector<__SKY_DAYCHANGE> m_WeatherChanges;		// 정보입력후에 qsort하자
-	size_t					m_iWeatherChangeCurPos;
+	int						m_iWeatherChangeCurPos;
 
 	uint32_t		m_dwCheckTick;	// 서버에서 시간을 받을때의 윈도우TickCount(실시간) (게임시간으로 24시에 다시 설정하기도 한다.)
 	uint32_t		m_dwCheckGameTime;	// 서버에서 내려받은 시간(게임 시간 초단위) 0 ~ (24*60*60)

--- a/Client/N3Base/N3TableBase.h
+++ b/Client/N3Base/N3TableBase.h
@@ -41,31 +41,41 @@ public:
 	}
 
 	void	Release();
-	Type*	Find(uint32_t dwID) // ID로 data 찾기
+
+	Type* Find(uint32_t dwID) // ID로 data 찾기
 	{
 		auto it = m_Datas.find(dwID);
-		if(it == m_Datas.end()) return NULL; // 찾기에 실패 했다!~!!
-		else return &(it->second);
+		if (it == m_Datas.end())
+			return nullptr; // 찾기에 실패 했다!~!!
+		
+		return &it->second;
 	}
-	size_t	GetSize() { return m_Datas.size(); }
-	Type*	GetIndexedData(size_t index)	//index로 찾기..
+
+	int GetSize() const
 	{
-		if (m_Datas.empty()) return NULL;
-		if (index >= m_Datas.size()) return NULL;
+		return static_cast<int>(m_Datas.size());
+	}
+
+	Type* GetIndexedData(int index)	//index로 찾기..
+	{
+		if (index < 0
+			|| index >= static_cast<int>(m_Datas.size()))
+			return nullptr;
 		
 		auto it = m_Datas.begin();
 		std::advance(it, index);
-		return &(it->second);
+		return &it->second;
 	}
-	bool	IDToIndex(uint32_t dwID, size_t * index) // 해당 ID의 Index 리턴..	Skill에서 쓴다..
+
+	bool IDToIndex(uint32_t dwID, int* index) // 해당 ID의 Index 리턴..	Skill에서 쓴다..
 	{
 		auto it = m_Datas.find(dwID);
 		if (it == m_Datas.end())
 			return false; // 찾기에 실패 했다!~!!
 
 		auto itSkill = m_Datas.begin();
-		size_t iSize = m_Datas.size();
-		for (size_t i = 0; i < iSize; i++, itSkill++)
+		int iSize = static_cast<int>(m_Datas.size());
+		for (int i = 0; i < iSize; i++, itSkill++)
 		{
 			if (itSkill == it)
 			{
@@ -76,7 +86,9 @@ public:
 
 		return false;
 	}
+
 	BOOL	LoadFromFile(const std::string& szFN);
+
 protected:
 	BOOL	Load(HANDLE hFile);
 	BOOL	WriteData(HANDLE hFile, DATA_TYPE DataType, const char* lpszData);

--- a/Client/N3Base/N3Texture.cpp
+++ b/Client/N3Base/N3Texture.cpp
@@ -336,13 +336,15 @@ bool CN3Texture::Load(HANDLE hFile)
 		{
 			if(iMMC > 1)
 			{
-				if(m_iLOD > 0) // LOD 만큼 건너뛰기...
+				if (m_iLOD > 0) // LOD 만큼 건너뛰기...
 				{
-					size_t iWTmp = HeaderOrg.nWidth, iHTmp = HeaderOrg.nHeight, iSkipSize = 0;
-					for(int i = 0; i < m_iLOD; i++, iWTmp /= 2, iHTmp /= 2)
+					int iWTmp = HeaderOrg.nWidth, iHTmp = HeaderOrg.nHeight, iSkipSize = 0;
+					for (int i = 0; i < m_iLOD; i++, iWTmp /= 2, iHTmp /= 2)
 					{
-						if(D3DFMT_DXT1 == HeaderOrg.Format) iSkipSize += iWTmp * iHTmp / 2; // DXT1 형식은 16비트 포맷에 비해 1/4 로 압축..
-						else iSkipSize += iWTmp * iHTmp; // DXT2 ~ DXT5 형식은 16비트 포맷에 비해 1/2 로 압축..
+						if (D3DFMT_DXT1 == HeaderOrg.Format)
+							iSkipSize += iWTmp * iHTmp / 2; // DXT1 형식은 16비트 포맷에 비해 1/4 로 압축..
+						else
+							iSkipSize += iWTmp * iHTmp; // DXT2 ~ DXT5 형식은 16비트 포맷에 비해 1/2 로 압축..
 					}
 					::SetFilePointer(hFile, iSkipSize, 0, FILE_CURRENT); // 건너뛰고.
 				}
@@ -362,7 +364,7 @@ bool CN3Texture::Load(HANDLE hFile)
 				}
 
 				// 텍스처 압축안되는 비디오 카드를 위한 여분의 데이터 건너뛰기.. 
-				size_t iWTmp = HeaderOrg.nWidth / 2, iHTmp = HeaderOrg.nHeight / 2;
+				int iWTmp = HeaderOrg.nWidth / 2, iHTmp = HeaderOrg.nHeight / 2;
 				for(; iWTmp >= 4 && iHTmp >= 4; iWTmp /= 2, iHTmp /= 2) // 한픽셀에 두바이트가 들어가는 A1R5G5B5 혹은 A4R4G4B4 포맷으로 되어 있다..
 					::SetFilePointer(hFile, iWTmp * iHTmp * 2, 0, FILE_CURRENT); // 건너뛰고.
 			}
@@ -389,11 +391,13 @@ bool CN3Texture::Load(HANDLE hFile)
 			if(iMMC > 1) // LOD 만큼 건너뛰기...
 			{
 				// 압축 데이터 건너뛰기..
-				size_t iWTmp = HeaderOrg.nWidth, iHTmp = HeaderOrg.nHeight, iSkipSize = 0;
-				for(; iWTmp >= 4 && iHTmp >= 4; iWTmp /= 2, iHTmp /= 2)
+				int iWTmp = HeaderOrg.nWidth, iHTmp = HeaderOrg.nHeight, iSkipSize = 0;
+				for (; iWTmp >= 4 && iHTmp >= 4; iWTmp /= 2, iHTmp /= 2)
 				{
-					if(D3DFMT_DXT1 == HeaderOrg.Format) iSkipSize += iWTmp * iHTmp / 2; // DXT1 형식은 16비트 포맷에 비해 1/4 로 압축..
-					else iSkipSize += iWTmp * iHTmp; // DXT2 ~ DXT5 형식은 16비트 포맷에 비해 1/2 로 압축..
+					if (D3DFMT_DXT1 == HeaderOrg.Format)
+						iSkipSize += iWTmp * iHTmp / 2; // DXT1 형식은 16비트 포맷에 비해 1/4 로 압축..
+					else
+						iSkipSize += iWTmp * iHTmp; // DXT2 ~ DXT5 형식은 16비트 포맷에 비해 1/2 로 압축..
 				}
 				::SetFilePointer(hFile, iSkipSize, 0, FILE_CURRENT); // 건너뛰고.
 
@@ -406,7 +410,8 @@ bool CN3Texture::Load(HANDLE hFile)
 				}
 
 				// 비디오 카드 지원 텍스처 크기가 작을경우 건너뛰기..
-				for(; iWTmp > s_DevCaps.MaxTextureWidth || iHTmp > s_DevCaps.MaxTextureHeight; iWTmp /= 2, iHTmp /= 2)
+				for (; iWTmp > static_cast<int>(s_DevCaps.MaxTextureWidth) || iHTmp > static_cast<int>(s_DevCaps.MaxTextureHeight);
+					iWTmp /= 2, iHTmp /= 2)
 					iSkipSize += iWTmp * iHTmp * 2;
 				if(iSkipSize) ::SetFilePointer(hFile, iSkipSize, 0, FILE_CURRENT); // 건너뛰고.
 
@@ -454,10 +459,12 @@ bool CN3Texture::Load(HANDLE hFile)
 			}
 
 			// 비디오 카드 지원 텍스처 크기가 작을경우 건너뛰기..
-			size_t iWTmp = HeaderOrg.nWidth, iHTmp = HeaderOrg.nHeight, iSkipSize = 0;
-			for(; iWTmp > s_DevCaps.MaxTextureWidth || iHTmp > s_DevCaps.MaxTextureHeight; iWTmp /= 2, iHTmp /= 2)
+			int iWTmp = HeaderOrg.nWidth, iHTmp = HeaderOrg.nHeight, iSkipSize = 0;
+			for (; iWTmp > static_cast<int>(s_DevCaps.MaxTextureWidth) || iHTmp > static_cast<int>(s_DevCaps.MaxTextureHeight);
+				iWTmp /= 2, iHTmp /= 2)
 				iSkipSize += iWTmp * iHTmp * iPixelSize;
-			if(iSkipSize) ::SetFilePointer(hFile, iSkipSize, 0, FILE_CURRENT); // 건너뛰고.
+			if (iSkipSize != 0)
+				::SetFilePointer(hFile, iSkipSize, 0, FILE_CURRENT); // 건너뛰고.
 
 			// 데이터 읽기..
 			for (int i = 0; i < iMMC; i++)

--- a/Client/N3Base/N3UIBase.h
+++ b/Client/N3Base/N3UIBase.h
@@ -165,14 +165,22 @@ public:
 	static	bool	EnableTooltip(const std::string& szFN);	// tooltip UI를 초기화 해준다.
 	static	void	DestroyTooltip();	// tooltip ui에 관련된 것을 해제해준다.
 
-	int				GetChildrenCount() { return m_Children.size(); }
-	CN3UIBase*		GetChildByIndex(size_t iIndex)
+	int GetChildrenCount() const
 	{
-		if (iIndex >= m_Children.size()) return NULL;
+		return static_cast<int>(m_Children.size());
+	}
+
+	CN3UIBase* GetChildByIndex(int iIndex)
+	{
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_Children.size()))
+			return nullptr;
+
 		auto it = m_Children.begin();
 		std::advance(it, iIndex);
 		return *it;
 	}
+
 	virtual void	operator = (const CN3UIBase& other);
 
 protected:

--- a/Client/N3Base/N3UIEdit.cpp
+++ b/Client/N3Base/N3UIEdit.cpp
@@ -534,9 +534,10 @@ uint32_t CN3UIEdit::MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT&
 	return dwRet;
 }
 
-void CN3UIEdit::SetCaretPos(UINT nPos)
+void CN3UIEdit::SetCaretPos(uint32_t nPos)
 {
-	if (nPos > m_iMaxStrLen) nPos = m_iMaxStrLen;	// 최대 길이보다 길경우 작게 세팅
+	if (nPos > m_iMaxStrLen)
+		nPos = m_iMaxStrLen;	// 최대 길이보다 길경우 작게 세팅
 	m_nCaretPos = nPos;
 
 	const std::string& szBuff = m_pBuffOutRef->GetString();
@@ -549,15 +550,22 @@ void CN3UIEdit::SetCaretPos(UINT nPos)
 	s_Caret.SetPos(m_pBuffOutRef->m_ptDrawPos.x + size.cx, m_pBuffOutRef->m_ptDrawPos.y);
 }
 
-void CN3UIEdit::SetMaxString(size_t iMax)		// 최대 글씨 수를 정해준다
+void CN3UIEdit::SetMaxString(uint32_t nMax)		// 최대 글씨 수를 정해준다
 {
-	if (iMax <= 0) {__ASSERT(0, "최대 글씨 수를 0보다 크게 정해주세요"); return;}
-	m_iMaxStrLen = iMax;
+	if (nMax == 0)
+	{
+		__ASSERT(0, "최대 글씨 수를 0보다 크게 정해주세요");
+		return;
+	}
 
-	if (NULL == m_pBuffOutRef) return;
+	m_iMaxStrLen = nMax;
+
+	if (m_pBuffOutRef == nullptr)
+		return;
 
 	const std::string szBuff = GetString();
-	if ( m_iMaxStrLen >= szBuff.size()) return;
+	if (m_iMaxStrLen >= szBuff.size())
+		return;
 
 	// 여기까지 오는 경우는 현재 글씨길이가 iMax보다 큰 경우이므로 제한글자에 맞춰 잘라주게 다시 설정한다.
 	SetString(szBuff);
@@ -651,8 +659,9 @@ void CN3UIEdit::SetString(const std::string& szString)
 	}
 
 	const std::string& szTempStr = m_pBuffOutRef->GetString();
-	size_t iStrLen = szTempStr.size();
-	if (m_nCaretPos > iStrLen) SetCaretPos(iStrLen);
+	uint32_t nStrLen = static_cast<uint32_t>(szTempStr.size());
+	if (m_nCaretPos > nStrLen)
+		SetCaretPos(nStrLen);
 }
 
 BOOL CN3UIEdit::MoveOffset(int iOffsetX, int iOffsetY)		// 위치 지정(chilren의 위치도 같이 바꾸어준다. caret위치도 같이 바꾸어줌.)

--- a/Client/N3Base/N3UIEdit.h
+++ b/Client/N3Base/N3UIEdit.h
@@ -63,9 +63,9 @@ public:
 
 protected:
 	static CN3Caret		s_Caret;
-	UINT				m_nCaretPos;		// 글자 단위위치(byte단위)
+	uint32_t			m_nCaretPos;		// 글자 단위위치(byte단위)
 	int					m_iCompLength;		// 현재 조합중인 글자의 byte수 0이면 조합중이 아니다.
-	size_t				m_iMaxStrLen;		// 쓸수 있는 글씨의 최대 숫자
+	uint32_t			m_iMaxStrLen;		// 쓸수 있는 글씨의 최대 숫자
 	std::string			m_szPassword;		// password buffer
 
 	CN3SndObj*			m_pSnd_Typing;		// 타이핑 할 때 나는 소리
@@ -83,8 +83,8 @@ public:
 	void				KillFocus();			// 포커스를 없앤다.
 	bool				SetFocus();				// 포커스를 준다.
 	bool				HaveFocus() const {return (this == s_pFocusedEdit);}
-	void				SetCaretPos(UINT nPos);	//몇번째 바이트에 있는지 설정한다.
-	void				SetMaxString(size_t iMax);		// 최대 글씨 수를 정해준다.
+	void				SetCaretPos(uint32_t nPos);	//몇번째 바이트에 있는지 설정한다.
+	void				SetMaxString(uint32_t nMax);		// 최대 글씨 수를 정해준다.
 protected:
 	BOOL				IsHangulMiddleByte( const char* lpszStr, int iPos );	// 한글의 2번째 바이트 글자인가?
 

--- a/Client/N3Base/N3UIList.h
+++ b/Client/N3Base/N3UIList.h
@@ -18,7 +18,7 @@ typedef std::list<CN3UIString*>::iterator it_pString;
 class CN3UIList : public CN3UIBase  
 {
 protected:
-	size_t					m_iCurSel;		// ÇöÀç ¼±ÅÃ..
+	int						m_iCurSel;		// 현재 선택..
 	std::list<CN3UIString*>	m_ListString;	// String List
 	class CN3UIScrollBar*	m_pScrollBarRef;
 
@@ -29,30 +29,67 @@ protected:
 	D3DCOLOR				m_crFont;
 	
 public:
-	const std::string&	FontName() { return m_szFontName; }
-	uint32_t				FontHeight() { return m_dwFontHeight; }
-	D3DCOLOR			FontColor() { return m_crFont; }
-	BOOL				FontIsBold() { return m_bFontBold; }
-	BOOL				FontIsItalic() { return m_bFontItalic; }
+	const std::string& FontName() const
+	{
+		return m_szFontName;
+	}
+
+	uint32_t FontHeight() const
+	{
+		return m_dwFontHeight;
+	}
+
+	D3DCOLOR FontColor() const
+	{
+		return m_crFont;
+	}
+
+	BOOL FontIsBold() const
+	{
+		return m_bFontBold;
+	}
+
+	BOOL FontIsItalic() const
+	{
+		return m_bFontItalic;
+	}
 
 	void	SetFont(const std::string& szFontName, uint32_t dwHeight, BOOL bBold, BOOL bItalic);
 	void	SetFontColor(D3DCOLOR color);
-	void	SetFontColor(size_t iIndex, D3DCOLOR color);
+	void	SetFontColor(int iIndex, D3DCOLOR color);
 
 	void	ResetContent();
 	void	UpdateChildRegions();
 	int		AddStrings(const std::string* pszStrings, int iStringCount);
 	int		AddString(const std::string& szString);
-	bool	InsertString(size_t iIndex, const std::string& szString);
-	bool	DeleteString(size_t iIndex);
-	bool	GetString(size_t iIndex, std::string& szString);
-	bool	SetString(size_t iIndex, const std::string& szString);
-	size_t	GetCurSel() { return m_iCurSel; }
-	bool	SetCurSel(size_t iIndex) { if (iIndex >= m_ListString.size()) m_iCurSel = ~((size_t)0); else m_iCurSel = iIndex; return true; }
-	CN3UIString*	GetChildStrFromList(std::string str);
-	int		GetCount() { return m_ListString.size(); }
+	bool	InsertString(int iIndex, const std::string& szString);
+	bool	DeleteString(int iIndex);
+	bool	GetString(int iIndex, std::string& szString);
+	bool	SetString(int iIndex, const std::string& szString);
 
-	int		GetScrollPos();
+	int	GetCurSel() const
+	{
+		return m_iCurSel;
+	}
+
+	bool SetCurSel(int iIndex)
+	{
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_ListString.size()))
+			m_iCurSel = -1;
+		else
+			m_iCurSel = iIndex;
+		return true;
+	}
+
+	CN3UIString* GetChildStrFromList(const std::string& str);
+
+	int GetCount() const
+	{
+		return static_cast<int>(m_ListString.size());
+	}
+
+	int		GetScrollPos() const;
 	bool	SetScrollPos(int iScrollPos);
 	
 	virtual void	Render();

--- a/Client/N3Base/N3UIScrollBar.h
+++ b/Client/N3Base/N3UIScrollBar.h
@@ -37,8 +37,8 @@ public:
 	void			SetRange(int iMin, int iMax) {if(m_pTrackBarRef) m_pTrackBarRef->SetRange(iMin,iMax);}
 	void			SetRangeMax(int iMax) {if(m_pTrackBarRef) m_pTrackBarRef->SetRangeMax(iMax);}
 	void			SetRangeMin(int iMin) {if(m_pTrackBarRef) m_pTrackBarRef->SetRangeMin(iMin);}
-	size_t			GetCurrentPos() const {if(m_pTrackBarRef) return m_pTrackBarRef->GetPos(); return 0;}
-	void			SetCurrentPos(size_t iPos) {if(m_pTrackBarRef) m_pTrackBarRef->SetCurrentPos(iPos);}
+	int				GetCurrentPos() const {if(m_pTrackBarRef) return m_pTrackBarRef->GetPos(); return 0;}
+	void			SetCurrentPos(int iPos) {if(m_pTrackBarRef) m_pTrackBarRef->SetCurrentPos(iPos);}
 	void			SetPageSize(int iSize) {if(m_pTrackBarRef) m_pTrackBarRef->SetPageSize(iSize);}
 	int				GetPageSize() const {if(m_pTrackBarRef) return m_pTrackBarRef->GetPageSize(); return 0;}
 	void			SetLineSize(int iSize) {m_iLineSize = iSize;}

--- a/Client/N3Base/N3UITrackBar.cpp
+++ b/Client/N3Base/N3UITrackBar.cpp
@@ -162,7 +162,7 @@ uint32_t CN3UITrackBar::MouseProc(uint32_t dwFlags, const POINT& ptCur, const PO
 //	if (m_pThumbImageRef) m_pThumbImageRef->Render();
 //}
 
-void CN3UITrackBar::SetRange(size_t iMin, size_t iMax)
+void CN3UITrackBar::SetRange(int iMin, int iMax)
 {
 	if (m_iMaxPos == iMax && m_iMinPos == iMin) return;
 	m_iMaxPos = iMax;		m_iMinPos = iMin;
@@ -171,7 +171,7 @@ void CN3UITrackBar::SetRange(size_t iMin, size_t iMax)
 	UpdateThumbPos();
 }
 
-void CN3UITrackBar::SetCurrentPos(size_t iPos)
+void CN3UITrackBar::SetCurrentPos(int iPos)
 {
 	if (iPos == m_iCurPos) return;
 	m_iCurPos = iPos;
@@ -229,7 +229,7 @@ void CN3UITrackBar::UpDownThumbPos(int iDiff)
 		else
 		{
 			m_pThumbImageRef->SetPos(rcThumb.left, rcThumb.top+iDiff);
-			m_iCurPos = (size_t)(m_iMinPos + (m_iMaxPos-m_iMinPos)*fPercentage);// SetCurrentPos함수를 호출하면 thumb위치를 다시 계산하기 때문에 직접 바꾸어줌.
+			m_iCurPos = static_cast<int>(m_iMinPos + (m_iMaxPos - m_iMinPos) * fPercentage);// SetCurrentPos함수를 호출하면 thumb위치를 다시 계산하기 때문에 직접 바꾸어줌.
 		}
 	}
 	else											// 좌우로 움직일 때
@@ -254,7 +254,7 @@ void CN3UITrackBar::UpDownThumbPos(int iDiff)
 		else
 		{
 			m_pThumbImageRef->SetPos(rcThumb.left+iDiff, rcThumb.top);
-			m_iCurPos = (size_t)(m_iMinPos + (m_iMaxPos-m_iMinPos)*fPercentage);// SetCurrentPos함수를 호출하면 thumb위치를 다시 계산하기 때문에 직접 바꾸어줌.
+			m_iCurPos = static_cast<int>(m_iMinPos + (m_iMaxPos - m_iMinPos) * fPercentage);// SetCurrentPos함수를 호출하면 thumb위치를 다시 계산하기 때문에 직접 바꾸어줌.
 		}
 	}
 }

--- a/Client/N3Base/N3UITrackBar.h
+++ b/Client/N3Base/N3UITrackBar.h
@@ -24,9 +24,9 @@ protected:
 	CN3UIImage*		m_pBkGndImageRef;		// 배경 이미지 referance (메모리 할당은 children list로 관리)
 	CN3UIImage*		m_pThumbImageRef;		// 가운데 드레그 하여 옮길 수 있는 이미지 referance
 
-	size_t			m_iMaxPos;									// 최대
-	size_t			m_iMinPos;									// 최소
-	size_t 			m_iCurPos;									// 현재 값
+	int				m_iMaxPos;									// 최대
+	int				m_iMinPos;									// 최소
+	int 			m_iCurPos;									// 현재 값
 	int				m_iPageSize;								// page단위 이동할때 이동값
 // Operations
 public:
@@ -36,15 +36,15 @@ public:
 	virtual uint32_t	MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT& ptOld);
 //	virtual void	Render();
 
-	void			SetRange(size_t iMin, size_t iMax);
-	void			SetRangeMax(size_t iMax) {SetRange(m_iMinPos, iMax);}
-	void			SetRangeMin(size_t iMin) {SetRange(iMin, m_iMaxPos);}
-	void			SetCurrentPos(size_t iPos);
-	size_t			GetPos() const {return m_iCurPos;}
+	void			SetRange(int iMin, int iMax);
+	void			SetRangeMax(int iMax) {SetRange(m_iMinPos, iMax);}
+	void			SetRangeMin(int iMin) {SetRange(iMin, m_iMaxPos);}
+	void			SetCurrentPos(int iPos);
+	int				GetPos() const {return m_iCurPos;}
 	void			SetPageSize(int iSize) {m_iPageSize = iSize;}
 	int				GetPageSize() const {return m_iPageSize;}
-	size_t			GetMaxPos() const {return m_iMaxPos;}
-	size_t			GetMinPos() const {return m_iMinPos;}
+	int				GetMaxPos() const {return m_iMaxPos;}
+	int				GetMinPos() const {return m_iMinPos;}
 protected:
 	void			UpdateThumbPos();							// m_iCurPos를 계산하여 Thumb위치 다시 계산하여 바꾸기
 	void			UpDownThumbPos(int iDiff);					// Thumb위치를 아래 위로 iDiff pixel만큼 움직인 후 m_iCurPos 갱신하기

--- a/Client/WarFare/GameEng.h
+++ b/Client/WarFare/GameEng.h
@@ -69,11 +69,29 @@ public:
 	//CN3Light*		Light(int index);
 
 	// Camera 함수들
-	void			CameraAdd(CN3Camera *pCamera) { m_Cameras.push_back(pCamera); }
-	int				CameraCount() { return m_Cameras.size(); }
-	CN3Camera*		Camera(size_t index);
-	void			CameraSetActiveByIndex(size_t index) { CN3Camera* pCam = this->Camera(index); if(pCam) m_pActiveCam = pCam; }
-	CN3Camera*		CameraGetActive() { return m_pActiveCam; }
+	int	CameraCount() const
+	{
+		return static_cast<int>(m_Cameras.size());
+	}
+
+	void CameraSetActiveByIndex(int index)
+	{
+		CN3Camera* pCam = Camera(index);
+		if (pCam != nullptr)
+			m_pActiveCam = pCam;
+	}
+
+	CN3Camera* CameraGetActive()
+	{
+		return m_pActiveCam;
+	}
+
+	void CameraAdd(CN3Camera* pCamera)
+	{
+		m_Cameras.push_back(pCamera);
+	}
+
+	CN3Camera*		Camera(int index);
 
 	// 추가한것..
 	void			ViewPointChange(e_ViewPoint eVP = VP_UNKNOWN);
@@ -108,9 +126,12 @@ inline CN3Light* CGameEng::Light(int index)
 }
 */
 
-inline CN3Camera* CGameEng::Camera(size_t index)
+inline CN3Camera* CGameEng::Camera(int index)
 {
-	if (index >= m_Cameras.size()) return NULL;
+	if (index < 0
+		|| index >= static_cast<int>(m_Cameras.size()))
+		return nullptr;
+
 	auto it = m_Cameras.begin();
 	std::advance(it, index);
 	return *it;

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -3647,12 +3647,9 @@ bool CGameProcMain::MsgRecv_MyInfo_LevelChange(Packet& pkt)
 
 		uint8_t	bExtraSkillPoint		= pkt.read<uint8_t>();	// 토탈 포인트
 		//TRACE("Skill change Extra value %d\n", bExtraSkillPoint);
-
-		uint64_t iExpNext		= pkt.read<uint32_t>(); 
-		uint64_t iExp			= pkt.read<uint32_t>();
 			
-		pInfoExt->iExpNext		= iExpNext; 
-		pInfoExt->iExp			= iExp; 
+		pInfoExt->iExpNext		= pkt.read<int32_t>();
+		pInfoExt->iExp			= pkt.read<int32_t>(); 
 
 		pInfoBase->iHPMax		= pkt.read<int16_t>();	
 		pInfoBase->iHP			= pkt.read<int16_t>();

--- a/Client/WarFare/N3TerrainPatch.h
+++ b/Client/WarFare/N3TerrainPatch.h
@@ -35,7 +35,7 @@ protected:
 	FanInfoList					m_FanInfoList;
 	
 	//for level1
-	uint32_t*						m_pTileTexIndx[2];
+	uint32_t*					m_pTileTexIndx[2];
 	bool*						m_pIsTileFull;
 
 	//lightmap...

--- a/Client/WarFare/UIKnightsOperation.cpp
+++ b/Client/WarFare/UIKnightsOperation.cpp
@@ -299,8 +299,9 @@ void CUIKnightsOperation::MsgSend_KnightsDestroy()
 void CUIKnightsOperation::MsgSend_KnightsJoin()
 {
 	if(NULL == m_pList_Knights) return;
-	size_t iCurSel = m_pList_Knights->GetCurSel();
-	if (iCurSel >= m_KnightsListExt.size())
+	int iCurSel = m_pList_Knights->GetCurSel();
+	if (iCurSel < 0
+		|| iCurSel >= static_cast<int>(m_KnightsListExt.size()))
 		return;
 
 	auto it = m_KnightsListExt.begin();

--- a/Client/WarFare/UILevelGuide.cpp
+++ b/Client/WarFare/UILevelGuide.cpp
@@ -233,11 +233,7 @@ void CUILevelGuide::SetTopLine(CN3UIScrollBar* pScroll, CN3UIString* pTextGuide)
 		return;
 
 	// limit check for the line which displayed first, topline
-	int iTopLine = std::clamp(
-		static_cast<int>(pScroll->GetCurrentPos()),
-		0,
-		iTotalLineCount - iVisibleLineCount);
-
+	int iTopLine = std::clamp(pScroll->GetCurrentPos(), 0, iTotalLineCount - iVisibleLineCount);
 	pTextGuide->SetStartLine(iTopLine);
 }
 

--- a/Client/WarFare/UILogin_1098.cpp
+++ b/Client/WarFare/UILogin_1098.cpp
@@ -247,7 +247,7 @@ bool CUILogIn_1098::ServerInfoGet(int iIndex, __GameServerInfo& GSI)
 {
 	if (m_pList_Server == nullptr
 		|| iIndex < 0
-		|| iIndex >= (int) m_ListServerInfos.size())
+		|| iIndex >= static_cast<int>(m_ListServerInfos.size()))
 		return false;
 
 	GSI = m_ListServerInfos[iIndex];

--- a/Client/WarFare/UILogin_1298.cpp
+++ b/Client/WarFare/UILogin_1298.cpp
@@ -64,7 +64,7 @@ CUILogIn_1298::CUILogIn_1298()
 
 	m_iSelectedServerIndex = -1;
 
-	for (size_t i = 0; i < MAX_SERVERS; i++)
+	for (int i = 0; i < MAX_SERVERS; i++)
 	{
 		m_pServer_Group[i] = nullptr;
 		m_pArrow_Group[i] = nullptr;
@@ -244,7 +244,7 @@ bool CUILogIn_1298::Load(HANDLE hFile)
 		m_pGroup_ServerList->SetVisible(false);
 
 	// get List_Server (structure: Group_ServerList_01 -> server_20 -> List_Server )
-	for (size_t i = 0; i < MAX_SERVERS; i++)
+	for (int i = 0; i < MAX_SERVERS; i++)
 	{
 		std::string szID = "server_" + std::to_string(i + 1);
 		N3_VERIFY_UI_COMPONENT(m_pServer_Group[i], m_pGroup_ServerList->GetChildByID(szID));
@@ -341,7 +341,7 @@ bool CUILogIn_1298::ServerInfoAdd(const __GameServerInfo& GSI)
 bool CUILogIn_1298::ServerInfoGet(int iIndex, __GameServerInfo& GSI)
 {
 	if (iIndex < 0
-		|| iIndex >= (int) m_ListServerInfos.size())
+		|| iIndex >= static_cast<int>(m_ListServerInfos.size()))
 		return false;
 
 	GSI = m_ListServerInfos[iIndex];

--- a/Client/WarFare/UINotice.cpp
+++ b/Client/WarFare/UINotice.cpp
@@ -76,7 +76,7 @@ bool CUINotice::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 		if(pSender == m_pScrollBar)
 		{
 			// 스크롤바에 맞는 채팅 Line 설정
-			int iCurLinePos = m_pScrollBar->GetCurrentPos();
+			// int iCurLinePos = m_pScrollBar->GetCurrentPos();
 		}
 	}
 

--- a/Client/WarFare/UIPartyBBS.cpp
+++ b/Client/WarFare/UIPartyBBS.cpp
@@ -95,7 +95,7 @@ bool CUIPartyBBS::SelectedString(CN3UIBase* pSender, int& iID)
 		if(pSender == m_pText[i])
 		{
 			iIndex = i % PARTY_BBS_MAXLINE;
-			if (iIndex >= (int)m_Datas.size())
+			if (iIndex >= static_cast<int>(m_Datas.size()))
 				return false;
 
 			iID = iIndex;

--- a/Client/WarFare/UIPartyOrForce.cpp
+++ b/Client/WarFare/UIPartyOrForce.cpp
@@ -36,7 +36,7 @@ CUIPartyOrForce::CUIPartyOrForce()
 		m_pAreas[i]					= nullptr;
 	}
 
-	m_iIndexSelected = ((size_t) ~0); // 현재 선택된 멤버인덱스..
+	m_iIndexSelected = -1; // 현재 선택된 멤버인덱스..
 }
 
 CUIPartyOrForce::~CUIPartyOrForce()
@@ -130,7 +130,7 @@ bool CUIPartyOrForce::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 	if( dwMsg == UIMSG_BUTTON_CLICK )
 	{
 		__InfoPartyOrForce* pIP = NULL;
-		it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
+		auto it = m_Members.begin(), itEnd = m_Members.end();
 		for(int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
 		{
 //			if(m_pStatic_IDs[i] && pSender == m_pStatic_IDs[i])
@@ -155,7 +155,8 @@ void CUIPartyOrForce::Render()
 
 	CN3UIBase::Render();
 
-	if (m_iIndexSelected >= m_Members.size()
+	if (m_iIndexSelected < 0
+		|| m_iIndexSelected >= static_cast<int>(m_Members.size())
 		|| m_iIndexSelected >= MAX_PARTY_OR_FORCE)
 		return;
 
@@ -176,9 +177,10 @@ void CUIPartyOrForce::Render()
 	CN3Base::RenderLines(rc, 0xff00ff00); // 선택 표시..
 }
 
-bool CUIPartyOrForce::TargetByIndex(size_t iIndex)
+bool CUIPartyOrForce::TargetByIndex(int iIndex)
 {
-	if (iIndex >= m_Members.size())
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_Members.size()))
 		return false;
 
 	auto it = m_Members.begin();
@@ -196,7 +198,7 @@ const __InfoPartyOrForce* CUIPartyOrForce::MemberInfoGetByID(int iID, int& iInde
 {
 	if(m_Members.empty()) return NULL;
 
-	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
+	auto it = m_Members.begin(), itEnd = m_Members.end();
 	iIndexResult = 0;
 	for(; it != itEnd; it++, iIndexResult++)
 	{
@@ -210,11 +212,11 @@ const __InfoPartyOrForce* CUIPartyOrForce::MemberInfoGetByID(int iID, int& iInde
 	return NULL;
 }
 
-const __InfoPartyOrForce* CUIPartyOrForce::MemberInfoGetByIndex(size_t iIndex)
+const __InfoPartyOrForce* CUIPartyOrForce::MemberInfoGetByIndex(int iIndex)
 {
-	if(m_Members.empty()
-		|| iIndex > m_Members.size())
-		return NULL;
+	if (iIndex < 0
+		|| iIndex >= static_cast<int>(m_Members.size()))
+		return nullptr;
 
 	auto it = m_Members.begin();
 	std::advance(it, iIndex);
@@ -229,7 +231,7 @@ CPlayerOther* CUIPartyOrForce::MemberGetByNearst(const __Vector3& vPosPlayer)
 	float fDistMin = FLT_MAX, fDistTmp = 0;
 	CPlayerOther* pTarget = NULL;
 
-	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
+	auto it = m_Members.begin(), itEnd = m_Members.end();
 	for(; it != itEnd; it++)
 	{
 		CPlayerOther* pUPC = CGameBase::s_pOPMgr->UPCGetByID(it->iID, false);
@@ -272,7 +274,7 @@ bool CUIPartyOrForce::MemberRemove(int iID)
 {
 	if(m_Members.empty()) return false;
 
-	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
+	auto it = m_Members.begin(), itEnd = m_Members.end();
 	for(; it != itEnd; it++)
 	{
 		if(iID == it->iID)
@@ -359,9 +361,9 @@ void CUIPartyOrForce::MemberInfoReInit() // 파티원 구성이 변경될때.. �
 
 const __InfoPartyOrForce* CUIPartyOrForce::MemberInfoGetSelected()
 {
-	if (m_Members.empty()
-		|| m_iIndexSelected >= m_Members.size())
-		return NULL;
+	if (m_iIndexSelected < 0
+		|| m_iIndexSelected >= static_cast<int>(m_Members.size()))
+		return nullptr;
 
 	auto it = m_Members.begin();
 	std::advance(it, m_iIndexSelected);
@@ -405,7 +407,7 @@ void CUIPartyOrForce::MemberHPChange(int iID, int iHP, int iHPMax, int iMP, int 
 
 void CUIPartyOrForce::MemberStatusChange(int iID, e_PartyStatus ePS, bool bSuffer)
 {
-	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
+	auto it = m_Members.begin(), itEnd = m_Members.end();
 	__InfoPartyOrForce* pIP = NULL;
 	for(int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
 	{
@@ -421,7 +423,7 @@ void CUIPartyOrForce::MemberStatusChange(int iID, e_PartyStatus ePS, bool bSuffe
 
 void CUIPartyOrForce::MemberLevelChange(int iID, int iLevel)
 {
-	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
+	auto it = m_Members.begin(), itEnd = m_Members.end();
 	__InfoPartyOrForce* pIP = NULL;
 	for(int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
 	{
@@ -436,7 +438,7 @@ void CUIPartyOrForce::MemberLevelChange(int iID, int iLevel)
 
 void CUIPartyOrForce::MemberClassChange(int iID, e_Class eClass)
 {
-	it_PartyOrForce it = m_Members.begin(), itEnd = m_Members.end();
+	auto it = m_Members.begin(), itEnd = m_Members.end();
 	__InfoPartyOrForce* pIP = NULL;
 	for(int i = 0; it != itEnd && i < MAX_PARTY_OR_FORCE; it++, i++)
 	{

--- a/Client/WarFare/UIPartyOrForce.h
+++ b/Client/WarFare/UIPartyOrForce.h
@@ -14,8 +14,6 @@
 #include "GameDef.h"
 #include <N3Base/N3UIBase.h>
 
-typedef std::list<__InfoPartyOrForce>::iterator it_PartyOrForce;
-
 class CUIPartyOrForce : public CN3UIBase // 파티에 관한 UI, 부대와 같은 클래스로 쓴다..
 {
 protected:
@@ -28,7 +26,7 @@ protected:
 	CN3UIArea*		m_pAreas[MAX_PARTY_OR_FORCE];				// 부대원갯수 만큼... 이름들..
 
 	std::list<__InfoPartyOrForce>	m_Members; // 파티 멤버
-	size_t		m_iIndexSelected; // 현재 선택된 멤버인덱스..
+	int			m_iIndexSelected; // 현재 선택된 멤버인덱스..
 
 public:
 	int			m_iPartyOrForce; // 파티냐? 부대냐?? 1 이면 파티 2 이면 부대..
@@ -42,17 +40,29 @@ public:
 	void		MemberStatusChange(int iID, e_PartyStatus ePS, bool bSuffer);
 
 	void		MemberInfoReInit(); // 파티원 구성이 변경될때.. 순서 및 각종 정보 업데이트..
-	bool		TargetByIndex(size_t iIndex); // 순서대로 타겟 잡기..
+	bool		TargetByIndex(int iIndex); // 순서대로 타겟 잡기..
+
+	int MemberCount() const
+	{
+		return static_cast<int>(m_Members.size());
+	}
 
 	const __InfoPartyOrForce*	MemberInfoGetByID(int iID, int& iIndexResult);
-	const __InfoPartyOrForce*	MemberInfoGetByIndex(size_t iIndex);
+	const __InfoPartyOrForce*	MemberInfoGetByIndex(int iIndex);
 	const __InfoPartyOrForce*	MemberInfoGetSelected(); // 현재 선택된 멤버인덱스..
 	const __InfoPartyOrForce*	MemberAdd(int iID, const std::string& szID, int iLevel, e_Class eClass, int iHP, int iHPMax, int iMP, int iMPMax);
 	class CPlayerOther*			MemberGetByNearst(const __Vector3& vPosPlayer);
 	bool						MemberRemove(int iID);
 	void						MemberDestroy();
-	size_t						MemberCount() { return m_Members.size(); }
-	void						MemberSelect(size_t iMemberIndex) { if (iMemberIndex > m_Members.size()) return; m_iIndexSelected = iMemberIndex; }
+
+	void MemberSelect(int iMemberIndex)
+	{
+		if (iMemberIndex < 0
+			|| iMemberIndex >= static_cast<int>(m_Members.size()))
+			return;
+
+		m_iIndexSelected = iMemberIndex;
+	}
 
 	bool Load(HANDLE hFile);
 	bool ReceiveMessage(class CN3UIBase* pSender, uint32_t dwMsg);

--- a/Client/WarFare/UIQuestTalk.cpp
+++ b/Client/WarFare/UIQuestTalk.cpp
@@ -204,10 +204,6 @@ void CUIQuestTalk::UpdateTextForScroll()
 		return;
 
 	// limit check for the line which displayed first, topline
-	int iTopLine = std::clamp(
-		iScrollPosition,
-		0,
-		iTotalLineCount - iVisibleLineCount);
-
+	int iTopLine = std::clamp(iScrollPosition, 0, iTotalLineCount - iVisibleLineCount);
 	m_pTextTalk->SetStartLine(iTopLine);
 }

--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -1161,8 +1161,8 @@ void CUISkillTreeDlg::InitIconUpdate()
 
 
 	// 아이디 = 직업 코드*1000 + 001부터.. (직업 코드+1)*100 + 001까지..
-	size_t iSkillIDFirst, iSkillIndexFirst, iSkillIndexLast, iModulo;
-	iSkillIDFirst = CGameBase::s_pPlayer->m_InfoBase.eClass*1000+1;
+	int iSkillIDFirst, iSkillIndexFirst, iSkillIndexLast, iModulo;
+	iSkillIDFirst = CGameBase::s_pPlayer->m_InfoBase.eClass * 1000 + 1;
 	iSkillIndexLast = CGameBase::s_pTbl_Skill.GetSize();
 
 	if (!CGameBase::s_pTbl_Skill.IDToIndex(iSkillIDFirst, &iSkillIndexFirst))
@@ -1173,7 +1173,7 @@ void CUISkillTreeDlg::InitIconUpdate()
 
 	if ( CGameBase::s_pPlayer->m_InfoBase.eClass <= CLASS_EL_DRUID )
 	{
-		for(size_t i = iSkillIndexFirst; i < CGameBase::s_pTbl_Skill.GetSize(); i++ )
+		for (int i = iSkillIndexFirst; i < CGameBase::s_pTbl_Skill.GetSize(); i++)
 		{
 			pUSkill = CGameBase::s_pTbl_Skill.GetIndexedData(i);
 			iDivide = pUSkill->dwID / 1000;
@@ -1185,7 +1185,7 @@ void CUISkillTreeDlg::InitIconUpdate()
 		}
 	}
 
-	for(size_t i = iSkillIndexFirst; i < iSkillIndexLast; i++ )
+	for (int i = iSkillIndexFirst; i < iSkillIndexLast; i++)
 	{
 		__TABLE_UPC_SKILL* pUSkill = CGameBase::s_pTbl_Skill.GetIndexedData(i);
 		if ( pUSkill == NULL ) continue;
@@ -1507,7 +1507,7 @@ stop:
 
 bool CUISkillTreeDlg::CheckSkillCanBeUse(__TABLE_UPC_SKILL* pUSkill)
 {
-	size_t iModulo = pUSkill->iNeedSkill % 10;
+	int iModulo = pUSkill->iNeedSkill % 10;
 	switch (iModulo)
 	{
 		case 0:																				// Basic Skills..

--- a/Client/WarFare/UITradeList.cpp
+++ b/Client/WarFare/UITradeList.cpp
@@ -86,8 +86,8 @@ void CUITradeList::Open(int iIDTarget)
 	__TABLE_ITEM_BASIC* pItem = NULL;
 
 	// 아이디 = 직업 코드*1000 + 001부터.. (직업 코드+1)*100 + 001까지..
-	size_t i, iIDFirst, iIDIndexFirst, iIDIndexLast, iDivide, iTotalCount;
-	iIDFirst = iIDTarget*1000+1;
+	int i, iIDFirst, iIDIndexFirst, iIDIndexLast, iDivide, iTotalCount;
+	iIDFirst = iIDTarget * 1000 + 1;
 
 	if (!CGameBase::s_pTbl_Exchange_Quest.IDToIndex(iIDFirst, &iIDIndexFirst))
 		return;		// 아무런 리스트도 가지고 있지 않다..

--- a/Client/WarFare/UITradeSellBBS.cpp
+++ b/Client/WarFare/UITradeSellBBS.cpp
@@ -730,12 +730,12 @@ void CUITradeSellBBS::RenderSelectContent()
 bool CUITradeSellBBS::SelectedString(CN3UIBase* pSender, int& iID)
 {
 	int iIndex = -1;
-	for(size_t  i = 0; i < TRADE_BBS_MAXSTRING ; i++)
+	for (int i = 0; i < TRADE_BBS_MAXSTRING; i++)
 	{
-		if(pSender == m_pText[i])
+		if (pSender == m_pText[i])
 		{
 			iIndex = i % TRADE_BBS_MAX_LINE;
-			if ((size_t)iIndex >= m_Datas.size())
+			if (iIndex >= static_cast<int>(m_Datas.size()))
 				return false;
 
 			iID = iIndex;

--- a/Client/WarFare/UIVarious.cpp
+++ b/Client/WarFare/UIVarious.cpp
@@ -766,10 +766,10 @@ void CUIKnights::RefreshList()
 {
 	ClearLists();
 
-	it_KMI it = m_MemberList.begin();
+	auto it = m_MemberList.begin();
 
-	size_t i = 10;
-	size_t e = m_iPageCur * 10;
+	int i = 10;
+	int e = m_iPageCur * 10;
 
 	for (; i < e; i++)
 	{
@@ -1089,18 +1089,24 @@ bool CUIFriends::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 
 	if (dwMsg == UIMSG_BUTTON_CLICK)					
 	{
-		if(pSender == m_pBtn_PrevPage || pSender == m_pBtn_NextPage)
+		if (pSender == m_pBtn_PrevPage
+			|| pSender == m_pBtn_NextPage)
 		{
-			size_t iPagePrev = m_iPageCur;
+			int iPagePrev = m_iPageCur;
 
-			if(pSender == m_pBtn_PrevPage) m_iPageCur--;
-			else m_iPageCur++;
+			if (pSender == m_pBtn_PrevPage)
+				m_iPageCur--;
+			else
+				m_iPageCur++;
 
-			if(m_iPageCur < 0) m_iPageCur = 0;
+			if (m_iPageCur < 0)
+			{
+				m_iPageCur = 0;
+			}
 			else
 			{
-				size_t iLinePerPage = 0;
-				if(m_pList_Friends)
+				int iLinePerPage = 0;
+				if (m_pList_Friends != nullptr)
 				{
 //					RECT rc = m_pList_Friends->GetRegion();
 //					uint32_t dwH = m_pList_Friends->FontHeight();
@@ -1108,10 +1114,12 @@ bool CUIFriends::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 					iLinePerPage = 10;
 				}
 
-				size_t iPageMax = 0;
-				if(iLinePerPage > 0) iPageMax = (m_MapFriends.size() / iLinePerPage) + 1;
+				int iPageMax = 0;
+				if (iLinePerPage > 0)
+					iPageMax = (static_cast<int>(m_MapFriends.size()) / iLinePerPage) + 1;
 				
-				if(m_iPageCur >= iPageMax) m_iPageCur = iPageMax - 1;
+				if (m_iPageCur >= iPageMax)
+					m_iPageCur = iPageMax - 1;
 			}
 			
 			if(iPagePrev != m_iPageCur) // 페이지가 변경될때 
@@ -1215,21 +1223,24 @@ void CUIFriends::UpdateList()
 //	RECT rc = m_pList_Friends->GetRegion();
 //	uint32_t dwH = m_pList_Friends->FontHeight();
 //	int iLinePerPage = (rc.bottom - rc.top) / dwH;
-	size_t iLinePerPage = 10;
+	int iLinePerPage = 10;
 //	if(iLinePerPage <= 0) return;
 
-	size_t iPageMax = m_MapFriends.size() / iLinePerPage;
-	if(m_iPageCur > iPageMax) return;
+	int iPageMax = static_cast<int>(m_MapFriends.size()) / iLinePerPage;
+	if (m_iPageCur < 0
+		|| m_iPageCur > iPageMax)
+		return;
 
-	size_t iSkip = m_iPageCur * iLinePerPage;
-	if(iSkip >= m_MapFriends.size()) return;
+	size_t iSkip = static_cast<size_t>(m_iPageCur * iLinePerPage);
+	if (iSkip >= m_MapFriends.size())
+		return;
 
 	if(m_pText_Page) m_pText_Page->SetStringAsInt(m_iPageCur+1); // 페이지 표시..
 
 	auto it = m_MapFriends.begin();
 	std::advance(it, iSkip);
 
-	for (size_t i = 0; i < iLinePerPage && it != m_MapFriends.end(); i++, it++)
+	for (int i = 0; i < iLinePerPage && it != m_MapFriends.end(); i++, it++)
 	{
 		__FriendsInfo& FI = it->second;
 		int iIndex = m_pList_Friends->AddString(FI.szName);

--- a/Client/WarFare/UIVarious.h
+++ b/Client/WarFare/UIVarious.h
@@ -224,7 +224,7 @@ typedef std::map<std::string, __FriendsInfo>::value_type val_FI;
 class CUIFriends : public CN3UIBase  
 {
 protected:
-	size_t m_iPageCur;
+	int m_iPageCur;
 	std::map<std::string, __FriendsInfo> m_MapFriends;
 
 	CN3UIList* m_pList_Friends;

--- a/Client/WarFare/UIWarp.cpp
+++ b/Client/WarFare/UIWarp.cpp
@@ -87,8 +87,9 @@ bool CUIWarp::InfoGetCur(__WarpInfo& WI)
 	if (NULL == m_pList_Infos)
 		return false;
 	
-	size_t iSel = m_pList_Infos->GetCurSel();
-	if (iSel >= m_ListInfos.size())
+	int iSel = m_pList_Infos->GetCurSel();
+	if (iSel < 0
+		|| iSel >= static_cast<int>(m_ListInfos.size()))
 		return false;
 	
 	auto it = m_ListInfos.begin();
@@ -116,8 +117,9 @@ void CUIWarp::UpdateList()
 void CUIWarp::UpdateAgreement()
 {
 	if(NULL == m_pList_Infos || NULL == m_pText_Agreement) return;
-	size_t iSel = m_pList_Infos->GetCurSel();
-	if (iSel >= m_ListInfos.size())
+	int iSel = m_pList_Infos->GetCurSel();
+	if (iSel < 0
+		|| iSel >= static_cast<int>(m_ListInfos.size()))
 		return;
 
 	auto it = m_ListInfos.begin();

--- a/ItemEditor/ItemInfo.cpp
+++ b/ItemEditor/ItemInfo.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 */
 
 #include "base.h"
@@ -168,19 +168,24 @@ void ItemInfo::setMeshFileForRace(e_Race race, bool check_type) {
 	}
 
 	int filename_ind = -1;
-	for(int i=0; i<_mesh_files_in_dir.size(); ++i) {
+	for (size_t i = 0; i < _mesh_files_in_dir.size(); ++i)
+	{
 		char tmp1[0xFFFF] = {};
 		char tmp2[0xFFFF] = {};
 
 		strcpy(tmp1, _mesh_files_in_dir[i].c_str());
 		strcpy(tmp2, filename.c_str());
 
-		for(int j=0; j<strlen(tmp1); ++j)
+		size_t len = strlen(tmp1);
+		for (size_t j = 0; j < len; ++j)
 			tmp1[j] = toupper(tmp1[j]);
-		for(int j=0; j<strlen(tmp2); ++j)
+
+		len = strlen(tmp2);
+		for (size_t j = 0; j < len; ++j)
 			tmp2[j] = toupper(tmp2[j]);
 
-		if(!strcmp(tmp1, tmp2)) {
+		if (!strcmp(tmp1, tmp2))
+		{
 			filename_ind = i;
 			break;
 		}
@@ -190,8 +195,12 @@ void ItemInfo::setMeshFileForRace(e_Race race, bool check_type) {
 }
 
 //-----------------------------------------------------------------------------
-ItemInfo* ItemInfo::GetItem(int i) {
-	if(i>_items.size() || i<0) return NULL;
+ItemInfo* ItemInfo::GetItem(int i)
+{
+	if (i < 0
+		|| i >= static_cast<int>(_items.size()))
+		return nullptr;
+
 	return &_items[i];
 }
 
@@ -223,7 +232,8 @@ string ItemInfo::getItemMeshFileForRace(e_Race race) {
 //-----------------------------------------------------------------------------
 void ItemInfo::setItemMeshFileForRace(e_Race race, string& filename) {
 	int filename_ind = -1;
-	for(int i=0; i<_mesh_files_in_dir.size(); ++i) {
+	for (size_t i = 0; i < _mesh_files_in_dir.size(); ++i)
+	{
 		char tmp1[0xFFFF] = {};
 		char tmp2[0xFFFF] = {};
 
@@ -235,12 +245,16 @@ void ItemInfo::setItemMeshFileForRace(e_Race race, string& filename) {
 		// TODO: if the mesh is something like .obj then we should probably
 		// convert it here
 
-		for(int j=0; j<strlen(tmp1); ++j)
+		size_t len = strlen(tmp1);
+		for (size_t j = 0; j < len; ++j)
 			tmp1[j] = toupper(tmp1[j]);
-		for(int j=0; j<strlen(tmp2); ++j)
+
+		len = strlen(tmp2);
+		for (size_t j = 0; j < len; ++j)
 			tmp2[j] = toupper(tmp2[j]);
 
-		if(!strcmp(tmp1, tmp2)) {
+		if (!strcmp(tmp1, tmp2))
+		{
 			filename_ind = i;
 			break;
 		}

--- a/ItemEditor/N3TableBase.h
+++ b/ItemEditor/N3TableBase.h
@@ -29,30 +29,41 @@ protected:
 // Operations
 public:
 	void	Release();
-	Type*	Find(uint32_t dwID) // ID로 data 찾기
+
+	Type* Find(uint32_t dwID) // ID로 data 찾기
 	{
-		it_Table it = m_Datas.find(dwID);
-		if(it == m_Datas.end()) return NULL; // 찾기에 실패 했다!~!!
-		else return &(it->second);
+		auto it = m_Datas.find(dwID);
+		if (it == m_Datas.end())
+			return nullptr; // 찾기에 실패 했다!~!!
+		
+		return &it->second;
 	}
-	size_t	GetSize() { return m_Datas.size(); }
-	Type*	GetIndexedData(size_t index)	//index로 찾기..
+
+	int GetSize() const
 	{
-		if (index >= m_Datas.size()) return NULL;
+		return static_cast<int>(m_Datas.size());
+	}
+
+	Type* GetIndexedData(int index)	//index로 찾기..
+	{
+		if (index < 0
+			|| index >= static_cast<int>(m_Datas.size()))
+			return nullptr;
 		
 		auto it = m_Datas.begin();
 		std::advance(it, index);
-		return &(it->second);
+		return &it->second;
 	}
-	bool IDToIndex(uint32_t dwID, size_t * index) // 해당 ID의 Index 리턴..	Skill에서 쓴다..
+
+	bool IDToIndex(uint32_t dwID, int* index) // 해당 ID의 Index 리턴..	Skill에서 쓴다..
 	{
 		auto it = m_Datas.find(dwID);
 		if (it == m_Datas.end())
 			return false; // 찾기에 실패 했다!~!!
 
 		auto itSkill = m_Datas.begin();
-		size_t iSize = m_Datas.size();
-		for (size_t i = 0; i < iSize; i++, itSkill++)
+		int iSize = static_cast<int>(m_Datas.size());
+		for (int i = 0; i < iSize; i++, itSkill++)
 		{
 			if (itSkill == it)
 			{
@@ -62,7 +73,9 @@ public:
 		}
 		return false;
 	}
+
 	BOOL	LoadFromFile(const std::string& szFN);
+
 protected:
 	BOOL	Load(HANDLE hFile);
 	BOOL	WriteData(HANDLE hFile, DATA_TYPE DataType, const char* lpszData);
@@ -341,7 +354,7 @@ BOOL CN3TableBase<Type>::LoadFromFile(const std::string& szFN)
 //}
 
 	// 암호화 풀고..
-	for(int i = 0; i < dwSizeLow; i++)
+	for (uint32_t i = 0; i < dwSizeLow; i++)
 	{
 		uint8_t byData = (pDatas[i] ^ (key_r>>8));
 		key_r = (pDatas[i] + key_r) * key_c1 + key_c2;

--- a/ItemEditor/base.cpp
+++ b/ItemEditor/base.cpp
@@ -39,14 +39,22 @@ std::wstring s2ws(const std::string& s) {
 //-----------------------------------------------------------------------------
 void N3LoadTexture(const char* szFN) {
 
-	int last_slash = 0;
-	int last_point = 0;
+	size_t last_slash = 0;
+	size_t last_point = 0;
 
 	memset(pTexName, 0x00, 0xFF);
-	while(szFN[last_slash++]!='\\' && last_slash<strlen(szFN));
-	while(szFN[last_point++]!='.' && last_point<strlen(szFN));
-	for(int i=last_slash; i<last_point-1; ++i) {
-		pTexName[i-last_slash] = szFN[i];
+
+	size_t len = strlen(szFN);
+
+	while (szFN[last_slash++] != '\\' && last_slash < len)
+		;
+
+	while (szFN[last_point++] != '.' && last_point < len)
+		;
+
+	for (size_t i = last_slash; i < last_point - 1; ++i)
+	{
+		pTexName[i - last_slash] = szFN[i];
 	}
 
 	strcat(pTexName, ".bmp");
@@ -665,7 +673,8 @@ void GenerateScene(void) {
 		pMesh->mTextureCoords[0] = new aiVector3D[iVC];
 		pMesh->mNumUVComponents[0] = iVC;
 
-		for(uint32_t i=0; i<iVC; ++i) {
+		for (int i = 0; i < iVC; ++i)
+		{
 			Vertex v;
 			v.x = vertices[5*i+0];
 			v.y = vertices[5*i+1];
@@ -680,7 +689,8 @@ void GenerateScene(void) {
 		pMesh->mFaces = new aiFace[iFC];
 		pMesh->mNumFaces = iFC;
 
-		for(uint32_t i=0; i<iFC; ++i) {
+		for (int i = 0; i < iFC; ++i)
+		{
 			aiFace& face = pMesh->mFaces[i];
 
 			face.mIndices = new uint32_t[3];

--- a/N3ME/DTexGroupMng.cpp
+++ b/N3ME/DTexGroupMng.cpp
@@ -275,10 +275,12 @@ int CDTexGroupMng::GetID2Index(int id)
 //
 int CDTexGroupMng::GetIndex2ID(int idx)
 {
-	if(idx < 0 || idx >= m_Groups.size()) return 0;
+	if (idx < 0
+		|| idx >= static_cast<int>(m_Groups.size()))
+		return 0;
 
 	it_DTexGroup it = m_Groups.begin();
-	int iSize = m_Groups.size();
+	int iSize = static_cast<int>(m_Groups.size());
 	for(int i = 0; i < idx; i++, it++);
 
 	CDTexGroup* pDTG = *it;

--- a/N3ME/DTexMng.cpp
+++ b/N3ME/DTexMng.cpp
@@ -299,7 +299,7 @@ void CDTexMng::SaveToFile(CString RealFileName)
 	FILE* stream = fopen(szDTexInfoFileName, "w");
 	if(!stream)	return;
 
-	int NumDTex = -m_pDTex.size();
+	int NumDTex = -static_cast<int>(m_pDTex.size());
 	fprintf(stream, "NumDTex = %d\n", NumDTex);
 	int version = N3ME_DTEX_DATA_VERSION;
 	fprintf(stream, "Version = %d\n", version);

--- a/N3ME/DlgMakeNPCPath.cpp
+++ b/N3ME/DlgMakeNPCPath.cpp
@@ -459,7 +459,7 @@ void CDlgMakeNPCPath::OnChangeEdtNpcpathname()
 void CDlgMakeNPCPath::SetNumPoint(int NumPoint)
 {
 	char NumP[5];
-	itoa((MAX_NPCPATH-NumPoint), NumP, 10);
+	_itoa((MAX_NPCPATH - NumPoint), NumP, 10);
 	SetDlgItemText(IDC_NUM_POINT, NumP);
 }
 

--- a/N3ME/DlgSetSound.cpp
+++ b/N3ME/DlgSetSound.cpp
@@ -145,10 +145,11 @@ void CDlgSetSound::OnBtnDeleteSoundgroup()
 		m_iIdx_Min = m_iIdx_Max;
 
 		int cnt = m_ListSoundGroup.GetCount();
-		for(int i=0;i<cnt;i++)
+		for (int i = 0;i < cnt;i++)
 		{
-			pSoundInfo = (LPSOUNDINFO)m_ListSoundGroup.GetItemDataPtr(i);
-			if(m_iIdx_Min > pSoundInfo->dwID) m_iIdx_Min = pSoundInfo->dwID;
+			pSoundInfo = (LPSOUNDINFO) m_ListSoundGroup.GetItemDataPtr(i);
+			if (m_iIdx_Min > static_cast<int>(pSoundInfo->dwID))
+				m_iIdx_Min = static_cast<int>(pSoundInfo->dwID);
 		}
 	}
 
@@ -157,10 +158,11 @@ void CDlgSetSound::OnBtnDeleteSoundgroup()
 		m_iIdx_Max = m_iIdx_Min;
 
 		int cnt = m_ListSoundGroup.GetCount();
-		for(int i=0;i<cnt;i++)
+		for (int i = 0;i < cnt;i++)
 		{
-			pSoundInfo = (LPSOUNDINFO)m_ListSoundGroup.GetItemDataPtr(i);
-			if(m_iIdx_Max < pSoundInfo->dwID) m_iIdx_Max = pSoundInfo->dwID;
+			pSoundInfo = (LPSOUNDINFO) m_ListSoundGroup.GetItemDataPtr(i);
+			if (m_iIdx_Max < static_cast<int>(pSoundInfo->dwID))
+				m_iIdx_Max = static_cast<int>(pSoundInfo->dwID);
 		}
 	}	
 	OnSelchangeListSoundgroup();
@@ -171,8 +173,13 @@ void CDlgSetSound::AddSoundGroup(char* szTitle, LPSOUNDINFO pSoundInfo)
 	int idx = m_ListSoundGroup.AddString(szTitle);
 	m_ListSoundGroup.SetItemDataPtr(idx, pSoundInfo);
 
-	if(pSoundInfo->dwID < m_iIdx_Min) m_iIdx_Min = pSoundInfo->dwID;
-	if(pSoundInfo->dwID > m_iIdx_Max) m_iIdx_Max = pSoundInfo->dwID;
+	int iSndID = static_cast<int>(pSoundInfo->dwID);
+
+	if (iSndID < m_iIdx_Min)
+		m_iIdx_Min = iSndID;
+
+	if (iSndID > m_iIdx_Max)
+		m_iIdx_Max = iSndID;
 }
 
 void CDlgSetSound::OnBtnInputInfo() 

--- a/N3ME/DlgSowSeed.cpp
+++ b/N3ME/DlgSowSeed.cpp
@@ -166,7 +166,7 @@ void CDlgSowSeed::OnBtnDelSeed()
 		{
 			LPGRASS_GROUP group_list = *it;
 			it_Grass it_grass = group_list->grass.begin();
-			for( int jj = 0 ; jj < group_list->grass.size(); jj++, it_grass++)
+			for (int jj = 0; jj < static_cast<int>(group_list->grass.size()); jj++, it_grass++)
 			{
 				LPGRASS grass_list = *it_grass;
 //				group_list->grass.remove(grass_list);
@@ -200,7 +200,7 @@ void CDlgSowSeed::RePaint()
 	{
 		LPGRASS_GROUP group_list = *it;
 		it_Grass it_grass = group_list->grass.begin();
-		for( int jj = 0 ; jj < group_list->grass.size(); jj++, it_grass++)
+		for (int jj = 0; jj < static_cast<int>(group_list->grass.size()); jj++, it_grass++)
 		{
 			LPGRASS grass_list = *it_grass;
 
@@ -384,7 +384,7 @@ void CDlgSowSeed::OnSelchangeCbTilegroup()
 		{
 			LPGRASS_GROUP group_list = *it;
 			it_Grass it_grass = group_list->grass.begin();
-			for( int jj = 0 ; jj < group_list->grass.size(); jj++, it_grass++)
+			for (int jj = 0; jj < static_cast<int>(group_list->grass.size()); jj++, it_grass++)
 			{
 				LPGRASS grass_list = *it_grass;
 

--- a/N3ME/LyTerrain.cpp
+++ b/N3ME/LyTerrain.cpp
@@ -1545,13 +1545,13 @@ void CLyTerrain::SaveGameData(HANDLE hFile)
 	{
 		LPGRASS_GROUP group = (LPGRASS_GROUP)*it;
 		it_Grass it_grass = group->grass.begin();
-		for( int j = 0 ; j < group->grass.size(); j++, it_grass++)
+		for (int j = 0; j < static_cast<int>(group->grass.size()); j++, it_grass++)
 		{
 			LPGRASS grass = *it_grass;
 
 			it_Obj_Name it_Obj = pFrm->GetMapMng()->m_SowSeedMng.Obj_Name.begin();
 			temp_Id =0;
-			for( int jj = 0; jj < pFrm->GetMapMng()->m_SowSeedMng.Obj_Name.size() ; jj++,it_Obj++)
+			for (int jj = 0; jj < static_cast<int>(pFrm->GetMapMng()->m_SowSeedMng.Obj_Name.size()); jj++, it_Obj++)
 			{
 				LPOBJ_NAME Obj = *it_Obj;
 				if( strcmp( group->FileName,Obj->FileName) == 0 )

--- a/N3ME/NPCPath.cpp
+++ b/N3ME/NPCPath.cpp
@@ -57,7 +57,9 @@ void CNPCPath::DelPrevPos()
 
 bool CNPCPath::GetPath(int idx, __Vector3* pPos)
 {
-	if(idx<0 || idx>=m_Path.size()) return false;
+	if (idx < 0
+		|| idx >= static_cast<int>(m_Path.size()))
+		return false;
 
 	std::list<__Vector3>::iterator it;
 	it = m_Path.begin();

--- a/N3ME/NPCPathMgr.cpp
+++ b/N3ME/NPCPathMgr.cpp
@@ -457,7 +457,9 @@ void CNPCPathMgr::UpdatePath()
 
 CNPCPath* CNPCPathMgr::GetpPath(int idx)
 {
-	if(idx<0 || idx>=m_pPaths.size()) return NULL;
+	if (idx < 0
+		|| idx >= static_cast<int>(m_pPaths.size()))
+		return nullptr;
 
 	std::list<CNPCPath*>::iterator itPath;
 	itPath = m_pPaths.begin();

--- a/N3ME/SowSeedMng.cpp
+++ b/N3ME/SowSeedMng.cpp
@@ -38,11 +38,11 @@ void CSowSeedMng::Release()
 {
 	it_Grass_Group it = Grass_Group.begin();
 	int i;
-	for(i = 0 ; i < Grass_Group.size(); i++,it++)
+	for (i = 0; i < static_cast<int>(Grass_Group.size()); i++, it++)
 	{
 		LPGRASS_GROUP group = (LPGRASS_GROUP)*it;
 		it_Grass it_grass = group->grass.begin();
-		for( int j = 0 ; j < group->grass.size(); j++, it_grass++)
+		for (int j = 0; j < static_cast<int>(group->grass.size()); j++, it_grass++)
 		{
 			LPGRASS grass = *it_grass;
 			if( grass != NULL)
@@ -294,14 +294,14 @@ void CSowSeedMng::Render(LPDIRECT3DDEVICE9 lpD3DDevice)
 	if( Render_Grass == TRUE)
 	{
 		it_Grass_Group it = Grass_Group.begin();
-		for( i = 0 ; i < Grass_Group.size(); i++,it++)
+		for (i = 0; i < static_cast<int>(Grass_Group.size()); i++, it++)
 		{
 			LPGRASS_GROUP group = *it;
 			it_Grass it_grass = group->grass.begin();
 
 			if( Select_Group_Id != i)
 			{
-				for( j = 0 ; j < group->grass.size(); j++, it_grass++)
+				for (j = 0; j < static_cast<int>(group->grass.size()); j++, it_grass++)
 				{
 					LPGRASS grass = *it_grass;
 
@@ -321,7 +321,7 @@ void CSowSeedMng::Render(LPDIRECT3DDEVICE9 lpD3DDevice)
 			if( Select_Group_Id == i )  // 선택된 그룹 
 			{
 				Render_Box(lpD3DDevice,group->Pos);
-				for( j = 0 ; j < group->grass.size(); j++, it_grass++)
+				for (j = 0; j < static_cast<int>(group->grass.size()); j++, it_grass++)
 				{
 					LPGRASS grass = *it_grass;
 
@@ -390,11 +390,11 @@ void CSowSeedMng::Add_Grass(void)
 			add_list = true;
 
 			it_Grass_Group it = Grass_Group.begin();
-			for( int ii = 0 ; ii < Grass_Group.size(); ii++,it++)
+			for (int ii = 0; ii < static_cast<int>(Grass_Group.size()); ii++, it++)
 			{
 				LPGRASS_GROUP group_list = *it;
 				it_Grass it_grass = group_list->grass.begin();
-				for( int jj = 0 ; jj < group_list->grass.size(); jj++, it_grass++)
+				for (int jj = 0; jj < static_cast<int>(group_list->grass.size()); jj++, it_grass++)
 				{
 					LPGRASS grass_list = *it_grass;
 					if( grass->Pos == grass_list->Pos)
@@ -439,11 +439,11 @@ void CSowSeedMng::Add_Grass(void)
 
 					add_list = true;
 					it_Grass_Group it = Grass_Group.begin();
-					for( int ii = 0 ; ii < Grass_Group.size(); ii++,it++)
+					for (int ii = 0; ii < static_cast<int>(Grass_Group.size()); ii++, it++)
 					{
 						LPGRASS_GROUP group_list = *it;
 						it_Grass it_grass = group_list->grass.begin();
-						for( int jj = 0 ; jj < group_list->grass.size(); jj++, it_grass++)
+						for (int jj = 0; jj < static_cast<int>(group_list->grass.size()); jj++, it_grass++)
 						{
 							LPGRASS grass_list = *it_grass;
 							if(grass_sub->Pos == grass_list->Pos)
@@ -518,11 +518,11 @@ int CSowSeedMng::SelectSeed(POINT point)
 	if (pFrame->GetMapMng()->GetTerrain()->Pick(point.x, point.y, &vPos))
 	{
 		it_Grass_Group it = Grass_Group.begin();
-		for( int i = 0 ; i < Grass_Group.size(); i++,it++)
+		for (int i = 0; i < static_cast<int>(Grass_Group.size()); i++, it++)
 		{
 			LPGRASS_GROUP group = *it;
 			it_Grass it_grass = group->grass.begin();
-			for( int j = 0 ; j < group->grass.size(); j++, it_grass++)
+			for (int j = 0; j < static_cast<int>(group->grass.size()); j++, it_grass++)
 			{
 				LPGRASS grass = *it_grass;
 
@@ -551,18 +551,18 @@ int CSowSeedMng::SelectSeed(POINT point)
 void CSowSeedMng::SetListPos(void)
 {
 	CMainFrame* pFrame = (CMainFrame*)AfxGetMainWnd();
-	if( Grass_Group.size() > Select_Group_Id)
+	if (Grass_Group.size() > static_cast<size_t>(Select_Group_Id))
 	{
 		pFrame->m_pDlgSowSeed->m_CB_Seed.ResetContent();
 
 		it_Grass_Group it = Grass_Group.begin();
-		for(int  i = 0,listCount=0 ; i < Grass_Group.size(); i++,it++)
+		for (int i = 0, listCount = 0; i < static_cast<int>(Grass_Group.size()); i++, it++)
 		{
 			if( i == Select_Group_Id)
 			{
 				LPGRASS_GROUP group = *it;
 				it_Grass it_grass = group->grass.begin();
-				for(int  j = 0 ; j < group->grass.size(); j++, it_grass++)
+				for (int j = 0; j < static_cast<int>(group->grass.size()); j++, it_grass++)
 				{
 					LPGRASS grass = *it_grass;
 					char text[256];
@@ -694,11 +694,11 @@ void CSowSeedMng::LoadData(void)
 	{
 		Render_Grass = FALSE;
 		it_Grass_Group it = Grass_Group.begin();
-		for( int i = 0 ; i < Grass_Group.size(); i++,it++)
+		for (int i = 0; i < static_cast<int>(Grass_Group.size()); i++, it++)
 		{
 			LPGRASS_GROUP group = (LPGRASS_GROUP)*it;
 			it_Grass it_grass = group->grass.begin();
-			for( int j = 0 ; j < group->grass.size(); j++, it_grass++)
+			for (int j = 0; j < static_cast<int>(group->grass.size()); j++, it_grass++)
 			{
 				LPGRASS grass = *it_grass;
 				if( grass != NULL)
@@ -801,12 +801,12 @@ void CSowSeedMng::SaveDataGame(void)
 	// 그룹 크기 
 	Obj_Name.clear();
 	it_Grass_Group it = Grass_Group.begin();
-	for( int i = 0 ,Object_ID = 0; i < Grass_Group.size(); i++,it++)
+	for (int i = 0, Object_ID = 0; i < static_cast<int>(Grass_Group.size()); i++, it++)
 	{
 		LPGRASS_GROUP group = *it;
 		BOOL back_push = TRUE;
 		it_Obj_Name it_Obj = Obj_Name.begin();
-		for( int j = 0; j < Obj_Name.size() ; j++,it_Obj++)
+		for (int j = 0; j < static_cast<int>(Obj_Name.size()); j++, it_Obj++)
 		{
 			LPOBJ_NAME Obj = *it_Obj;
 			if( strcmp( group->FileName,Obj->FileName) == 0 )
@@ -827,7 +827,7 @@ void CSowSeedMng::SaveDataGame(void)
 	WriteFile(hFile, &iNum, sizeof(int), &dwRWC, NULL);
 
 	it_Obj_Name it_Obj = Obj_Name.begin();
-	for( int j = 0; j < Obj_Name.size() ; j++,it_Obj++)
+	for (int j = 0; j < static_cast<int>(Obj_Name.size()); j++, it_Obj++)
 	{
 		LPOBJ_NAME Obj = *it_Obj;
 		int len = strlen(Obj->FileName);
@@ -873,7 +873,7 @@ void CSowSeedMng::Test_GameDataSave(void)
 	{
 		LPGRASS_GROUP group = (LPGRASS_GROUP)*it;
 		it_Grass it_grass = group->grass.begin();
-		for( int j = 0 ; j < group->grass.size(); j++, it_grass++)
+		for( int j = 0 ; j < static_cast<int>(group->grass.size()); j++, it_grass++)
 		{
 			LPGRASS grass = *it_grass;
 

--- a/N3ME/Wall.cpp
+++ b/N3ME/Wall.cpp
@@ -39,7 +39,9 @@ void CWall::DelPrevVertex()
 
 bool CWall::GetVertex(int idx, __Vector3* pPos)
 {
-	if(idx<0 || idx>=m_Wall.size()) return false;
+	if (idx < 0
+		|| idx >= static_cast<int>(m_Wall.size()))
+		return false;
 
 	std::list<__Vector3>::iterator it;
 	it = m_Wall.begin();

--- a/N3ME/WallMgr.cpp
+++ b/N3ME/WallMgr.cpp
@@ -355,7 +355,9 @@ void CWallMgr::SetCurrWall(CWall* pWall)
 
 CWall* CWallMgr::GetpWall(int idx)
 {
-	if(idx<0 || idx>=m_pWalls.size()) return NULL;
+	if (idx < 0
+		|| idx >= static_cast<int>(m_pWalls.size()))
+		return nullptr;
 
 	std::list<CWall*>::iterator itWall;
 	itWall = m_pWalls.begin();

--- a/Server/AIServer/ServerDlg.cpp
+++ b/Server/AIServer/ServerDlg.cpp
@@ -970,11 +970,9 @@ BOOL CServerDlg::LoadNpcPosTable(std::vector<model::NpcPos*>& rows)
 //	NPC Thread 들을 작동시킨다.
 void CServerDlg::ResumeAI()
 {
-	int i, j;
-
-	for (i = 0; i < m_NpcThreadArray.size(); i++)
+	for (size_t i = 0; i < m_NpcThreadArray.size(); i++)
 	{
-		for (j = 0; j < NPC_NUM; j++)
+		for (int j = 0; j < NPC_NUM; j++)
 			m_NpcThreadArray[i]->m_ThreadInfo.pNpc[j] = m_NpcThreadArray[i]->m_pNpc[j];
 
 		m_NpcThreadArray[i]->m_ThreadInfo.pIOCP = &m_Iocport;

--- a/Server/Ebenezer/EbenezerDlg.cpp
+++ b/Server/Ebenezer/EbenezerDlg.cpp
@@ -219,7 +219,6 @@ CEbenezerDlg::CEbenezerDlg(CWnd* pParent /*=nullptr*/)
 
 	m_bVictory = 0;
 	m_byOldVictory = 0;
-	m_bBanishDelayStart = 0;
 	m_byBattleSave = 0;
 	m_sKarusCount = 0;
 	m_sElmoradCount = 0;
@@ -308,7 +307,7 @@ BOOL CEbenezerDlg::OnInitDialog()
 	SetIcon(m_hIcon, TRUE);			// Set big icon
 	SetIcon(m_hIcon, FALSE);		// Set small icon
 
-	srand(time(nullptr));
+	srand(static_cast<uint32_t>(time(nullptr)));
 
 	// Compress Init
 	memset(m_CompBuf, 0, sizeof(m_CompBuf));	// 압축할 데이터를 모으는 버퍼
@@ -2909,8 +2908,6 @@ void CEbenezerDlg::BattleZoneVictoryCheck()
 	else
 		return;
 
-	m_bBanishDelayStart = TimeGet();
-
 	Announcement(DECLARE_WINNER);
 
 	// GOLD DISTRIBUTION PROCEDURE FOR WINNERS !!!
@@ -2957,7 +2954,6 @@ void CEbenezerDlg::BanishLosers()
 void CEbenezerDlg::ResetBattleZone()
 {
 	m_bVictory = 0;
-	m_bBanishDelayStart = 0;
 	m_byBanishFlag = 0;
 	m_sBanishDelay = 0;
 	m_bKarusFlag = 0;

--- a/Server/Ebenezer/EbenezerDlg.h
+++ b/Server/Ebenezer/EbenezerDlg.h
@@ -237,7 +237,6 @@ public:
 	// ~Yookozuna 2002.06.12
 	BYTE    m_byBattleOpen, m_byOldBattleOpen;					// 0:전쟁중이 아님, 1:전쟁중(국가간전쟁), 2:눈싸움전쟁
 	BYTE	m_bVictory, m_byOldVictory;
-	BYTE	m_bBanishDelayStart;
 	BYTE	m_bKarusFlag, m_bElmoradFlag;
 	BYTE    m_byKarusOpenFlag, m_byElmoradOpenFlag, m_byBanishFlag, m_byBattleSave;
 	short   m_sDiscount;	// 능력치와 포인트 초기화 할인 (0:할인없음, 1:할인(50%) )

--- a/Server/Ebenezer/IOCPSocket2.cpp
+++ b/Server/Ebenezer/IOCPSocket2.cpp
@@ -146,7 +146,7 @@ int CIOCPSocket2::Send(char* pBuf, long length, int dwFlag)
 
 	if (m_CryptionFlag)
 	{
-		unsigned short len = length + sizeof(WORD) + 2 + 1;
+		uint16_t len = static_cast<uint16_t>(length + sizeof(WORD) + 2 + 1);
 
 		m_Sen_val++;
 		m_Sen_val &= 0x00ffffff;

--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -5506,8 +5506,7 @@ void CUser::SendNotice()
 		if (strlen(m_pMain->m_ppNotice[i]) == 0)
 			continue;
 
-		SetByte(send_buff, strlen(m_pMain->m_ppNotice[i]), send_index);
-		SetString(send_buff, m_pMain->m_ppNotice[i], strlen(m_pMain->m_ppNotice[i]), send_index);
+		SetString1(send_buff, m_pMain->m_ppNotice[i], send_index);
 		count++;
 	}
 
@@ -6249,7 +6248,7 @@ void CUser::ExchangeAdd(char* pBuf)
 		}
 	}
 
-	if (m_ExchangeItemList.size() > ((bGold) ? 13 : 12))
+	if (static_cast<int>(m_ExchangeItemList.size()) > ((bGold) ? 13 : 12))
 		goto add_fail;
 
 	// Gold 가 중복되면 추가하지 않는댜..
@@ -10433,21 +10432,19 @@ void CUser::MarketBBSReport(char* pBuf, BYTE type)
 			SetShort(send_buff, strlen(pUser->m_pUserData->m_id), send_index);
 			SetString(send_buff, pUser->m_pUserData->m_id, strlen(pUser->m_pUserData->m_id), send_index);
 
-			title_length = strlen(m_pMain->m_strBuyTitle[i]);
+			title_length = static_cast<short>(strlen(m_pMain->m_strBuyTitle[i]));
 			if (title_length > MAX_BBS_TITLE)
 				title_length = MAX_BBS_TITLE;
 
-			SetShort(send_buff, title_length, send_index);
-			SetString(send_buff, m_pMain->m_strBuyTitle[i], title_length, send_index);
+			SetString2(send_buff, m_pMain->m_strBuyTitle[i], title_length, send_index);
 //			SetShort(send_buff, strlen(m_pMain->m_strBuyTitle[i]), send_index);
 //			SetString(send_buff, m_pMain->m_strBuyTitle[i], strlen(m_pMain->m_strBuyTitle[i]), send_index);
 
-			message_length = strlen(m_pMain->m_strBuyMessage[i]);
+			message_length = static_cast<short>(strlen(m_pMain->m_strBuyMessage[i]));
 			if (message_length > MAX_BBS_MESSAGE)
 				message_length = MAX_BBS_MESSAGE;
 
-			SetShort(send_buff, message_length, send_index);
-			SetString(send_buff, m_pMain->m_strBuyMessage[i], message_length, send_index);
+			SetString2(send_buff, m_pMain->m_strBuyMessage[i], message_length, send_index);
 //			SetShort(send_buff, strlen(m_pMain->m_strBuyMessage[i]), send_index);
 //			SetString(send_buff, m_pMain->m_strBuyMessage[i], strlen(m_pMain->m_strBuyMessage[i]), send_index);
 
@@ -10479,25 +10476,21 @@ void CUser::MarketBBSReport(char* pBuf, BYTE type)
 				continue;
 
 			SetShort(send_buff, m_pMain->m_sSellID[i], send_index);
+			SetString2(send_buff, pUser->m_pUserData->m_id, send_index);
 
-			SetShort(send_buff, strlen(pUser->m_pUserData->m_id), send_index);
-			SetString(send_buff, pUser->m_pUserData->m_id, strlen(pUser->m_pUserData->m_id), send_index);
-
-			title_length = strlen(m_pMain->m_strSellTitle[i]);
+			title_length = static_cast<short>(strlen(m_pMain->m_strSellTitle[i]));
 			if (title_length > MAX_BBS_TITLE)
 				title_length = MAX_BBS_TITLE;
 
-			SetShort(send_buff, title_length, send_index);
-			SetString(send_buff, m_pMain->m_strSellTitle[i], title_length, send_index);
+			SetString2(send_buff, m_pMain->m_strSellTitle[i], title_length, send_index);
 //			SetShort(send_buff, strlen(m_pMain->m_strSellTitle[i]), send_index);
 //			SetString(send_buff, m_pMain->m_strSellTitle[i], strlen(m_pMain->m_strSellTitle[i]), send_index);
 
-			message_length = strlen(m_pMain->m_strSellMessage[i]);
+			message_length = static_cast<short>(strlen(m_pMain->m_strSellMessage[i]));
 			if (message_length > MAX_BBS_MESSAGE)
 				message_length = MAX_BBS_MESSAGE;
 
-			SetShort(send_buff, message_length, send_index);
-			SetString(send_buff, m_pMain->m_strSellMessage[i], message_length, send_index);
+			SetString2(send_buff, m_pMain->m_strSellMessage[i], message_length, send_index);
 //			SetShort(send_buff, strlen(m_pMain->m_strSellMessage[i]), send_index);
 //			SetString(send_buff, m_pMain->m_strSellMessage[i], strlen(m_pMain->m_strSellMessage[i]), send_index);
 
@@ -10770,24 +10763,22 @@ void CUser::MarketBBSMessage(char* pBuf)
 			if (m_pMain->m_sBuyID[message_index] == -1)
 				goto fail_return;
 
-			message_length = strlen(m_pMain->m_strBuyMessage[message_index]);
+			message_length = static_cast<short>(strlen(m_pMain->m_strBuyMessage[message_index]));
 			if (message_length > MAX_BBS_MESSAGE)
 				message_length = MAX_BBS_MESSAGE;
 
-			SetShort(send_buff, message_length, send_index);
-			SetString(send_buff, m_pMain->m_strBuyMessage[message_index], message_length, send_index);
+			SetString2(send_buff, m_pMain->m_strBuyMessage[message_index], message_length, send_index);
 			break;
 
 		case MARKET_BBS_SELL:
 			if (m_pMain->m_sSellID[message_index] == -1)
 				goto fail_return;
 
-			message_length = strlen(m_pMain->m_strSellMessage[message_index]);
+			message_length = static_cast<short>(strlen(m_pMain->m_strSellMessage[message_index]));
 			if (message_length > MAX_BBS_MESSAGE)
 				message_length = MAX_BBS_MESSAGE;
 
-			SetShort(send_buff, message_length, send_index);
-			SetString(send_buff, m_pMain->m_strSellMessage[message_index], message_length, send_index);
+			SetString2(send_buff, m_pMain->m_strSellMessage[message_index], message_length, send_index);
 			break;
 	}
 

--- a/UIE/DlgTexture.cpp
+++ b/UIE/DlgTexture.cpp
@@ -229,12 +229,18 @@ void CDlgTexture::Resize()
 		pWnd->GetWindowRect(&rc);
 
 		// texture window 배치
-		int iTexViewerWidth = rcClient.Width()-rc.Width()-iOffset;
+		int iTexViewerWidth = rcClient.Width() - rc.Width() - iOffset;
 		int iTexViewerHeight = rcClient.Height();
-		if (iTexViewerWidth<0) iTexViewerWidth = 0;
-		else if (iTexViewerWidth > pFrm->m_Eng.s_DevParam.BackBufferWidth) iTexViewerWidth = pFrm->m_Eng.s_DevParam.BackBufferWidth;
-		if (iTexViewerHeight<0) iTexViewerHeight = 0;
-		else if (iTexViewerHeight > pFrm->m_Eng.s_DevParam.BackBufferHeight) iTexViewerHeight = pFrm->m_Eng.s_DevParam.BackBufferHeight;
+		if (iTexViewerWidth < 0)
+			iTexViewerWidth = 0;
+		else if (iTexViewerWidth > static_cast<int>(pFrm->m_Eng.s_DevParam.BackBufferWidth))
+			iTexViewerWidth = static_cast<int>(pFrm->m_Eng.s_DevParam.BackBufferWidth);
+
+		if (iTexViewerHeight < 0)
+			iTexViewerHeight = 0;
+		else if (iTexViewerHeight > static_cast<int>(pFrm->m_Eng.s_DevParam.BackBufferHeight))
+			iTexViewerHeight = static_cast<int>(pFrm->m_Eng.s_DevParam.BackBufferHeight);
+
 		m_pTexViewer->MoveWindow(0, 0, iTexViewerWidth, iTexViewerHeight);
 
 		// 버튼들 배치

--- a/UIE/UIEDoc.h
+++ b/UIE/UIEDoc.h
@@ -29,7 +29,10 @@ public:
 	int			GetSelectedUICount() { return m_SelectedUIs.size(); }
 	CN3UIBase*	GetSelectedUI(int iIndex = 0)
 	{
-		if(iIndex < 0 || iIndex >= m_SelectedUIs.size()) return NULL;
+		if (iIndex < 0
+			|| iIndex >= static_cast<int>(m_SelectedUIs.size()))
+			return nullptr;
+
 		it_UI it = m_SelectedUIs.begin();
 		for(int i = 0; i < iIndex; i++, it++);
 		return *it;


### PR DESCRIPTION
This change was made in c6e97cb8a0e27a44ee3ba678d713009cb50973d7 in attempt to reduce unnecessary casts & redundant checks, since most logic is basic unsigned logic.

Official logic continues to treat this as signed, so for simplicity's sake and to avoid unintentional issues with cases not refactored to behave correctly with unsigned logic, we'll simply revert this so it's all signed again.

*Ideally* we'd just refactor affected logic to behave correctly with unsigned logic, but I fear this will cause more confusion with newer developers, introducing more bugs down the track, so it's probably safer to just treat it all as signed.

Resolves #404