### PR TITLE
Add unofficial internal cooldown to establishing game connections

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -23,6 +23,15 @@
 
 constexpr int CURRENT_VERSION = 1298;
 
+// This is the maximum time we must wait after sending the WIZ_VERSION_CHECK packet on the login scene, before we're allowed
+// to attempt to re-establish a connection to the game server.
+// We'll use 5 seconds here as it's a more than reasonable enough time for it to receive a packet, even with lag, while not being
+// too excessive.
+// If the client disconnects in this time, this timer will be reset, so there's no need to account for this.
+// Officially it Sleep()s for 1 second prior to even sending WIZ_VERSION_CHECK packet we need to wait for, so there's not really
+// a comparable official limit. All this accomplishes is reducing the number of connection attempts, not preventing overlaps.
+constexpr float TIME_UNTIL_NEXT_GAME_CONNECTION_ATTEMPT = 5.0f;
+
 constexpr float PACKET_INTERVAL_MOVE = 1.5f;				// Interval between regularly sent player/NPC movement packets.
 constexpr float PACKET_INTERVAL_ROTATE = 4.0f;				// Interval between regularly sent player rotation packets.
 constexpr float PACKET_INTERVAL_REQUEST_TARGET_HP = 2.0f;

--- a/Client/WarFare/GameProcLogIn_1098.cpp
+++ b/Client/WarFare/GameProcLogIn_1098.cpp
@@ -40,6 +40,7 @@ CGameProcLogIn_1098::CGameProcLogIn_1098()
 		m_pLights[i] = nullptr;
 
 	m_bLogIn = false; // 로그인 중복 방지..
+	m_fTimeUntilNextGameConnectionAttempt = 0.0f;
 }
 
 CGameProcLogIn_1098::~CGameProcLogIn_1098()
@@ -172,11 +173,26 @@ void CGameProcLogIn_1098::Init()
 	{
 		MsgSend_AccountLogIn(s_eLogInClassification); // 로그인..
 	}
+
+	// Re-entered the scene; we can reset any existing timer.
+	// The point of this delay is to prevent the user from intentionally or otherwise spamming connections
+	// to the game server, in the small window where we're still on the login scene and are waiting for the
+	// game server to respond.
+	// Once we've changed scenes, this timer doesn't matter anymore; we can't continue to spam it.
+	// Returning back to this scene, then, means we're fine to have it reset.
+	ResetGameConnectionAttemptTimer();
 }
 
 void CGameProcLogIn_1098::Tick() // 프로시져 인덱스를 리턴한다. 0 이면 그대로 진행
 {
 	CGameProcedure::Tick();	// 키, 마우스 입력 등등..
+
+	if (m_fTimeUntilNextGameConnectionAttempt > 0.0f)
+	{
+		m_fTimeUntilNextGameConnectionAttempt -= s_fSecPerFrm;
+		if (m_fTimeUntilNextGameConnectionAttempt < 0.0f)
+			m_fTimeUntilNextGameConnectionAttempt = 0.0f;
+	}
 
 	for (int i = 0; i < 3; i++)
 		m_pLights[i]->Tick();
@@ -491,7 +507,7 @@ bool CGameProcLogIn_1098::ProcessPacket(Packet & pkt)
 
 void CGameProcLogIn_1098::ConnectToGameServer() // 고른 게임 서버에 접속
 {
-	if (s_fTimeUntilNextGameConnectionAttempt > 0.0f)
+	if (m_fTimeUntilNextGameConnectionAttempt > 0.0f)
 		return;
 
 	__GameServerInfo GSI;
@@ -510,7 +526,7 @@ void CGameProcLogIn_1098::ConnectToGameServer() // 고른 게임 서버에 접�
 	else
 	{
 		s_szServer = GSI.szName;
-		s_fTimeUntilNextGameConnectionAttempt = TIME_UNTIL_NEXT_GAME_CONNECTION_ATTEMPT;
+		m_fTimeUntilNextGameConnectionAttempt = TIME_UNTIL_NEXT_GAME_CONNECTION_ATTEMPT;
 
 		MsgSend_VersionCheck();
 	}

--- a/Client/WarFare/GameProcLogIn_1098.cpp
+++ b/Client/WarFare/GameProcLogIn_1098.cpp
@@ -491,6 +491,9 @@ bool CGameProcLogIn_1098::ProcessPacket(Packet & pkt)
 
 void CGameProcLogIn_1098::ConnectToGameServer() // 고른 게임 서버에 접속
 {
+	if (s_fTimeUntilNextGameConnectionAttempt > 0.0f)
+		return;
+
 	__GameServerInfo GSI;
 	if (!m_pUILogIn->ServerInfoGetCur(GSI))
 		return; // 서버를 고른다음..
@@ -507,6 +510,8 @@ void CGameProcLogIn_1098::ConnectToGameServer() // 고른 게임 서버에 접�
 	else
 	{
 		s_szServer = GSI.szName;
+		s_fTimeUntilNextGameConnectionAttempt = TIME_UNTIL_NEXT_GAME_CONNECTION_ATTEMPT;
+
 		MsgSend_VersionCheck();
 	}
 }

--- a/Client/WarFare/GameProcLogIn_1098.h
+++ b/Client/WarFare/GameProcLogIn_1098.h
@@ -17,24 +17,30 @@ public:
 	bool					m_bLogIn; // 로그인 중복 방지..
 	std::string				m_szRegistrationSite;
 
+	float					m_fTimeUntilNextGameConnectionAttempt;
+
 public:
-	void	MsgRecv_GameServerGroupList(Packet& pkt);
-	void	MsgRecv_AccountLogIn(int iCmd, Packet& pkt);
-	int		MsgRecv_VersionCheck(Packet& pkt); // virtual
-	int		MsgRecv_GameServerLogIn(Packet& pkt); // virtual - 국가 번호를 리턴한다.
+	inline void ResetGameConnectionAttemptTimer()
+	{
+		m_fTimeUntilNextGameConnectionAttempt = 0.0f;
+	}
 
-	bool	MsgSend_AccountLogIn(enum e_LogInClassification eLIC);
+	void MsgRecv_GameServerGroupList(Packet& pkt);
+	void MsgRecv_AccountLogIn(int iCmd, Packet& pkt);
+	int	 MsgRecv_VersionCheck(Packet& pkt) override;
+	int	 MsgRecv_GameServerLogIn(Packet& pkt) override; // 국가 번호를 리턴한다.
 
-	void Release();
-	void Init();
-	void Tick();
-	void Render();
+	bool MsgSend_AccountLogIn(enum e_LogInClassification eLIC);
+
+	void Release() override;
+	void Init() override;
+	void Tick() override;
+	void Render() override;
 
 protected:
 	bool ProcessPacket(Packet& pkt) override;
 
 public:
-
 	void ConnectToGameServer(); // 고른 게임 서버에 접속
 	CGameProcLogIn_1098();
 	~CGameProcLogIn_1098() override;

--- a/Client/WarFare/GameProcLogIn_1298.cpp
+++ b/Client/WarFare/GameProcLogIn_1298.cpp
@@ -32,6 +32,7 @@ CGameProcLogIn_1298::CGameProcLogIn_1298()
 {
 	m_pUILogIn	= nullptr;
 	m_bLogIn	= false; // 로그인 중복 방지..
+	m_fTimeUntilNextGameConnectionAttempt = 0.0f;
 }
 
 CGameProcLogIn_1298::~CGameProcLogIn_1298()
@@ -137,6 +138,26 @@ void CGameProcLogIn_1298::Init()
 	if (LIC_KNIGHTONLINE != s_eLogInClassification)
 	{
 		MsgSend_AccountLogIn(s_eLogInClassification); // 로그인..
+	}
+
+	// Re-entered the scene; we can reset any existing timer.
+	// The point of this delay is to prevent the user from intentionally or otherwise spamming connections
+	// to the game server, in the small window where we're still on the login scene and are waiting for the
+	// game server to respond.
+	// Once we've changed scenes, this timer doesn't matter anymore; we can't continue to spam it.
+	// Returning back to this scene, then, means we're fine to have it reset.
+	ResetGameConnectionAttemptTimer();
+}
+
+void CGameProcLogIn_1298::Tick()
+{
+	CGameProcedure::Tick();
+
+	if (m_fTimeUntilNextGameConnectionAttempt > 0.0f)
+	{
+		m_fTimeUntilNextGameConnectionAttempt -= s_fSecPerFrm;
+		if (m_fTimeUntilNextGameConnectionAttempt < 0.0f)
+			m_fTimeUntilNextGameConnectionAttempt = 0.0f;
 	}
 }
 
@@ -452,7 +473,7 @@ bool CGameProcLogIn_1298::ProcessPacket(Packet & pkt)
 
 void CGameProcLogIn_1298::ConnectToGameServer() // 고른 게임 서버에 접속
 {
-	if (s_fTimeUntilNextGameConnectionAttempt > 0.0f)
+	if (m_fTimeUntilNextGameConnectionAttempt > 0.0f)
 		return;
 
 	__GameServerInfo GSI;
@@ -471,7 +492,7 @@ void CGameProcLogIn_1298::ConnectToGameServer() // 고른 게임 서버에 접�
 	else
 	{
 		s_szServer = GSI.szName;
-		s_fTimeUntilNextGameConnectionAttempt = TIME_UNTIL_NEXT_GAME_CONNECTION_ATTEMPT;
+		m_fTimeUntilNextGameConnectionAttempt = TIME_UNTIL_NEXT_GAME_CONNECTION_ATTEMPT;
 
 		MsgSend_VersionCheck();
 	}

--- a/Client/WarFare/GameProcLogIn_1298.cpp
+++ b/Client/WarFare/GameProcLogIn_1298.cpp
@@ -455,6 +455,9 @@ bool CGameProcLogIn_1298::ProcessPacket(Packet & pkt)
 
 void CGameProcLogIn_1298::ConnectToGameServer() // 고른 게임 서버에 접속
 {
+	if (s_fTimeUntilNextGameConnectionAttempt > 0.0f)
+		return;
+
 	__GameServerInfo GSI;
 	if (!m_pUILogIn->ServerInfoGetCur(GSI))
 		return; // 서버를 고른다음..
@@ -471,6 +474,8 @@ void CGameProcLogIn_1298::ConnectToGameServer() // 고른 게임 서버에 접�
 	else
 	{
 		s_szServer = GSI.szName;
+		s_fTimeUntilNextGameConnectionAttempt = TIME_UNTIL_NEXT_GAME_CONNECTION_ATTEMPT;
+
 		MsgSend_VersionCheck();
 	}
 }

--- a/Client/WarFare/GameProcLogIn_1298.h
+++ b/Client/WarFare/GameProcLogIn_1298.h
@@ -4,33 +4,41 @@
 
 #include "GameProcedure.h"
 
+class CUILogIn_1298;
 class CGameProcLogIn_1298 : public CGameProcedure
 {
 public:
-	class CUILogIn_1298*		m_pUILogIn;
+	CUILogIn_1298*	m_pUILogIn;
 	
 	bool			m_bLogIn; // 로그인 중복 방지..
 	std::string		m_szRegistrationSite;
 
-public:
-	void	MsgRecv_GameServerGroupList(Packet& pkt);
-	void	MsgRecv_AccountLogIn(int iCmd, Packet& pkt);
-	int		MsgRecv_VersionCheck(Packet& pkt) override; // virtual
-	int		MsgRecv_GameServerLogIn(Packet& pkt) override; // virtual - 국가 번호를 리턴한다.
-	void	MsgRecv_News(Packet& pkt);
+	float			m_fTimeUntilNextGameConnectionAttempt;
 
-	bool	MsgSend_AccountLogIn(enum e_LogInClassification eLIC);
-	bool	MsgSend_NewsReq();
+public:
+	inline void ResetGameConnectionAttemptTimer()
+	{
+		m_fTimeUntilNextGameConnectionAttempt = 0.0f;
+	}
+
+	void MsgRecv_GameServerGroupList(Packet& pkt);
+	void MsgRecv_AccountLogIn(int iCmd, Packet& pkt);
+	int MsgRecv_VersionCheck(Packet& pkt) override;
+	int MsgRecv_GameServerLogIn(Packet& pkt) override; // 국가 번호를 리턴한다.
+	void MsgRecv_News(Packet& pkt);
+
+	bool MsgSend_AccountLogIn(enum e_LogInClassification eLIC);
+	bool MsgSend_NewsReq();
 
 	void Release() override;
 	void Init() override;
+	void Tick() override;
 	void Render() override;
 
 protected:
 	bool ProcessPacket(Packet& pkt) override;
 
 public:
-
 	void ConnectToGameServer(); // 고른 게임 서버에 접속
 	CGameProcLogIn_1298();
 	~CGameProcLogIn_1298() override;

--- a/Client/WarFare/GameProcedure.cpp
+++ b/Client/WarFare/GameProcedure.cpp
@@ -101,8 +101,6 @@ bool CGameProcedure::s_bIsRestarting = false;
 // NOTE: adding boolean to check if window has focus or not
 bool CGameProcedure::s_bIsWindowInFocus = true;
 
-float CGameProcedure::s_fTimeUntilNextGameConnectionAttempt = 0.0f;
-
 CGameProcedure::CGameProcedure()
 {
 	m_bCursorLocked = false;
@@ -348,13 +346,6 @@ void CGameProcedure::Tick()
 
 	if (s_pGameCursor != nullptr)
 		s_pGameCursor->Tick();
-
-	if (s_fTimeUntilNextGameConnectionAttempt > 0.0f)
-	{
-		s_fTimeUntilNextGameConnectionAttempt -= s_fSecPerFrm;
-		if (s_fTimeUntilNextGameConnectionAttempt < 0.0f)
-			s_fTimeUntilNextGameConnectionAttempt = 0.0f;
-	}
 
 	ProcessUIKeyInput();
 
@@ -843,7 +834,8 @@ void CGameProcedure::ReportServerConnectionFailed(const std::string& szServerNam
 void CGameProcedure::ReportServerConnectionClosed(bool bNeedQuitGame)
 {
 	// Reset timer to allow immediate reconnections.
-	s_fTimeUntilNextGameConnectionAttempt = 0.0f;
+	if (s_pProcLogIn != nullptr)
+		s_pProcLogIn->ResetGameConnectionAttemptTimer();
 
 	if (!s_bNeedReportConnectionClosed)
 		return;

--- a/Client/WarFare/GameProcedure.cpp
+++ b/Client/WarFare/GameProcedure.cpp
@@ -345,6 +345,7 @@ void CGameProcedure::StaticMemberRelease()
 void CGameProcedure::Tick()
 {
 	s_pLocalInput->Tick(); // 키보드와 마우스로부터 입력을 받는다.
+
 	if (s_pGameCursor != nullptr)
 		s_pGameCursor->Tick();
 
@@ -851,7 +852,7 @@ void CGameProcedure::ReportServerConnectionClosed(bool bNeedQuitGame)
 	e_Behavior eBehavior = ((bNeedQuitGame) ? BEHAVIOR_EXIT : BEHAVIOR_NOTHING);
 	MessageBoxPost(szMsg, "", MB_OK, eBehavior);
 
-	if (s_pPlayer)
+	if (s_pPlayer != nullptr)
 	{
 		__Vector3 vPos = s_pPlayer->Position();
 		CLogWriter::Write("Socket Closed... Zone({}) Pos({:.1f}, {:.1f}, {:.1f}) Exp({})",

--- a/Client/WarFare/GameProcedure.cpp
+++ b/Client/WarFare/GameProcedure.cpp
@@ -101,6 +101,8 @@ bool CGameProcedure::s_bIsRestarting = false;
 // NOTE: adding boolean to check if window has focus or not
 bool CGameProcedure::s_bIsWindowInFocus = true;
 
+float CGameProcedure::s_fTimeUntilNextGameConnectionAttempt = 0.0f;
+
 CGameProcedure::CGameProcedure()
 {
 	m_bCursorLocked = false;
@@ -343,7 +345,15 @@ void CGameProcedure::StaticMemberRelease()
 void CGameProcedure::Tick()
 {
 	s_pLocalInput->Tick(); // 키보드와 마우스로부터 입력을 받는다.
-	if(s_pGameCursor) s_pGameCursor->Tick();
+	if (s_pGameCursor != nullptr)
+		s_pGameCursor->Tick();
+
+	if (s_fTimeUntilNextGameConnectionAttempt > 0.0f)
+	{
+		s_fTimeUntilNextGameConnectionAttempt -= s_fSecPerFrm;
+		if (s_fTimeUntilNextGameConnectionAttempt < 0.0f)
+			s_fTimeUntilNextGameConnectionAttempt = 0.0f;
+	}
 
 	ProcessUIKeyInput();
 
@@ -825,13 +835,15 @@ void CGameProcedure::ReportServerConnectionFailed(const std::string& szServerNam
 {
 	std::string szMsg = fmt::format_text_resource(IDS_FMT_CONNECT_ERROR, szServerName, iErrCode);
 	
-	e_Behavior eBehavior = ((bNeedQuitGame) ? BEHAVIOR_EXIT : BEHAVIOR_NOTHING);
+	e_Behavior eBehavior = (bNeedQuitGame ? BEHAVIOR_EXIT : BEHAVIOR_NOTHING);
 	MessageBoxPost(szMsg, "", MB_OK, eBehavior);
-	return;
 }
 
 void CGameProcedure::ReportServerConnectionClosed(bool bNeedQuitGame)
 {
+	// Reset timer to allow immediate reconnections.
+	s_fTimeUntilNextGameConnectionAttempt = 0.0f;
+
 	if (!s_bNeedReportConnectionClosed)
 		return;
 
@@ -839,7 +851,7 @@ void CGameProcedure::ReportServerConnectionClosed(bool bNeedQuitGame)
 	e_Behavior eBehavior = ((bNeedQuitGame) ? BEHAVIOR_EXIT : BEHAVIOR_NOTHING);
 	MessageBoxPost(szMsg, "", MB_OK, eBehavior);
 
-	if(s_pPlayer)
+	if (s_pPlayer)
 	{
 		__Vector3 vPos = s_pPlayer->Position();
 		CLogWriter::Write("Socket Closed... Zone({}) Pos({:.1f}, {:.1f}, {:.1f}) Exp({})",
@@ -850,7 +862,8 @@ void CGameProcedure::ReportServerConnectionClosed(bool bNeedQuitGame)
 		CLogWriter::Write("Socket Closed...");
 	}
 
-	if(s_pSocket) s_pSocket->Release();
+	if (s_pSocket!= nullptr)
+		s_pSocket->Release();
 }
 
 void CGameProcedure::ReportDebugStringAndSendToServer(const std::string& szDebug)

--- a/Client/WarFare/GameProcedure.h
+++ b/Client/WarFare/GameProcedure.h
@@ -102,8 +102,6 @@ public:
 	// NOTE: adding boolean to check if window has focus or not
 	static bool		s_bIsWindowInFocus;
 
-	static float	s_fTimeUntilNextGameConnectionAttempt;
-
 public:
 	static std::string MessageBoxPost(const std::string& szMsg, const std::string& szTitle, int iStyle, e_Behavior eBehavior = BEHAVIOR_NOTHING);
 	static void MessageBoxClose(const std::string& szMsg);

--- a/Client/WarFare/GameProcedure.h
+++ b/Client/WarFare/GameProcedure.h
@@ -102,6 +102,8 @@ public:
 	// NOTE: adding boolean to check if window has focus or not
 	static bool		s_bIsWindowInFocus;
 
+	static float	s_fTimeUntilNextGameConnectionAttempt;
+
 public:
 	static std::string MessageBoxPost(const std::string& szMsg, const std::string& szTitle, int iStyle, e_Behavior eBehavior = BEHAVIOR_NOTHING);
 	static void MessageBoxClose(const std::string& szMsg);

--- a/Client/WarFare/WarFareMain.cpp
+++ b/Client/WarFare/WarFareMain.cpp
@@ -288,8 +288,7 @@ LRESULT CALLBACK WndProcMain(
 				} break;
 				case FD_CLOSE:
 				{
-					if (CGameProcedure::s_bNeedReportConnectionClosed)
-						CGameProcedure::ReportServerConnectionClosed(true);
+					CGameProcedure::ReportServerConnectionClosed(true);
 					//TRACE("Socket closed..\n");
 				}  break;
 				case FD_READ:


### PR DESCRIPTION
As-is, the client can spam successful game server connections as there's a window between it connecting and sending the WIZ_VERSION_CHECK packet, and it getting a response. In this window, the player can initiate another request, causing it to establish another connection. If the WIZ_VERSION_CHECK packet from the first connection is received, it ends up associating the wrong encryption key -- because that's no longer the session it's using it for.

Notably this is, for the most part, official behaviour. It is very possible to continue to spam the game server with the official client, but they force a 1s delay between connection requests which limits the frequency you can actually spam. The bug is still very much an issue there though.

The official Sleep() approach isn't ideal; it doesn't really solve a lot. We should simply be unable to establish a new game server connection while we're waiting for the WIZ_VERSION_CHECK response. This is unofficial behaviour of course, but it doesn't really affect compatibility between clients (only its connection behaviour for testing). As it is, this causes (more) unintentional disconnects at login, which I'd argue makes it harder to even get to testing 99% of other behaviour, so it should still be improved.

The official Sleep() approach doesn't really prevent the inconsistency of the unintentional "failures". All it does is it stops the game server from being excessively flooded with new connections, since it throttles it to 1 a second.

Instead, we enforce a 5 second internal cooldown on ConnectToGameServer() calls. 5 seconds is plenty of time to receive a packet, even with lag. This is reset if we detect a disconnect, and the timer otherwise ticked down in GameProcLogIn_1098::Tick() / CGameProcLogIn_1298::Tick().

This prevents us from accidentally or otherwise attempting to connect multiple times, causing mixed WIZ_VERSION_CHECK request handling and thus incorrect encryption states/keys from being used.

Resolves #430