### PR TITLE
Restore back button for character selection

### DIFF
--- a/Client/WarFare/UICharacterSelect.h
+++ b/Client/WarFare/UICharacterSelect.h
@@ -11,27 +11,30 @@
 
 #include <N3Base/N3UIBase.h>
 
+struct __CharacterSelectInfo;
 class CUICharacterSelect : public CN3UIBase
 {
 protected:
-	CN3UIBase* m_pBtnLeft;
-	CN3UIBase* m_pBtnRight;
-	CN3UIBase* m_pBtnExit;
-	CN3UIBase* m_pBtnDelete;
+	CN3UIBase*		m_pBtnLeft;
+	CN3UIBase*		m_pBtnRight;
+	CN3UIBase*		m_pBtnExit;
+	CN3UIBase*		m_pBtnDelete;
+	CN3UIBase*		m_pBtnBack;
+	CN3UIString*	m_pUserInfoStr;
 
 public:
-	uint32_t MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT& ptOld);
-	bool OnKeyPress(int iKey);
+	uint32_t MouseProc(uint32_t dwFlags, const POINT& ptCur, const POINT& ptOld) override;
+	bool OnKeyPress(int iKey) override;
 	CUICharacterSelect();
-	virtual ~CUICharacterSelect();
+	~CUICharacterSelect() override;
 
-	virtual void	Release();
-	virtual bool	Load(HANDLE hFile);
-	virtual void	Tick();
-	virtual bool	ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg);
+	void Release() override;
+	bool Load(HANDLE hFile) override;
+	void Tick() override;
+	bool ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg) override;
 
-	void	DisplayChrInfo(__CharacterSelectInfo* pCSInfo);
-	void	DontDisplayInfo();
+	void DisplayChrInfo(__CharacterSelectInfo* pCSInfo);
+	void DontDisplayInfo();
 };
 
 #endif // !defined(AFX_UICharacterSelect_H__665CADA6_E25B_47D6_B962_6DA49673048F__INCLUDED_)


### PR DESCRIPTION
The back button on the character selection screen is currently explicitly hidden.
This is moved into position as matching the UIF (15 pixels above the "Exit" button).

Server/client logic does not handle this exceptionally well, but since arbitrary unrelated fresh connections to a freshly restarted server with an empty CURRENTUSER table seems to be flakey all on its own, that's a problem for another time. There's likely a few different unrelated issues at play there.

*When* a connection is correctly established, it does tend to allow you to go back now, and then reconnect to the game server just fine.

Resolves #44 

<img width="967" height="746" alt="image" src="https://github.com/user-attachments/assets/a3310e7d-3d02-4258-ac4d-56512ae9411e" />
