### PR TITLE
CUIHelp: Use N3_VERIFY_UI_COMPONENT + CN3UIButton button types

### DIFF
--- a/Client/WarFare/UIHelp.cpp
+++ b/Client/WarFare/UIHelp.cpp
@@ -19,10 +19,10 @@ static char THIS_FILE[]=__FILE__;
 
 CUIHelp::CUIHelp()
 {
-	m_pBtn_Close = NULL;
-	m_pBtn_Prev = NULL;
-	m_pBtn_Next = NULL;
-	for(int i = 0; i < MAX_HELP_PAGE; i++) m_pPages[i] = NULL;
+	m_pBtn_Close = nullptr;
+	m_pBtn_Prev = nullptr;
+	m_pBtn_Next = nullptr;
+	for(int i = 0; i < MAX_HELP_PAGE; i++) m_pPages[i] = nullptr;
 }
 
 CUIHelp::~CUIHelp()
@@ -47,9 +47,9 @@ bool CUIHelp::Load(HANDLE hFile)
 		}
 	}
 
-	m_pBtn_Close = GetChildByID("Btn_Close");
-	m_pBtn_Prev = GetChildByID("Btn_Left");
-	m_pBtn_Next = GetChildByID("Btn_Right");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Close, (CN3UIButton*) GetChildByID("Btn_Close"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Prev, (CN3UIButton*) GetChildByID("Btn_Left"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Next, (CN3UIButton*) GetChildByID("Btn_Right"));
 
 	return true;
 }
@@ -86,7 +86,7 @@ bool CUIHelp::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 		{
 			for(int i = 0; i < MAX_HELP_PAGE; i++)
 			{
-				if(NULL == m_pPages[i]) continue;
+				if(m_pPages[i] == nullptr) continue;
 
 				m_pPages[i]->SetVisible(false);
 				if(i == iPage) m_pPages[i]->SetVisible(true);
@@ -101,10 +101,10 @@ void CUIHelp::Release()
 {
 	CN3UIBase::Release();
 
-	m_pBtn_Close = NULL;
-	m_pBtn_Prev = NULL;
-	m_pBtn_Next = NULL;
-	for(int i = 0; i < MAX_HELP_PAGE; i++) m_pPages[i] = NULL;
+	m_pBtn_Close = nullptr;
+	m_pBtn_Prev = nullptr;
+	m_pBtn_Next = nullptr;
+	for(int i = 0; i < MAX_HELP_PAGE; i++) m_pPages[i] = nullptr;
 }
 
 bool CUIHelp::OnKeyPress(int iKey)

--- a/Client/WarFare/UIHelp.cpp
+++ b/Client/WarFare/UIHelp.cpp
@@ -6,6 +6,7 @@
 #include "UIHelp.h"
 #include "GameProcedure.h"
 #include "UIManager.h"
+
 #include <N3Base/N3UIButton.h>
 
 #ifdef _DEBUG
@@ -23,7 +24,9 @@ CUIHelp::CUIHelp()
 	m_pBtn_Close = nullptr;
 	m_pBtn_Prev = nullptr;
 	m_pBtn_Next = nullptr;
-	for(int i = 0; i < MAX_HELP_PAGE; i++) m_pPages[i] = nullptr;
+
+	for (int i = 0; i < MAX_HELP_PAGE; i++)
+		m_pPages[i] = nullptr;
 }
 
 CUIHelp::~CUIHelp()
@@ -48,21 +51,21 @@ bool CUIHelp::Load(HANDLE hFile)
 		}
 	}
 
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Close, (CN3UIButton*) GetChildByID("Btn_Close"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Prev,  (CN3UIButton*) GetChildByID("Btn_Left"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Next,  (CN3UIButton*) GetChildByID("Btn_Right"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Close,	GetChildByID<CN3UIButton>("Btn_Close"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Prev,		GetChildByID<CN3UIButton>("Btn_Left"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Next,		GetChildByID<CN3UIButton>("Btn_Right"));
 
 	return true;
 }
 
 bool CUIHelp::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 {
-	if (dwMsg == UIMSG_BUTTON_CLICK)					
+	if (dwMsg == UIMSG_BUTTON_CLICK)
 	{
 		int iPage = -1;
-		for(int i = 0; i < MAX_HELP_PAGE; i++)
+		for (int i = 0; i < MAX_HELP_PAGE; i++)
 		{
-			if(m_pPages[i] && m_pPages[i]->IsVisible())
+			if (m_pPages[i] != nullptr && m_pPages[i]->IsVisible())
 			{
 				iPage = i;
 				break;
@@ -70,28 +73,34 @@ bool CUIHelp::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 		}
 
 		int iPagePrev = iPage;
-		
-		if(pSender == m_pBtn_Prev)
+
+		if (pSender == m_pBtn_Prev)
 		{
 			iPage--;
-			if(iPage < 0) iPage = 0;
+			if (iPage < 0)
+				iPage = 0;
 		}
-		else if(pSender == m_pBtn_Next)
+		else if (pSender == m_pBtn_Next)
 		{
 			iPage++;
-			if(iPage >= MAX_HELP_PAGE) iPage = 0;
+			if (iPage >= MAX_HELP_PAGE)
+				iPage = 0;
 		}
-		else if(pSender == m_pBtn_Close) this->SetVisible(false);
-
-		if(iPagePrev != iPage)
+		else if (pSender == m_pBtn_Close)
 		{
-			for(int i = 0; i < MAX_HELP_PAGE; i++)
+			SetVisible(false);
+		}
+
+		if (iPagePrev != iPage)
+		{
+			for (int i = 0; i < MAX_HELP_PAGE; i++)
 			{
-				if(m_pPages[i] == nullptr) 
+				if (m_pPages[i] == nullptr)
 					continue;
 
 				m_pPages[i]->SetVisible(false);
-				if(i == iPage) m_pPages[i]->SetVisible(true);
+				if (i == iPage)
+					m_pPages[i]->SetVisible(true);
 			}
 		}
 	}
@@ -106,7 +115,8 @@ void CUIHelp::Release()
 	m_pBtn_Close = nullptr;
 	m_pBtn_Prev = nullptr;
 	m_pBtn_Next = nullptr;
-	for(int i = 0; i < MAX_HELP_PAGE; i++) 
+
+	for (int i = 0; i < MAX_HELP_PAGE; i++) 
 		m_pPages[i] = nullptr;
 }
 
@@ -117,9 +127,11 @@ bool CUIHelp::OnKeyPress(int iKey)
 	case DIK_PRIOR:
 		ReceiveMessage(m_pBtn_Prev, UIMSG_BUTTON_CLICK);
 		return true;
+
 	case DIK_NEXT:
 		ReceiveMessage(m_pBtn_Next, UIMSG_BUTTON_CLICK);
 		return true;
+
 	case DIK_ESCAPE:
 		ReceiveMessage(m_pBtn_Close, UIMSG_BUTTON_CLICK);
 		return true;
@@ -131,7 +143,7 @@ bool CUIHelp::OnKeyPress(int iKey)
 void CUIHelp::SetVisible(bool bVisible)
 {
 	CN3UIBase::SetVisible(bVisible);
-	if(bVisible)
+	if (bVisible)
 		CGameProcedure::s_pUIMgr->SetVisibleFocusedUI(this);
 	else
 		CGameProcedure::s_pUIMgr->ReFocusUI();//this_ui

--- a/Client/WarFare/UIHelp.cpp
+++ b/Client/WarFare/UIHelp.cpp
@@ -6,6 +6,7 @@
 #include "UIHelp.h"
 #include "GameProcedure.h"
 #include "UIManager.h"
+#include <N3Base/N3UIButton.h>
 
 #ifdef _DEBUG
 #undef THIS_FILE
@@ -48,8 +49,8 @@ bool CUIHelp::Load(HANDLE hFile)
 	}
 
 	N3_VERIFY_UI_COMPONENT(m_pBtn_Close, (CN3UIButton*) GetChildByID("Btn_Close"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Prev, (CN3UIButton*) GetChildByID("Btn_Left"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Next, (CN3UIButton*) GetChildByID("Btn_Right"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Prev,  (CN3UIButton*) GetChildByID("Btn_Left"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Next,  (CN3UIButton*) GetChildByID("Btn_Right"));
 
 	return true;
 }
@@ -86,7 +87,8 @@ bool CUIHelp::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 		{
 			for(int i = 0; i < MAX_HELP_PAGE; i++)
 			{
-				if(m_pPages[i] == nullptr) continue;
+				if(m_pPages[i] == nullptr) 
+					continue;
 
 				m_pPages[i]->SetVisible(false);
 				if(i == iPage) m_pPages[i]->SetVisible(true);
@@ -104,7 +106,8 @@ void CUIHelp::Release()
 	m_pBtn_Close = nullptr;
 	m_pBtn_Prev = nullptr;
 	m_pBtn_Next = nullptr;
-	for(int i = 0; i < MAX_HELP_PAGE; i++) m_pPages[i] = nullptr;
+	for(int i = 0; i < MAX_HELP_PAGE; i++) 
+		m_pPages[i] = nullptr;
 }
 
 bool CUIHelp::OnKeyPress(int iKey)

--- a/Client/WarFare/UIHelp.h
+++ b/Client/WarFare/UIHelp.h
@@ -10,6 +10,7 @@
 #endif // _MSC_VER > 1000
 
 #include <N3Base/N3UIBase.h>
+#include <N3Base/N3UIButton.h>
 
 const int MAX_HELP_PAGE = 4;
 
@@ -18,9 +19,9 @@ class CUIHelp : public CN3UIBase
 public:
 	CN3UIBase* m_pPages[MAX_HELP_PAGE];
 
-	CN3UIBase* m_pBtn_Prev;
-	CN3UIBase* m_pBtn_Next;
-	CN3UIBase* m_pBtn_Close;
+	CN3UIButton* m_pBtn_Prev;
+	CN3UIButton* m_pBtn_Next;
+	CN3UIButton* m_pBtn_Close;
 
 public:
 	void SetVisible(bool bVisible);

--- a/Client/WarFare/UIHelp.h
+++ b/Client/WarFare/UIHelp.h
@@ -10,7 +10,6 @@
 #endif // _MSC_VER > 1000
 
 #include <N3Base/N3UIBase.h>
-#include <N3Base/N3UIButton.h>
 
 const int MAX_HELP_PAGE = 4;
 

--- a/Client/WarFare/UIHelp.h
+++ b/Client/WarFare/UIHelp.h
@@ -11,11 +11,11 @@
 
 #include <N3Base/N3UIBase.h>
 
-const int MAX_HELP_PAGE = 4;
-
 class CUIHelp : public CN3UIBase  
 {
 public:
+	static constexpr int MAX_HELP_PAGE = 4;
+
 	CN3UIBase* m_pPages[MAX_HELP_PAGE];
 
 	CN3UIButton* m_pBtn_Prev;
@@ -23,14 +23,14 @@ public:
 	CN3UIButton* m_pBtn_Close;
 
 public:
-	void SetVisible(bool bVisible);
-	bool	OnKeyPress(int iKey);
-	void	Release();
-	bool	Load(HANDLE hFile);
-	bool	ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg);
-
 	CUIHelp();
-	virtual ~CUIHelp();
+	~CUIHelp() override;
+
+	void SetVisible(bool bVisible) override;
+	bool OnKeyPress(int iKey) override;
+	void Release() override;
+	bool Load(HANDLE hFile) override;
+	bool ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg) override;
 };
 
 #endif // !defined(AFX_UIHELP_H__EFE9F4A4_295F_4A67_B97A_1DF248F1101A__INCLUDED_)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Code style update (formatting, renaming)

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
load use old way, NULL macro is used.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
NULL changed to nullptr
N3_VERIFY_UI_COMPONENT used to load UI elements 
Button type changed to N3UIButton from N3UIBase
CN3UIButton included on header

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
clean up & to provide match other parts of UI.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
