### PR TITLE
ByteBuffer: Force explicit reads via read<T>()

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -6373,13 +6373,11 @@ void CGameProcMain::MsgRecv_KnightsListBasic(Packet& pkt) // 기사단 기본 �
 
 void CGameProcMain::MsgRecv_ContinousPacket(Packet& pkt) // 압축된 데이터 이다... 한번 더 파싱해야 한다!!!
 {
-	uint16_t iWholeSize;
-	pkt >> iWholeSize;
+	uint16_t iWholeSize = pkt.read<uint16_t>();
 
 	while (pkt.rpos() < iWholeSize)
 	{
-		uint16_t iSizeThisPacket;
-		pkt >> iSizeThisPacket;
+		uint16_t iSizeThisPacket = pkt.read<uint16_t>();
 
 		if (iSizeThisPacket <= 0 || iSizeThisPacket >= iWholeSize)
 		{
@@ -7836,8 +7834,8 @@ void CGameProcMain::MsgSend_SpeedCheck(bool bInit)
 
 void CGameProcMain::MsgRecv_ClassPromotion(Packet& pkt)
 {
-	uint16_t sClass, socketID;
-	pkt >> sClass >> socketID;
+	uint16_t sClass = pkt.read<uint16_t>();
+	uint16_t socketID = pkt.read<uint16_t>();
 
 	// TODO: Clean this up when CPlayerMySelf is derived properly so we can share this logic in a much nicer fashion.
 	if (socketID == s_pPlayer->IDNumber())

--- a/Server/shared/ByteBuffer.h
+++ b/Server/shared/ByteBuffer.h
@@ -9,100 +9,154 @@ public:
 	constexpr static size_t DEFAULT_SIZE = 32;
 	bool m_doubleByte;
 
-	ByteBuffer(): _rpos(0), _wpos(0), m_doubleByte(true) { _storage.reserve(DEFAULT_SIZE); }
-	ByteBuffer(size_t res): _rpos(0), _wpos(0), m_doubleByte(true) { _storage.reserve(res <= 0 ? DEFAULT_SIZE : res); }
-	ByteBuffer(const ByteBuffer &buf): _rpos(buf._rpos), _wpos(buf._wpos), _storage(buf._storage) { }
-	virtual ~ByteBuffer() {}
+	ByteBuffer()
+		: _rpos(0), _wpos(0), m_doubleByte(true)
+	{
+		_storage.reserve(DEFAULT_SIZE);
+	}
 
-	void clear() 
+	ByteBuffer(size_t res)
+		: _rpos(0), _wpos(0), m_doubleByte(true)
+	{
+		_storage.reserve(res <= 0 ? DEFAULT_SIZE : res);
+	}
+
+	ByteBuffer(const ByteBuffer& buf)
+		: _rpos(buf._rpos), _wpos(buf._wpos), _storage(buf._storage)
+	{
+	}
+
+	virtual ~ByteBuffer()
+	{
+	}
+
+	void clear()
 	{
 		_storage.clear();
 		_rpos = _wpos = 0;
 	}
 
-	template <typename T> void append(T value) { append((uint8_t *)&value, sizeof(value)); }
-	template <typename T> void put(size_t pos,T value) { put(pos,(uint8_t *)&value, sizeof(value)); }
+	template <typename T>
+	void append(T value)
+	{
+		append((uint8_t*) &value, sizeof(value));
+	}
+
+	template <typename T>
+	void put(size_t pos, T value)
+	{
+		put(pos, (uint8_t*) &value, sizeof(value));
+	}
 
 	// stream like operators for storing data
-	ByteBuffer &operator<<(bool value) { append<char>((char)value); return *this; }
+	ByteBuffer& operator<<(bool value)
+	{
+		append<char>((char) value);
+		return *this;
+	}
 
 	// unsigned
-	ByteBuffer &operator<<(uint8_t value)		{ append<uint8_t> (value); return *this; }
-	ByteBuffer &operator<<(uint16_t value)	{ append<uint16_t>(value); return *this; }
-	ByteBuffer &operator<<(uint32_t value)	{ append<uint32_t>(value); return *this; }
-	ByteBuffer &operator<<(uint64_t value)	{ append<uint64_t>(value); return *this; }
-	// signed as in 2e complement
-	ByteBuffer &operator<<(int8_t value)		{ append<int8_t> (value); return *this; }
-	ByteBuffer &operator<<(int16_t value)		{ append<int16_t>(value); return *this; }
-	ByteBuffer &operator<<(int32_t value)		{ append<int32_t>(value); return *this; }
-	ByteBuffer &operator<<(int64_t value)		{ append<int64_t>(value); return *this; }
-	ByteBuffer &operator<<(float value)		{ append<float>(value); return *this; }
-
-	ByteBuffer &operator<<(ByteBuffer &value)
+	ByteBuffer& operator<<(uint8_t value)
 	{
-		if (value.wpos())
+		append<uint8_t>(value);
+		return *this;
+	}
+
+	ByteBuffer& operator<<(uint16_t value)
+	{
+		append<uint16_t>(value);
+		return *this;
+	}
+
+	ByteBuffer& operator<<(uint32_t value)
+	{
+		append<uint32_t>(value);
+		return *this;
+	}
+
+	ByteBuffer& operator<<(uint64_t value)
+	{
+		append<uint64_t>(value);
+		return *this;
+	}
+
+	// signed as in 2e complement
+	ByteBuffer& operator<<(int8_t value)
+	{
+		append<int8_t>(value);
+		return *this;
+	}
+
+	ByteBuffer& operator<<(int16_t value)
+	{
+		append<int16_t>(value);
+		return *this;
+	}
+
+	ByteBuffer& operator<<(int32_t value)
+	{
+		append<int32_t>(value);
+		return *this;
+	}
+
+	ByteBuffer& operator<<(int64_t value)
+	{
+		append<int64_t>(value); return *this;
+	}
+
+	ByteBuffer& operator<<(float value)
+	{
+		append<float>(value);
+		return *this;
+	}
+
+	ByteBuffer& operator<<(ByteBuffer& value)
+	{
+		if (value.wpos() > 0)
 			append(value.contents(), value.wpos());
 		return *this;
 	}
 
-	// stream like operators for reading data
-	ByteBuffer &operator>>(bool &value)		{ value = read<char>() > 0 ? true : false; return *this; }
-	// unsigned
-	ByteBuffer &operator>>(uint8_t &value)	{ value = read<uint8_t>(); return *this; }
-	ByteBuffer &operator>>(uint16_t &value)	{ value = read<uint16_t>(); return *this; }
-	ByteBuffer &operator>>(uint32_t &value)	{ value = read<uint32_t>(); return *this; }
-	ByteBuffer &operator>>(uint64_t &value)	{ value = read<uint64_t>(); return *this; }
-	// signed as in 2e complement
-	ByteBuffer &operator>>(int8_t &value)		{ value = read<int8_t>(); return *this; }
-	ByteBuffer &operator>>(int16_t &value)	{ value = read<int16_t>(); return *this; }
-	ByteBuffer &operator>>(int32_t &value)	{ value = read<int32_t>(); return *this; }
-	ByteBuffer &operator>>(int64_t &value)	{ value = read<int64_t>(); return *this; }
-	ByteBuffer &operator>>(float &value)	{ value = read<float>(); return *this; }
-
 	// Hacky KO string flag - either it's a single byte length, or a double byte.
-	void SByte() { m_doubleByte = false; }
-	void DByte() { m_doubleByte = true; }
-
-	ByteBuffer &operator<<(const std::string &value)  { *this << value.c_str(); return *this; }
-	ByteBuffer &operator<<(std::string &value) { *this << value.c_str(); return *this; }
-	ByteBuffer &operator<<(const char *str) 
+	void SByte()
 	{
-		uint16_t len = (uint16_t)strlen(str);
-		if (m_doubleByte)
-			append((uint8_t*)&len, 2);
-		else
-			append((uint8_t*)&len, 1);
-		append((uint8_t *)str, len);
-		return *this;
-	}	
-	ByteBuffer &operator<<(char *str)  { *this << (const char*)str; return *this; }
-
-	ByteBuffer &operator>>(std::string& value) 
-	{
-		uint16_t len;
-		value.clear();
-		if (m_doubleByte)
-			len = read<uint16_t>();
-		else
-			len = read<uint8_t>();
-
-		if (_rpos + len <= size())
-		{
-			for (uint16_t i = 0; i < len; i++)
-				value.push_back(read<char>());
-		}
-		return *this;
+		m_doubleByte = false;
 	}
 
-	uint8_t operator[](size_t pos) { return read<uint8_t>(pos); }
+	void DByte()
+	{
+		m_doubleByte = true;
+	}
 
-	size_t rpos() const { return _rpos; };
-	size_t rpos(size_t rpos) { return _rpos = rpos; };
-	size_t wpos() const { return _wpos; };
-	size_t wpos(size_t wpos) { return _wpos = wpos; };
+	uint8_t operator[](size_t pos)
+	{
+		return read<uint8_t>(pos);
+	}
+
+	size_t rpos() const
+	{
+		return _rpos;
+	}
+
+	size_t rpos(size_t rpos)
+	{
+		_rpos = rpos;
+		return _rpos;
+	}
+
+	size_t wpos() const
+	{
+		return _wpos;
+	}
+
+	size_t wpos(size_t wpos)
+	{
+		_wpos = wpos;
+		return _wpos;
+	}
 
 	template <typename T>
-	T read() 
+	T read()
 	{
 		T r = read<T>(_rpos);
 		_rpos += sizeof(T);
@@ -110,7 +164,7 @@ public:
 	}
 
 	template <>
-	std::string read() 
+	std::string read()
 	{
 		std::string r;
 		readString(r);
@@ -118,17 +172,17 @@ public:
 	}
 
 	template <typename T>
-	T read(size_t pos) const 
+	T read(size_t pos) const
 	{
 		//ASSERT(pos + sizeof(T) <= size());
 		if (pos + sizeof(T) > size())
-			return (T)0;
-		return *((T*)&_storage[pos]);
+			return (T) 0;
+		return *((T*) &_storage[pos]);
 	}
 
-	void read(void *dest, size_t len) 
+	void read(void* dest, size_t len)
 	{
-		if (_rpos + len <= size()) 
+		if (_rpos + len <= size())
 			memcpy(dest, &_storage[_rpos], len);
 		else // throw error();
 			memset(dest, 0, len);
@@ -176,7 +230,7 @@ public:
 	}
 
 	// one should never use resize
-	void resize(size_t newsize) 
+	void resize(size_t newsize)
 	{
 		_storage.resize(newsize);
 		_rpos = 0;
@@ -189,12 +243,24 @@ public:
 		_wpos = size();
 	}
 
-	void reserve(size_t ressize)  { if (ressize > size()) _storage.reserve(ressize); };
+	void reserve(size_t ressize)
+	{
+		if (ressize > size())
+			_storage.reserve(ressize);
+	}
 
 	// append to the end of buffer
-	void append(const std::string& str) { append((uint8_t *)str.c_str(),str.size() + 1); }
-	void append(const char *src, size_t cnt) { return append((const uint8_t *)src, cnt); }
-	void append(const void *src, size_t cnt)
+	void append(const std::string& str)
+	{
+		append((uint8_t*) str.c_str(), str.size() + 1);
+	}
+
+	void append(const char* src, size_t cnt)
+	{
+		return append((const uint8_t*) src, cnt);
+	}
+
+	void append(const void* src, size_t cnt)
 	{
 		if (!cnt)
 			return;
@@ -209,7 +275,12 @@ public:
 		_wpos += cnt;
 	}
 
-	void append(const ByteBuffer& buffer) { if (buffer.size() > 0) append(buffer.contents(), buffer.size()); }
+	void append(const ByteBuffer& buffer)
+	{
+		if (buffer.size() > 0)
+			append(buffer.contents(), buffer.size());
+	}
+
 	void append(const ByteBuffer& buffer, size_t len)
 	{
 		ASSERT(buffer.rpos() + len <= buffer.size());
@@ -223,7 +294,7 @@ public:
 		buffer.rpos(buffer.rpos() + len);
 	}
 
-	void put(size_t pos, const void *src, size_t cnt) 
+	void put(size_t pos, const void* src, size_t cnt)
 	{
 		ASSERT(pos + cnt <= size());
 		memcpy(&_storage[pos], src, cnt);


### PR DESCRIPTION
Stream operators are nice, but particularly for reads, they mask problems here. If a type externally changes, there's no way to enforce or make it immediately clear what type we're reading.

We should just be explicit about it so that the protocol is immediately obvious and consistent.

Writing is another story. I leave the `>>` operators for now; it may be worth replacing them, but this issue is mitigated simply by enforcing the cast when using the operator, e.g.:
```cpp
pkt << uint16_t(field);
```

This makes it immediately obvious what the protocol is and avoids it breaking when `field` changes externally, though code-wise it obviously isn't enforced. It also ends up not obviously pairing with the reads, but I think it's still a step in the right direction for enforcing consistent protocol behaviour.