### PR TITLE
UICmd : NULL to nullptr, N3_VERIFY to load UI

### DIFF
--- a/Client/WarFare/UICmd.cpp
+++ b/Client/WarFare/UICmd.cpp
@@ -25,27 +25,27 @@ static char THIS_FILE[]=__FILE__;
 
 CUICmd::CUICmd()
 {
-	m_pBtn_Exit = NULL;			//나가기
+	m_pBtn_Exit = nullptr;			//나가기
 
-	m_pBtn_Act = NULL;			//행동
-	m_pBtn_Act_Walk = NULL;	//걷기
-	m_pBtn_Act_Run = NULL;		//달리기
-	m_pBtn_Act_Stop = NULL;	//서기
-	m_pBtn_Act_Attack = NULL;	//공격
+	m_pBtn_Act = nullptr;			//행동
+	m_pBtn_Act_Walk = nullptr;	//걷기
+	m_pBtn_Act_Run = nullptr;		//달리기
+	m_pBtn_Act_Stop = nullptr;	//서기
+	m_pBtn_Act_Attack = nullptr;	//공격
 	
-	m_pBtn_Act_StandUp = NULL; // 일어서기.
-	m_pBtn_Act_SitDown = NULL;	// 앉기
+	m_pBtn_Act_StandUp = nullptr; // 일어서기.
+	m_pBtn_Act_SitDown = nullptr;	// 앉기
 
-	m_pBtn_Camera = NULL;			//카메라
-	m_pBtn_Inventory = NULL;		//아이템 창 
-	m_pBtn_Party_Invite = NULL;	//파티 초대
-	m_pBtn_Party_Disband = NULL;	//파티 탈퇴
-	m_pBtn_CmdList = NULL;			//옵션
-	m_pBtn_Quest = NULL;			//퀘스트
-	m_pBtn_Character = NULL;		//자기 정보창   
-	m_pBtn_Skill = NULL;			//스킬트리 또는 마법창 
-	m_pBtn_Belong = NULL;			//소속 기사단 
-	m_pBtn_Map = NULL;				// 미니맵
+	m_pBtn_Camera = nullptr;			//카메라
+	m_pBtn_Inventory = nullptr;		//아이템 창 
+	m_pBtn_Party_Invite = nullptr;	//파티 초대
+	m_pBtn_Party_Disband = nullptr;	//파티 탈퇴
+	m_pBtn_CmdList = nullptr;			//옵션
+	m_pBtn_Quest = nullptr;			//퀘스트
+	m_pBtn_Character = nullptr;		//자기 정보창   
+	m_pBtn_Skill = nullptr;			//스킬트리 또는 마법창 
+	m_pBtn_Belong = nullptr;			//소속 기사단 
+	m_pBtn_Map = nullptr;				// 미니맵
 }
 
 CUICmd::~CUICmd()
@@ -56,31 +56,31 @@ CUICmd::~CUICmd()
 bool CUICmd::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
-
-	m_pBtn_Act =			GetChildByID("btn_control");	//__ASSERT(m_pBtn_Act, "NULL UI Component!!");
-	m_pBtn_Act_Walk =		GetChildByID("btn_walk");		//__ASSERT(m_pBtn_Act_Walk, "NULL UI Component!!");
-	m_pBtn_Act_Run =		GetChildByID("btn_run");		//__ASSERT(m_pBtn_Act_Run, "NULL UI Component!!");
-	m_pBtn_Act_Stop =		GetChildByID("btn_stop");		//__ASSERT(m_pBtn_Act_Stop, "NULL UI Component!!");
-	m_pBtn_Act_Attack =		GetChildByID("btn_attack");		//__ASSERT(m_pBtn_Act_Attack, "NULL UI Component!!");
-	m_pBtn_Act_StandUp =	GetChildByID("btn_stand");		//__ASSERT(m_pBtn_Act_StandUp, "NULL UI Component!!");
-	m_pBtn_Act_SitDown =	GetChildByID("btn_sit");		//__ASSERT(m_pBtn_Act_SitDown, "NULL UI Component!!");
-
-	if(m_pBtn_Act_StandUp) m_pBtn_Act_StandUp->SetVisible(false); // 일어서기 버튼은 미리 죽여놓는다..
 	
-	m_pBtn_Character =		GetChildByID("btn_character");	//__ASSERT(m_pBtn_Character, "NULL UI Component!!");
-	m_pBtn_Inventory =		GetChildByID("btn_inventory");	//__ASSERT(m_pBtn_Inventory, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Act, GetChildByID("btn_control"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Act_Walk, GetChildByID("btn_walk"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Act_Run, GetChildByID("btn_run"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Act_Stop, GetChildByID("btn_stop"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Act_Attack, GetChildByID("btn_attack"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Act_StandUp, GetChildByID("btn_stand"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Act_SitDown, GetChildByID("btn_sit"));
 
-	m_pBtn_CmdList =			GetChildByID("btn_option");		//__ASSERT(m_pBtn_Option, "NULL UI Component!!");
-	m_pBtn_Camera =			GetChildByID("btn_camera");		//__ASSERT(m_pBtn_Camera, "NULL UI Component!!");
-	m_pBtn_Party_Invite =	GetChildByID("btn_invite");		//__ASSERT(m_pBtn_Party_Invite, "NULL UI Component!!");
-	m_pBtn_Party_Disband =	GetChildByID("btn_disband");	//__ASSERT(m_pBtn_Party_Disband, "NULL UI Component!!");
-	m_pBtn_Skill =			GetChildByID("btn_skill");		//__ASSERT(m_pBtn_Skill, "NULL UI Component!!");
-	m_pBtn_Exit	=			GetChildByID("btn_Exit");		//__ASSERT(m_pBtn_Exit, "NULL UI Component!!");
+	// 일어서기 버튼은 미리 죽여놓는다..
+	if(m_pBtn_Act_StandUp) 
+		m_pBtn_Act_StandUp->SetVisible(false); 
+	
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Character, GetChildByID("btn_character"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Inventory, GetChildByID("btn_inventory"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_CmdList, GetChildByID("btn_option"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Camera, GetChildByID("btn_camera"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Party_Invite, GetChildByID("btn_invite"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Party_Disband, GetChildByID("btn_disband"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Skill, GetChildByID("btn_skill"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Exit, GetChildByID("btn_Exit"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Quest, GetChildByID("btn_quest"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Belong, GetChildByID("btn_knight"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Map, GetChildByID("btn_map"));
 
-	m_pBtn_Quest =		GetChildByID("btn_quest");			//__ASSERT(m_pBtn_Quest, "NULL UI Component!!");
-	m_pBtn_Belong =		GetChildByID("btn_knight");			//__ASSERT(m_pBtn_Belong, "NULL UI Component!!");
-
-	m_pBtn_Map =		GetChildByID("btn_map");			//__ASSERT(m_pBtn_Map, "NULL UI Component!!");
 
 //	this->SetVisibleActButtons(true);
 //	this->SetVisibleOptButtons(false);
@@ -158,7 +158,7 @@ bool CUICmd::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 
 			bool bIAmLeader = false, bIAmMemberOfParty = false;
 			int iMemberIndex = -1;
-			CPlayerBase* pTarget = NULL;
+			CPlayerBase* pTarget = nullptr;
 			pMain->PartyOrForceConditionGet(bIAmLeader, bIAmMemberOfParty, iMemberIndex, pTarget); // 파티의 상황을 보고..
 			
 			std::string szMsg;
@@ -262,7 +262,7 @@ bool CUICmd::OnKeyPress(int iKey)
 			//열려있는 다른 유아이를 닫아준다.
 			CGameProcedure::s_pUIMgr->ReFocusUI();//this_ui
 			CN3UIBase* pFocus = CGameProcedure::s_pUIMgr->GetFocusedUI();
-			if(pFocus && pFocus != this) pFocus->OnKeyPress(iKey);
+			if(pFocus != nullptr && pFocus != this) pFocus->OnKeyPress(iKey);
 		}
 		return true;
 	}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Code style update (formatting, renaming)

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
NULL macro used and UI components loaded by old way.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
NULL converted to nullptr
N3_UI_VERIFY used to load components instead of __ASSERT

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
cleanup

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
