### PR TITLE
implementing binding and provoke, type 7 skills

### DIFF
--- a/Server/AIServer/MagicProcess.cpp
+++ b/Server/AIServer/MagicProcess.cpp
@@ -94,7 +94,7 @@ void CMagicProcess::MagicPacket(char* pBuf)
 				break;
 
 			case 7:
-				ExecuteType7(pTable->ID);
+				ExecuteType7(pTable->ID, tid, data1, data2, data3, pTable->Moral);
 				break;
 
 			case 8:
@@ -139,7 +139,7 @@ void CMagicProcess::MagicPacket(char* pBuf)
 					break;
 
 				case 7:
-					ExecuteType7(pTable->ID);
+					ExecuteType7(pTable->ID, tid, data1, data2, data3, pTable->Moral);
 					break;
 
 				case 8:
@@ -601,8 +601,76 @@ void CMagicProcess::ExecuteType6(int magicid)
 {
 }
 
-void CMagicProcess::ExecuteType7(int magicid)
+void CMagicProcess::ExecuteType7(int magicid, int tid, int data1, int data2, int data3, int moral)
 {
+	int damage = 0, result = 1, send_index = 0, attack_type = 0;
+	char send_buff[256] = {};
+	model::MagicType7* pType = nullptr;
+	CNpc* pNpc = nullptr;
+
+	model::Magic* pMagic = m_pMain->m_MagicTableMap.GetData(magicid);
+	if (pMagic == nullptr)
+		return;
+
+	// AoE skills, AoE sleep needs to be implemented
+	if (tid == -1)
+	{
+		AreaAttack(7, magicid, moral, data1, data2, data3, 0, 0);
+		return;
+	}
+
+	pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
+	if (pNpc == nullptr
+		|| pNpc->m_NpcState == NPC_DEAD
+		|| pNpc->m_iHP == 0)
+	{
+		result = 0;
+		goto packet_send;
+	}
+
+	pType = m_pMain->m_MagicType7TableMap.GetData(magicid);      // Get magic skill table type 3.
+	if (pType == nullptr)
+		return;
+
+	damage = pType->Damage;
+	// attacking ex: binding
+	if (damage > 0)
+	{
+		attack_type = magicid;
+		if (!pNpc->SetDamage(attack_type, damage, m_pSrcUser->m_strUserID, m_pSrcUser->m_iUserId + USER_BAND, m_pSrcUser->m_pIocport))
+		{
+			pNpc->SendExpToUserList(); 
+			pNpc->SendDead(m_pSrcUser->m_pIocport);
+			m_pSrcUser->SendAttackSuccess(tid, MAGIC_ATTACK_TARGET_DEAD, damage, pNpc->m_iHP);
+		}
+		else
+		{
+			m_pSrcUser->SendAttackSuccess(tid, ATTACK_SUCCESS, damage, pNpc->m_iHP);
+		}
+	}
+	else // sleeping
+	{
+		// note: sleep works, but duration does not (infinite).
+		pNpc->m_NpcState = NPC_SLEEPING;
+		pNpc->m_Delay = pType->Duration;	
+	}
+
+	
+
+packet_send:
+		SetByte(send_buff, AG_MAGIC_ATTACK_RESULT, send_index);
+		SetByte(send_buff, MAGIC_EFFECTING, send_index);
+		SetDWORD(send_buff, magicid, send_index);
+		SetShort(send_buff, m_pSrcUser->m_iUserId, send_index);
+		SetShort(send_buff, tid, send_index);
+		SetShort(send_buff, data1, send_index);
+		SetShort(send_buff, result, send_index);
+		SetShort(send_buff, data3, send_index);
+		SetShort(send_buff, moral, send_index);
+		SetShort(send_buff, 0, send_index);
+		SetShort(send_buff, 0, send_index);
+		m_pMain->Send(send_buff, send_index, m_pSrcUser->m_curZone);
+
 }
 
 void CMagicProcess::ExecuteType8(int magicid)
@@ -717,6 +785,7 @@ short CMagicProcess::AreaAttack(int magictype, int magicid, int moral, int data1
 {
 	model::MagicType3* pType3 = nullptr;
 	model::MagicType4* pType4 = nullptr;
+	model::MagicType7* pType7 = nullptr;
 	int radius = 0;
 
 	if (magictype == 3)
@@ -740,6 +809,17 @@ short CMagicProcess::AreaAttack(int magictype, int magicid, int moral, int data1
 		}
 
 		radius = pType4->Radius;
+	}
+	else if (magictype == 7)
+	{
+		pType7 = m_pMain->m_MagicType7TableMap.GetData(magicid);
+		if (pType7 == nullptr)
+		{
+			spdlog::error("MagicProcess::AreaAttack: No MAGIC_TYPE7 definition [magicId={}]", magicid);
+			return 0;
+		}
+
+		radius = pType7->Radius;
 	}
 
 	if (radius <= 0)
@@ -816,6 +896,7 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 
 	model::MagicType3* pType3 = nullptr;
 	model::MagicType4* pType4 = nullptr;
+	model::MagicType7* pType7 = nullptr;
 	model::Magic* pMagic = nullptr;
 
 	int damage = 0, tid = 0, target_damage = 0, attribute = 0;
@@ -851,6 +932,17 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 		}
 
 		fRadius = (float) pType4->Radius;
+	}
+	else if (magictype == 7)
+	{
+		pType7 = m_pMain->m_MagicType7TableMap.GetData(magicid);
+		if (pType7 == nullptr)
+		{
+			spdlog::error("MagicProcess::AreaAttackDamage: No MAGIC_TYPE7 definition [magicId={}]", magicid);
+			return;
+		}
+		target_damage = pType7->Damage;
+		fRadius = (float) pType7->Radius;
 	}
 
 	if (fRadius <= 0)
@@ -1017,6 +1109,39 @@ void CMagicProcess::AreaAttackDamage(int magictype, int rx, int rz, int magicid,
 				SetShort(send_buff, 0, send_index);
 				SetShort(send_buff, 0, send_index);
 				m_pMain->Send(send_buff, send_index, m_pSrcUser->m_curZone);
+			}
+			else if (magictype == 7)
+			{
+				damage = target_damage;
+				attack_type = magicid;
+				if (!pNpc->SetDamage(attack_type, damage, m_pSrcUser->m_strUserID, m_pSrcUser->m_iUserId + USER_BAND, m_pSrcUser->m_pIocport))
+				{
+					pNpc->SendExpToUserList();
+					pNpc->SendDead(m_pSrcUser->m_pIocport);
+					m_pSrcUser->SendAttackSuccess(pNpc->m_sNid + NPC_BAND, MAGIC_ATTACK_TARGET_DEAD, damage, pNpc->m_iHP);
+				}
+				else
+				{
+					m_pSrcUser->SendAttackSuccess(pNpc->m_sNid + NPC_BAND, ATTACK_SUCCESS, damage, pNpc->m_iHP);
+				}
+				
+				memset(send_buff, 0, sizeof(send_buff));
+				send_index = 0;
+
+				SetByte(send_buff, AG_MAGIC_ATTACK_RESULT, send_index);
+				SetByte(send_buff, MAGIC_EFFECTING, send_index);
+				SetDWORD(send_buff, magicid, send_index);
+				SetShort(send_buff, m_pSrcUser->m_iUserId, send_index);
+				SetShort(send_buff, pNpc->m_sNid + NPC_BAND, send_index);
+				SetShort(send_buff, data1, send_index);
+				SetShort(send_buff, result, send_index);
+				SetShort(send_buff, data3, send_index);
+				SetShort(send_buff, moral, send_index);
+				SetShort(send_buff, 0, send_index);
+				SetShort(send_buff, 0, send_index);
+
+				m_pMain->Send(send_buff, send_index, m_pSrcUser->m_curZone);
+				
 			}
 		}
 	}

--- a/Server/AIServer/MagicProcess.h
+++ b/Server/AIServer/MagicProcess.h
@@ -30,7 +30,7 @@ public:
 	void ExecuteType10(int magicid);
 	void ExecuteType9(int magicid);
 	void ExecuteType8(int magicid);
-	void ExecuteType7(int magicid);
+	void ExecuteType7(int magicid, int tid, int data1, int data2, int data3, int moral);
 	void ExecuteType6(int magicid);
 	void ExecuteType5(int magicid);
 	void ExecuteType4(int magicid, int sid, int tid, int data1, int data2, int data3, int moral);

--- a/Server/AIServer/ServerDlg.cpp
+++ b/Server/AIServer/ServerDlg.cpp
@@ -274,6 +274,13 @@ BOOL CServerDlg::OnInitDialog()
 		return FALSE;
 	}
 
+	if (!GetMagicType7Data())
+	{
+		spdlog::error("ServerDlg::OnInitDialog: failed to load MAGIC_TYPE7, closing server");
+		EndDialog(IDCANCEL);
+		return FALSE;
+	}
+
 	//----------------------------------------------------------------------
 	//	Load NPC Item Table
 	//----------------------------------------------------------------------
@@ -1081,6 +1088,9 @@ BOOL CServerDlg::DestroyWindow()
 
 	if (!m_MagicType4TableMap.IsEmpty())
 		m_MagicType4TableMap.DeleteAllData();
+
+	if (!m_MagicType7TableMap.IsEmpty())
+		m_MagicType7TableMap.DeleteAllData();
 
 	// Npc Array Delete
 	if (!m_NpcMap.IsEmpty())
@@ -1963,6 +1973,19 @@ BOOL CServerDlg::GetMagicType4Data()
 	}
 
 	spdlog::info("ServerDlg::GetMagicType4Data: MAGIC_TYPE4 loaded");
+	return TRUE;
+}
+
+BOOL CServerDlg::GetMagicType7Data()
+{
+	recordset_loader::STLMap loader(m_MagicType7TableMap);
+	if (!loader.Load_ForbidEmpty())
+	{
+		ReportTableLoadError(loader.GetError(), __func__);
+		return FALSE;
+	}
+
+	spdlog::info("ServerDlg::GetMagicType7Data: MAGIC_TYPE7 loaded");
 	return TRUE;
 }
 

--- a/Server/AIServer/ServerDlg.h
+++ b/Server/AIServer/ServerDlg.h
@@ -59,6 +59,7 @@ typedef CSTLMap <model::MagicType1>			MagicType1TableMap;
 typedef CSTLMap <model::MagicType2>			MagicType2TableMap;
 typedef CSTLMap <model::MagicType3>			MagicType3TableMap;
 typedef CSTLMap	<model::MagicType4>			MagicType4TableMap;
+typedef CSTLMap	<model::MagicType7>			MagicType7TableMap;
 typedef CSTLMap <_PARTY_GROUP>				PartyMap;
 typedef CSTLMap <model::MakeWeapon>			MakeWeaponTableMap;
 typedef CSTLMap <model::MakeItemGradeCode>	MakeGradeItemCodeTableMap;
@@ -143,6 +144,7 @@ public:
 	MagicType2TableMap			m_MagicType2TableMap;
 	MagicType3TableMap			m_MagicType3TableMap;
 	MagicType4TableMap			m_MagicType4TableMap;
+	MagicType7TableMap			m_MagicType7TableMap;
 	MakeWeaponTableMap			m_MakeWeaponTableMap;
 	MakeWeaponTableMap			m_MakeDefensiveTableMap;
 	MakeGradeItemCodeTableMap	m_MakeGradeItemArray;
@@ -228,6 +230,7 @@ private:
 	BOOL GetMagicType2Data();
 	BOOL GetMagicType3Data();
 	BOOL GetMagicType4Data();
+	BOOL GetMagicType7Data();
 	BOOL GetMonsterTableData();
 	BOOL GetNpcTableData();
 	BOOL GetNpcItemTable();

--- a/Server/Ebenezer/AISocket.cpp
+++ b/Server/Ebenezer/AISocket.cpp
@@ -822,6 +822,7 @@ void CAISocket::RecvMagicAttackResult(char* pBuf)
 		if (sid >= USER_BAND
 			&& sid < NPC_BAND)
 		{
+			TRACE("HERE\n");
 			pUser = (CUser*) m_pMain->m_Iocport.m_SockArray[sid];
 			if (pUser == nullptr
 				|| pUser->m_bResHpType == USER_DEAD)

--- a/Server/Ebenezer/EbenezerDlg.cpp
+++ b/Server/Ebenezer/EbenezerDlg.cpp
@@ -438,6 +438,15 @@ BOOL CEbenezerDlg::OnInitDialog()
 		return FALSE;
 	}
 
+	spdlog::info("EbenezerDlg::OnInitDialog: loading MAGIC_TYPE7 table");
+	if (!LoadMagicType7())
+	{
+		spdlog::error("EbenezerDlg::OnInitDialog: failed to cache MAGIC_TYPE7 table, closing");
+		AfxMessageBox(_T("MagicType7 Load Fail"));
+		AfxPostQuitMessage(0);
+		return FALSE;
+	}
+
 	spdlog::info("EbenezerDlg::OnInitDialog: loading MAGIC_TYPE8 table");
 	if (!LoadMagicType8())
 	{
@@ -642,6 +651,9 @@ BOOL CEbenezerDlg::DestroyWindow()
 
 	if (!m_MagicType5TableMap.IsEmpty())
 		m_MagicType5TableMap.DeleteAllData();
+
+	if (!m_MagicType7TableMap.IsEmpty())
+		m_MagicType7TableMap.DeleteAllData();
 
 	if (!m_MagicType8TableMap.IsEmpty())
 		m_MagicType8TableMap.DeleteAllData();
@@ -1346,6 +1358,18 @@ BOOL CEbenezerDlg::LoadMagicType4()
 BOOL CEbenezerDlg::LoadMagicType5()
 {
 	recordset_loader::STLMap loader(m_MagicType5TableMap);
+	if (!loader.Load_ForbidEmpty())
+	{
+		ReportTableLoadError(loader.GetError(), __func__);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+BOOL CEbenezerDlg::LoadMagicType7()
+{
+	recordset_loader::STLMap loader(m_MagicType7TableMap);
 	if (!loader.Load_ForbidEmpty())
 	{
 		ReportTableLoadError(loader.GetError(), __func__);

--- a/Server/Ebenezer/EbenezerDlg.h
+++ b/Server/Ebenezer/EbenezerDlg.h
@@ -59,6 +59,7 @@ typedef CSTLMap <model::MagicType2>			MagicType2TableMap;
 typedef CSTLMap <model::MagicType3>			MagicType3TableMap;
 typedef CSTLMap	<model::MagicType4>			MagicType4TableMap;
 typedef CSTLMap <model::MagicType5>			MagicType5TableMap;
+typedef CSTLMap <model::MagicType7>			MagicType7TableMap;
 typedef CSTLMap <model::MagicType8>			MagicType8TableMap;
 typedef CSTLMap <CNpc>						NpcMap;
 typedef CSTLMap <CAISocket>					AISocketMap;
@@ -119,6 +120,7 @@ public:
 	BOOL LoadMagicType8();
 	BOOL LoadMagicType4();
 	BOOL LoadMagicType5();
+	BOOL LoadMagicType7();
 	BOOL LoadMagicType3();
 	BOOL LoadMagicType2();
 	BOOL LoadMagicType1();
@@ -202,6 +204,7 @@ public:
 	MagicType3TableMap		m_MagicType3TableMap;
 	MagicType4TableMap		m_MagicType4TableMap;
 	MagicType5TableMap		m_MagicType5TableMap;
+	MagicType7TableMap		m_MagicType7TableMap;
 	MagicType8TableMap		m_MagicType8TableMap;
 	CoefficientTableMap		m_CoefficientTableMap;		// 공식 계산 계수데이타 테이블
 	LevelUpTableArray		m_LevelUpTableArray;

--- a/Server/Ebenezer/MagicProcess.cpp
+++ b/Server/Ebenezer/MagicProcess.cpp
@@ -289,11 +289,11 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 			}
 		}
 	}
-
+	
 	// Client indicates that magic failed. Just send back packet.
 	if (command == MAGIC_FAIL)
 		goto return_echo;
-
+	
 	// When the arrow starts flying....
 	if (command == MAGIC_FLYING)
 	{
@@ -330,12 +330,12 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 		}
 		goto return_echo;
 	}
-
+	
 	// If magic was successful...
 	pTable = IsAvailable(magicid, tid, sid, command, data1, data2, data3);
 	if (pTable == nullptr)
 		return;
-
+	
 	if (command == MAGIC_EFFECTING)
 	{
 		int initial_result = 1;
@@ -409,7 +409,7 @@ void CMagicProcess::MagicPacket(char* pBuf, int len)
 				{
 					SetShort(send_buff, 0, send_index);
 				}
-
+				
 				m_pMain->Send_AIServer(m_pSrcUser->m_pUserData->m_bZone, send_buff, send_index);
 			}
 		}
@@ -548,6 +548,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 	CNpc* pMon = nullptr;		// When the monster is the source....
 	BOOL bFlag = FALSE;		// Identifies source : TRUE means source is NPC.
 	model::MagicType5* pType = nullptr;		// Only for type 5 magic!
+	model::MagicType7* pType7 = nullptr;
 
 	int modulator = 0, Class = 0, send_index = 0, moral = 0;	// Variable Initialization.
 	char send_buff[128] = {};
@@ -556,7 +557,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 	model::Magic* pTable = m_pMain->m_MagicTableMap.GetData(magicid);   // Get main magic table.
 	if (pTable == nullptr)
 		goto fail_return;
-
+	
 	// Check source validity when the source is a player.
 	if (sid >= 0
 		&& sid < MAX_USER)
@@ -580,7 +581,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 	{
 		goto fail_return;
 	}
-
+	
 	// Target existence check routine for player.
 	if (tid >= 0
 		&& tid < MAX_USER)
@@ -661,7 +662,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 	{
 		moral = m_pSrcUser->m_pUserData->m_bNation;
 	}
-
+	
 	// Compare morals between source and target character.
 	switch (pTable->Moral)
 	{
@@ -813,7 +814,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 			break;
 //
 	}
-
+	
 	// If the user cast the spell (and not the NPC).....
 	if (!bFlag)
 	{
@@ -841,7 +842,7 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 		{
 			goto fail_return;
 		}
-
+		
 		// MP/SP SUBTRACTION ROUTINE!!! ITEM AND HP TOO!!!
 		if (type == MAGIC_EFFECTING)
 		{
@@ -978,6 +979,25 @@ model::Magic* CMagicProcess::IsAvailable(int magicid, int tid, int sid, BYTE typ
 								goto fail_return;
 							}
 						}
+					}
+				}
+			}
+
+			if (pTable->Type1 == 7) // provoke, binding, sleep
+			{
+				if (tid > NPC_BAND)
+				{
+					pType7 = m_pMain->m_MagicType7TableMap.GetData(magicid);
+					
+					if (pType7 == nullptr) 
+						goto fail_return;
+					
+					if (pType7->TargetChange == 1) // damaging
+					{
+						return pTable;
+					}
+					else if (pType7->TargetChange == 2) // sleeping
+					{
 					}
 				}
 			}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
tables related to type 7 skills not loaded in ebenezer and aiserver. No method exists to make those skills work.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
Tables loaded, Attacking type of type 7 made working ( binding and provoke ). Had problems with duration resetting and sleeping types and left them empty.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
loaded tables and followed same logic with other skills' implementation.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
