### PR TITLE
Update skill HP requirement for Sacrifice skill

### DIFF
--- a/Client/WarFare/MagicSkillMng.cpp
+++ b/Client/WarFare/MagicSkillMng.cpp
@@ -198,6 +198,10 @@ bool CMagicSkillMng::HasRequiredMana(const __TABLE_UPC_SKILL* pSkill) const
 
 bool CMagicSkillMng::HasRequiredHealth(const __TABLE_UPC_SKILL* pSkill) const
 {
+	// Ignore HP requirement for Sacrifice skill.
+	if (pSkill->iExhaustHP >= 10000)
+		return true;
+
 	return s_pPlayer->m_InfoBase.iHP >= pSkill->iExhaustHP;
 }
 


### PR DESCRIPTION
Restore skill HP requirement check originally from #421, ignoring the HP requirement for the Sacrifice skill.