### PR TITLE
removal of irrelevant check

### DIFF
--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -644,18 +644,6 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL* pSkil
 
 		if (pItem->byAttachPoint == ITEM_LIMITED_EXHAUST)
 		{
-			// 종족 체크..
-			switch ( pItem->byNeedRace )
-			{
-				case 0:
-					break;
-
-				default:
-					if ( pItem->byNeedRace != CGameBase::s_pPlayer->m_InfoBase.eRace )
-						return false;
-					break;
-			}
-
 			// 직업 체크..
 			if (pItem->byNeedClass != 0)
 			{


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Having irrelevant code inside SkillMng.cpp can cause future problems.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Irrelevant controller removed.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
This part of code checks for items which has byAttachPoint = 17 & byNeedRace = playerRace
there are no such items, byNeedRace probably implemented / translated wrong. only a few items have byNeedRace rather than 0 and those items' value is 20. None of those items with 20 value has byAttachPoint = 17, they differ but never 17. Those items are dumplings (user kill rewards), rice cakes etc.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
