### PR TITLE
Allow level 80 characters to login

### DIFF
--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -2609,13 +2609,17 @@ void CUser::SendTimeStatus()
 
 void CUser::SetDetailData()
 {
-	C3DMap* pMap = nullptr;
-
 	SetSlotItemValue();
 	SetUserAbility();
 
 	if (m_pUserData->m_bLevel > MAX_LEVEL)
+	{
+		spdlog::error("User::SetDetailData: user exceeds max level [accountId={} charId={} level={}]",
+			m_pUserData->m_Accountid, m_pUserData->m_id, m_pUserData->m_bLevel);
+
 		Close();
+		return;
+	}
 
 	m_iMaxExp = m_pMain->m_LevelUpTableArray[m_pUserData->m_bLevel - 1]->RequiredExp;
 	m_iMaxWeight = (m_pUserData->m_bStr + m_sItemStr) * 50;

--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -2614,7 +2614,7 @@ void CUser::SetDetailData()
 	SetSlotItemValue();
 	SetUserAbility();
 
-	if (m_pUserData->m_bLevel >= MAX_LEVEL)
+	if (m_pUserData->m_bLevel > MAX_LEVEL)
 		Close();
 
 	m_iMaxExp = m_pMain->m_LevelUpTableArray[m_pUserData->m_bLevel - 1]->RequiredExp;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
cannot login game if level is 80

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
can login now.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
important for testing 80 level skills.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
