### PR TITLE
removing wrong hacking prevention

### DIFF
--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -552,26 +552,6 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 	int LeftItem = s_pPlayer->ItemClass_LeftHand();
 	int RightItem = s_pPlayer->ItemClass_RightHand();
 
-	if(pSkill->iNeedSkill==1055 || pSkill->iNeedSkill==2055)
-	{
-		if((LeftItem != ITEM_CLASS_SWORD && LeftItem != ITEM_CLASS_AXE && LeftItem != ITEM_CLASS_MACE ) ||
-			(RightItem != ITEM_CLASS_SWORD && RightItem != ITEM_CLASS_AXE && RightItem != ITEM_CLASS_MACE) )
-		{
-			std::string buff = fmt::format_text_resource(IDS_SKILL_FAIL_INVALID_ITEM);
-			m_pGameProcMain->MsgOutput(buff, 0xffffff00);
-			return false;
-		}
-	}
-	else if(pSkill->iNeedSkill==1056 || pSkill->iNeedSkill==2056)
-	{
-		if(	RightItem != ITEM_CLASS_SWORD_2H && RightItem != ITEM_CLASS_AXE_2H &&
-			RightItem != ITEM_CLASS_MACE_2H && RightItem != ITEM_CLASS_POLEARM )
-		{
-			std::string buff = fmt::format_text_resource(IDS_SKILL_FAIL_INVALID_ITEM);
-			m_pGameProcMain->MsgOutput(buff, 0xffffff00);
-			return false;
-		}
-	}
 
 	if(pInfoBase->iHP < pSkill->iExhaustHP)
 	{

--- a/Server/Ebenezer/MagicProcess.cpp
+++ b/Server/Ebenezer/MagicProcess.cpp
@@ -845,47 +845,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 			goto fail_return;
 		}
 
-		// Weapons verification in case of COMBO attack (another hacking prevention).
-		if (pTable->Type1 == 1)
-		{
-			// Weapons verification in case of DUAL ATTACK (type 1)!
-			if (pTable->Skill == 1055
-				|| pTable->Skill == 2055)
-			{
-				// Get item info for left hand.
-				model::Item* pLeftHand = m_pMain->m_ItemTableMap.GetData(m_pSrcUser->m_pUserData->m_sItemArray[LEFTHAND].nNum);
-				if (pLeftHand == nullptr)
-					return nullptr;
-
-				// Get item info for right hand.
-				model::Item* pRightHand = m_pMain->m_ItemTableMap.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
-				if (pRightHand == nullptr)
-					return nullptr;
-
-				int left_index = pLeftHand->Kind / 10;
-				int right_index = pRightHand->Kind / 10;
-
-				if ((left_index != WEAPON_SWORD && left_index != WEAPON_AXE && left_index != WEAPON_MACE)
-					&& (right_index != WEAPON_SWORD && right_index != WEAPON_AXE && right_index != WEAPON_MACE))
-					return nullptr;
-			}
-			// Weapons verification in case of DOUBLE ATTACK !
-			else if (pTable->Skill == 1056
-				|| pTable->Skill == 2056)
-			{
-				// Get item info for right hand.
-				model::Item* pRightHand = m_pMain->m_ItemTableMap.GetData(m_pSrcUser->m_pUserData->m_sItemArray[RIGHTHAND].nNum);
-				if (pRightHand == nullptr)
-					return nullptr;
-
-				int right_index = pRightHand->Kind / 10;
-
-				if ((right_index != WEAPON_SWORD && right_index != WEAPON_AXE && right_index != WEAPON_MACE
-					&& right_index != WEAPON_SPEAR)
-					|| m_pSrcUser->m_pUserData->m_sItemArray[LEFTHAND].nNum != 0)
-					return nullptr;
-			}
-		}
+		
 
 		// MP/SP SUBTRACTION ROUTINE!!! ITEM AND HP TOO!!!
 		if (type == MAGIC_EFFECTING)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
wrong hacking prevention causes game to differ from original behavior.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
It is removed and now magicskillmanager is closer to original behavior.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
First part of deleted if block checks for skill IDs 1055xx, those skills are warrior attack skills. That include shear, pierce, leg cutting, carver, sever, prick, multiple shock, cleave, mangling and trust. Removed code prevent using those skills when dual 1h weapons are not equipped.

Second part of deleted if block checks for skill IDs 1056xx, those skills are warrior defence skills. That include hinder,resists,arrest,endure ... sacrifice. Code claims : defense skills cannot be used if we are not equipping 2h weapons.

Both those behaviors are wrong, this can be verified with original exe and equipping mentioned items. For example, when player equip 2h weapons original exe's skill bar and skill tree dlg shows skills usable ( for attack skills ). It is same for defense skills as well.  

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
