### PR TITLE
CUIExitMenu: Use N3_VERIFY_UI_COMPONENT

### DIFF
--- a/Client/WarFare/UIExitMenu.cpp
+++ b/Client/WarFare/UIExitMenu.cpp
@@ -192,11 +192,11 @@ bool CUIExitMenu::Load(HANDLE hFile)
 {
 	if (!CN3UIBase::Load(hFile))
 		return false;
-	
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Chr, (CN3UIButton*) GetChildByID("btn_chr"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Option, (CN3UIButton*) GetChildByID("btn_option"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Exit, (CN3UIButton*) GetChildByID("btn_exit"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel, (CN3UIButton*) GetChildByID("btn_cancel"));
+
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Chr,		GetChildByID<CN3UIButton>("btn_chr"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Option,	GetChildByID<CN3UIButton>("btn_option"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Exit,		GetChildByID<CN3UIButton>("btn_exit"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel,	GetChildByID<CN3UIButton>("btn_cancel"));
 
 	return true;
 }

--- a/Client/WarFare/UIExitMenu.cpp
+++ b/Client/WarFare/UIExitMenu.cpp
@@ -192,11 +192,11 @@ bool CUIExitMenu::Load(HANDLE hFile)
 {
 	if (!CN3UIBase::Load(hFile))
 		return false;
-
-	m_pBtn_Chr		= (CN3UIButton*) GetChildByID("btn_chr");		__ASSERT(m_pBtn_Chr, "NULL UI Component!!");
-	m_pBtn_Option	= (CN3UIButton*) GetChildByID("btn_option");	__ASSERT(m_pBtn_Option, "NULL UI Component!!");
-	m_pBtn_Exit		= (CN3UIButton*) GetChildByID("btn_exit");		__ASSERT(m_pBtn_Exit, "NULL UI Component!!");
-	m_pBtn_Cancel	= (CN3UIButton*) GetChildByID("btn_cancel");	__ASSERT(m_pBtn_Cancel, "NULL UI Component!!");
+	
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Chr, (CN3UIButton*) GetChildByID("btn_chr"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Option, (CN3UIButton*) GetChildByID("btn_option"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Exit, (CN3UIButton*) GetChildByID("btn_exit"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel, (CN3UIButton*) GetChildByID("btn_cancel"));
 
 	return true;
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Code style update (formatting, renaming)

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
uses old way to load UI elements.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
__ASSERT is replaced with N3_VERIFY_UI_COMPONENT

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
code clean-up.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
