### PR TITLE
Improve CN3UIBase::GetChildByID() lookups

### DIFF
--- a/Client/N3Base/N3UIBase.cpp
+++ b/Client/N3Base/N3UIBase.cpp
@@ -462,19 +462,62 @@ void CN3UIBase::PrintChildIDs(void) {
 	}
 }
 
-CN3UIBase* CN3UIBase::GetChildByID(const std::string& szID)
+CN3UIBase* CN3UIBase::GetChildByID(const std::string_view szID) const
 {
 	if (szID.empty())
 		return nullptr;
 
 	for (CN3UIBase* pChild : m_Children)
 	{
-		if (lstrcmpiA(szID.c_str(), pChild->m_szID.c_str()) == 0)
+		const std::string& childID = pChild->GetID();
+		if (szID.length() == childID.length()
+			&& _strnicmp(szID.data(), childID.data(), szID.length()) == 0)
 			return pChild;
 	}
 
 	return nullptr;
 }
+
+CN3UIBase* CN3UIBase::GetChildByID(const std::string_view szID, eUI_TYPE eUIType) const
+{
+	if (szID.empty())
+		return nullptr;
+
+	for (CN3UIBase* pChild : m_Children)
+	{
+		if (eUIType != pChild->UIType())
+			continue;
+
+		const std::string& childID = pChild->GetID();
+		if (szID.length() == childID.length()
+			&& _strnicmp(szID.data(), childID.data(), szID.length()) == 0)
+			return pChild;
+	}
+
+	return nullptr;
+}
+
+#define IMPL_GETCHILDBYID(Class, UIType)							\
+template <>															\
+Class* CN3UIBase::GetChildByID<Class>(std::string_view szID) const	\
+{																	\
+    return static_cast<Class*>(GetChildByID(szID, UIType));			\
+}
+
+IMPL_GETCHILDBYID(CN3UIArea,		UI_TYPE_AREA);
+IMPL_GETCHILDBYID(CN3UIBase,		UI_TYPE_BASE);
+IMPL_GETCHILDBYID(CN3UIButton,		UI_TYPE_BUTTON);
+IMPL_GETCHILDBYID(CN3UIEdit,		UI_TYPE_EDIT);
+IMPL_GETCHILDBYID(CN3UIImage,		UI_TYPE_IMAGE);
+IMPL_GETCHILDBYID(CN3UIList,		UI_TYPE_LIST);
+IMPL_GETCHILDBYID(CN3UIProgress,	UI_TYPE_PROGRESS);
+IMPL_GETCHILDBYID(CN3UIScrollBar,	UI_TYPE_SCROLLBAR);
+IMPL_GETCHILDBYID(CN3UIStatic,		UI_TYPE_STATIC);
+IMPL_GETCHILDBYID(CN3UIString,		UI_TYPE_STRING);
+IMPL_GETCHILDBYID(CN3UITooltip,		UI_TYPE_TOOLTIP);
+IMPL_GETCHILDBYID(CN3UITrackBar,	UI_TYPE_TRACKBAR);
+
+#undef IMPL_GETCHILDBYID
 
 void CN3UIBase::SetVisible(bool bVisible)
 {

--- a/Client/N3Base/N3UIBase.h
+++ b/Client/N3Base/N3UIBase.h
@@ -94,8 +94,8 @@ protected:
 	UIList		m_Children;		// children pointer list
 	eUI_TYPE	m_eType;		// UI Type - button, image .....
 	eUI_STATE	m_eState;		// UI state
-	uint32_t		m_dwStyle;		// style
-	uint32_t		m_dwReserved;	// 기타 임시로 넣고 싶은 정보를 넣으면 된다.
+	uint32_t	m_dwStyle;		// style
+	uint32_t	m_dwReserved;	// 기타 임시로 넣고 싶은 정보를 넣으면 된다.
 
 	RECT		m_rcRegion;		// UI - screen coordinates (screen : main window client area) 중의 : 부모에 대한 상대좌표가 아니다.
 	RECT		m_rcMovable;	// UI를 드래그 하여 움직이게 할 수 있는 영역 - (screen : main window client area)           ~~~~~~~
@@ -120,11 +120,11 @@ public:
 	void			SetMoveRect(const RECT& Rect) { m_rcMovable = Rect; }
 	RECT			GetMoveRect() { return m_rcMovable; }
 	void			SetReserved(uint32_t dwReserved) {m_dwReserved = dwReserved;}
-	uint32_t			GetReserved() const {return m_dwReserved;}
+	uint32_t		GetReserved() const {return m_dwReserved;}
 	CN3UIBase*		GetParent() const {return m_pParent;}
 	static CN3UIEdit*	GetFocusedEdit() {return s_pFocusedEdit;}
 	static CN3UITooltip*	GetTooltipCtrl() {return s_pTooltipCtrl;}
-	uint32_t			GetStyle()	{return m_dwStyle;}
+	uint32_t		GetStyle()	{return m_dwStyle;}
 
 	void			SetUIType(eUI_TYPE eUIType) { m_eType = eUIType; }	// by ecli666 툴에 기능 넣기 귀찮아서.. ^^
 // Operations
@@ -138,7 +138,15 @@ public:
 	POINT			GetPos() const;
 	virtual void	SetPos(int x, int y);	// 위치 지정(chilren의 위치도 같이 바꾸어준다.) 내부적으로 MoveOffset함수를 부른다.
 	void			SetPosCenter();	// 화면 정가운데로 맞추어준다..(chilren의 위치도 같이 바꾸어준다.) 내부적으로 MoveOffset함수를 부른다.
-	CN3UIBase*		GetChildByID(const std::string& szID);
+
+	// Find first control matching the specified ID.
+	CN3UIBase*		GetChildByID(const std::string_view szID) const;
+
+	// Find first control matching both the specified ID and UI type.
+	CN3UIBase*		GetChildByID(const std::string_view szID, eUI_TYPE eUIType) const;
+
+	template <typename T>
+	T* GetChildByID(const std::string_view szID) const;
 
 	virtual void	SetRegion(const RECT& pRect) { m_rcRegion = pRect; }	// 영역 지정
 	virtual BOOL	MoveOffset(int iOffsetX, int iOffsetY);	// offset만큼 이동해준다.(region, children, move rect 이동)

--- a/Client/N3Base/N3UIList.h
+++ b/Client/N3Base/N3UIList.h
@@ -23,7 +23,7 @@ protected:
 	class CN3UIScrollBar*	m_pScrollBarRef;
 
 	std::string				m_szFontName;
-	uint32_t					m_dwFontHeight;
+	uint32_t				m_dwFontHeight;
 	BOOL					m_bFontBold;
 	BOOL					m_bFontItalic;
 	D3DCOLOR				m_crFont;

--- a/Client/WarFare/GameCursor.cpp
+++ b/Client/WarFare/GameCursor.cpp
@@ -50,7 +50,7 @@ bool CGameCursor::Load(HANDLE hFile)
 	for (int i = 0; i < CURSOR_COUNT; i++)
 	{
 		szID = fmt::format("Image_Cursor{:02}", i);
-		N3_VERIFY_UI_COMPONENT(m_pImageCursor[i], (CN3UIImage*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pImageCursor[i], GetChildByID<CN3UIImage>(szID));
 	}
 
 	return true;

--- a/Client/WarFare/UICharacterSelect.cpp
+++ b/Client/WarFare/UICharacterSelect.cpp
@@ -61,7 +61,7 @@ bool CUICharacterSelect::Load(HANDLE hFile)
 	N3_VERIFY_UI_COMPONENT(m_pBtnExit, GetChildByID("bt_exit"));
 	N3_VERIFY_UI_COMPONENT(m_pBtnDelete, GetChildByID("bt_delete"));
 	N3_VERIFY_UI_COMPONENT(m_pBtnBack, GetChildByID("bt_back"));
-	N3_VERIFY_UI_COMPONENT(m_pUserInfoStr, (CN3UIString*) GetChildByID("text00"));
+	N3_VERIFY_UI_COMPONENT(m_pUserInfoStr, GetChildByID<CN3UIString>("text00"));
 
 	// 위치를 화면 해상도에 맞게 바꾸기...
 	POINT pt;

--- a/Client/WarFare/UICmdList.cpp
+++ b/Client/WarFare/UICmdList.cpp
@@ -57,9 +57,9 @@ bool CUICmdList::Load(HANDLE hFile)
 	if (!CN3UIBase::Load(hFile))
 		return false;
 
-	N3_VERIFY_UI_COMPONENT(m_pBtn_cancel,	(CN3UIButton*) GetChildByID("btn_cancel"));
-	N3_VERIFY_UI_COMPONENT(m_pList_CmdCat,	(CN3UIList*) GetChildByID("list_curtailment"));
-	N3_VERIFY_UI_COMPONENT(m_pList_Cmds,	(CN3UIList*) GetChildByID("list_content"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_cancel,	GetChildByID<CN3UIButton>("btn_cancel"));
+	N3_VERIFY_UI_COMPONENT(m_pList_CmdCat,	GetChildByID<CN3UIList>("list_curtailment"));
+	N3_VERIFY_UI_COMPONENT(m_pList_Cmds,	GetChildByID<CN3UIList>("list_content"));
 
 	CreateCategoryList();
 	return true;

--- a/Client/WarFare/UIInventory.cpp
+++ b/Client/WarFare/UIInventory.cpp
@@ -191,7 +191,7 @@ void CUIInventory::GoldUpdate()
 {
 	CN3UIString* pUITextGold;
 
-	N3_VERIFY_UI_COMPONENT(pUITextGold, (CN3UIString*) GetChildByID("text_gold"));
+	N3_VERIFY_UI_COMPONENT(pUITextGold, GetChildByID<CN3UIString>("text_gold"));
 
 	if (pUITextGold != nullptr)
 	{

--- a/Client/WarFare/UILevelGuide.cpp
+++ b/Client/WarFare/UILevelGuide.cpp
@@ -77,24 +77,24 @@ bool CUILevelGuide::Load(HANDLE hFile)
 
 	std::string szID;
 
-	N3_VERIFY_UI_COMPONENT(m_pEdit_Level,			(CN3UIEdit*)   GetChildByID("edit_level"));
-	N3_VERIFY_UI_COMPONENT(m_pText_Page,			(CN3UIString*) GetChildByID("text_page"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Check,			(CN3UIButton*) GetChildByID("btn_check"));
-	N3_VERIFY_UI_COMPONENT(m_pText_Level,			(CN3UIString*) GetChildByID("text_level"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Up,				(CN3UIButton*) GetChildByID("btn_up"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Down,				(CN3UIButton*) GetChildByID("btn_down"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel,			(CN3UIButton*) GetChildByID("btn_cancel"));
+	N3_VERIFY_UI_COMPONENT(m_pEdit_Level,			GetChildByID<CN3UIEdit>("edit_level"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Page,			GetChildByID<CN3UIString>("text_page"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Check,			GetChildByID<CN3UIButton>("btn_check"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Level,			GetChildByID<CN3UIString>("text_level"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Up,				GetChildByID<CN3UIButton>("btn_up"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Down,				GetChildByID<CN3UIButton>("btn_down"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel,			GetChildByID<CN3UIButton>("btn_cancel"));
 
 	for (int i = 0; i < MAX_QUESTS_PER_PAGE; i++)
 	{
 		szID = "scroll_guide" + std::to_string(i);
-		N3_VERIFY_UI_COMPONENT(m_pScroll_Guide[i],	(CN3UIScrollBar*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pScroll_Guide[i],	GetChildByID<CN3UIScrollBar>(szID));
 
 		szID = "text_guide" + std::to_string(i);
-		N3_VERIFY_UI_COMPONENT(m_pText_Guide[i],	(CN3UIString*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pText_Guide[i],	GetChildByID<CN3UIString>(szID));
 
 		szID = "text_title" + std::to_string(i);
-		N3_VERIFY_UI_COMPONENT(m_pText_Title[i],	(CN3UIString*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pText_Title[i],	GetChildByID<CN3UIString>(szID));
 	}
 
 	return true;

--- a/Client/WarFare/UILoading.cpp
+++ b/Client/WarFare/UILoading.cpp
@@ -48,15 +48,15 @@ bool CUILoading::Load(HANDLE hFile)
 	if (!CN3UIBase::Load(hFile))
 		return false;
 
-	N3_VERIFY_UI_COMPONENT(m_pText_Version, (CN3UIString*) GetChildByID("Text_Version"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Version,		GetChildByID<CN3UIString>("Text_Version"));
 	if (m_pText_Version != nullptr)
 	{
 		std::string version = fmt::format("Ver. {:.3f}", CURRENT_VERSION / 1000.0f);
 		m_pText_Version->SetString(version);
 	}
 
-	N3_VERIFY_UI_COMPONENT(m_pText_Info , (CN3UIString*) GetChildByID("Text_Info"));
-	N3_VERIFY_UI_COMPONENT(m_pProgress_Loading, (CN3UIProgress*) GetChildByID("Progress_Loading"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Info,		GetChildByID<CN3UIString>("Text_Info"));
+	N3_VERIFY_UI_COMPONENT(m_pProgress_Loading,	GetChildByID<CN3UIProgress>("Progress_Loading"));
 
 	SetPosCenter(); // 가운데로 맞추기..
 	m_pText_Version->SetPos(10, 10); // Version 은 맨위에 표시..

--- a/Client/WarFare/UILogin_1098.cpp
+++ b/Client/WarFare/UILogin_1098.cpp
@@ -124,17 +124,17 @@ bool CUILogIn_1098::Load(HANDLE hFile)
 	if (!CN3UIBase::Load(hFile))
 		return false;
 
-	N3_VERIFY_UI_COMPONENT(m_pGroup_LogIn, GetChildByID("Group_LogIn"));
+	N3_VERIFY_UI_COMPONENT(m_pGroup_LogIn,		GetChildByID("Group_LogIn"));
 
 	if (m_pGroup_LogIn != nullptr)
 	{
-		N3_VERIFY_UI_COMPONENT(m_pBtn_LogIn,	(CN3UIButton*) m_pGroup_LogIn->GetChildByID("Btn_Login"));
-		N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel,	(CN3UIButton*) m_pGroup_LogIn->GetChildByID("Btn_Cancel"));
-		N3_VERIFY_UI_COMPONENT(m_pBtn_Option,	(CN3UIButton*) m_pGroup_LogIn->GetChildByID("Btn_Option"));
-		N3_VERIFY_UI_COMPONENT(m_pBtn_Join,		(CN3UIButton*) m_pGroup_LogIn->GetChildByID("Btn_Join"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_LogIn,	m_pGroup_LogIn->GetChildByID<CN3UIButton>("Btn_Login"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel,	m_pGroup_LogIn->GetChildByID<CN3UIButton>("Btn_Cancel"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_Option,	m_pGroup_LogIn->GetChildByID<CN3UIButton>("Btn_Option"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_Join,		m_pGroup_LogIn->GetChildByID<CN3UIButton>("Btn_Join"));
 
-		N3_VERIFY_UI_COMPONENT(m_pEdit_id,		(CN3UIEdit*) m_pGroup_LogIn->GetChildByID("Edit_ID"));
-		N3_VERIFY_UI_COMPONENT(m_pEdit_pw,		(CN3UIEdit*) m_pGroup_LogIn->GetChildByID("Edit_PW"));
+		N3_VERIFY_UI_COMPONENT(m_pEdit_id,		m_pGroup_LogIn->GetChildByID<CN3UIEdit>("Edit_ID"));
+		N3_VERIFY_UI_COMPONENT(m_pEdit_pw,		m_pGroup_LogIn->GetChildByID<CN3UIEdit>("Edit_PW"));
 
 		// N3_VERIFY_UI_COMPONENT(m_pImg_GradeLogo,	m_pGroup_LogIn->GetChildByID("Img_Grade"));
 	}
@@ -170,8 +170,8 @@ bool CUILogIn_1098::Load(HANDLE hFile)
 	N3_VERIFY_UI_COMPONENT(m_pGroup_ServerList, GetChildByID("Group_ServerList"));
 	if (m_pGroup_ServerList != nullptr)
 	{
-		N3_VERIFY_UI_COMPONENT(m_pList_Server,	(CN3UIList*) m_pGroup_ServerList->GetChildByID("List_Server"));
-		N3_VERIFY_UI_COMPONENT(m_pBtn_Connect,	(CN3UIButton*) m_pGroup_ServerList->GetChildByID("Btn_Connect"));
+		N3_VERIFY_UI_COMPONENT(m_pList_Server,	m_pGroup_ServerList->GetChildByID<CN3UIList>("List_Server"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_Connect,	m_pGroup_ServerList->GetChildByID<CN3UIButton>("Btn_Connect"));
 
 		m_pGroup_ServerList->SetVisible(false);
 	}

--- a/Client/WarFare/UILogin_1298.cpp
+++ b/Client/WarFare/UILogin_1298.cpp
@@ -184,13 +184,13 @@ bool CUILogIn_1298::Load(HANDLE hFile)
 
 	if (m_pGroup_LogIn != nullptr)
 	{
-		N3_VERIFY_UI_COMPONENT(m_pBtn_LogIn,		(CN3UIButton*) m_pGroup_LogIn->GetChildByID("btn_ok"));
-		N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel,		(CN3UIButton*) m_pGroup_LogIn->GetChildByID("btn_cancel"));
-		N3_VERIFY_UI_COMPONENT(m_pBtn_Option,		(CN3UIButton*) m_pGroup_LogIn->GetChildByID("btn_option"));
-		N3_VERIFY_UI_COMPONENT(m_pBtn_Join,			(CN3UIButton*) m_pGroup_LogIn->GetChildByID("btn_homepage"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_LogIn,	m_pGroup_LogIn->GetChildByID<CN3UIButton>("btn_ok"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel,	m_pGroup_LogIn->GetChildByID<CN3UIButton>("btn_cancel"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_Option,	m_pGroup_LogIn->GetChildByID<CN3UIButton>("btn_option"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_Join,		m_pGroup_LogIn->GetChildByID<CN3UIButton>("btn_homepage"));
 
-		N3_VERIFY_UI_COMPONENT(m_pEdit_id,			(CN3UIEdit*) m_pGroup_LogIn->GetChildByID("Edit_ID"));
-		N3_VERIFY_UI_COMPONENT(m_pEdit_pw,			(CN3UIEdit*) m_pGroup_LogIn->GetChildByID("Edit_PW"));
+		N3_VERIFY_UI_COMPONENT(m_pEdit_id,		m_pGroup_LogIn->GetChildByID<CN3UIEdit>("Edit_ID"));
+		N3_VERIFY_UI_COMPONENT(m_pEdit_pw,		m_pGroup_LogIn->GetChildByID<CN3UIEdit>("Edit_PW"));
 
 		m_pGroup_LogIn->SetVisible(true);
 	}
@@ -202,38 +202,38 @@ bool CUILogIn_1298::Load(HANDLE hFile)
 	
 	if (m_pGroup_Notice_1 != nullptr)
 	{
-		N3_VERIFY_UI_COMPONENT(m_pBtn_NoticeOK_1,		(CN3UIButton*) m_pGroup_Notice_1->GetChildByID("btn_ok"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice1_Name_1,	(CN3UIString*) m_pGroup_Notice_1->GetChildByID("text_notice_name_01"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice1_Text_1,	(CN3UIString*) m_pGroup_Notice_1->GetChildByID("text_notice_01"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_NoticeOK_1,		m_pGroup_Notice_1->GetChildByID<CN3UIButton>("btn_ok"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice1_Name_1,	m_pGroup_Notice_1->GetChildByID<CN3UIString>("text_notice_name_01"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice1_Text_1,	m_pGroup_Notice_1->GetChildByID<CN3UIString>("text_notice_01"));
 
 		m_pGroup_Notice_1->SetVisible(false);
 	}
 
 	if (m_pGroup_Notice_2 != nullptr)
 	{
-		N3_VERIFY_UI_COMPONENT(m_pBtn_NoticeOK_2,		(CN3UIButton*) m_pGroup_Notice_2->GetChildByID("btn_ok"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice2_Name_1,	(CN3UIString*) m_pGroup_Notice_2->GetChildByID("text_notice_name_01"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice2_Text_1,	(CN3UIString*) m_pGroup_Notice_2->GetChildByID("text_notice_01"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice2_Name_2,	(CN3UIString*) m_pGroup_Notice_2->GetChildByID("text_notice_name_02"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice2_Text_2,	(CN3UIString*) m_pGroup_Notice_2->GetChildByID("text_notice_02"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_NoticeOK_2,		m_pGroup_Notice_2->GetChildByID<CN3UIButton>("btn_ok"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice2_Name_1,	m_pGroup_Notice_2->GetChildByID<CN3UIString>("text_notice_name_01"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice2_Text_1,	m_pGroup_Notice_2->GetChildByID<CN3UIString>("text_notice_01"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice2_Name_2,	m_pGroup_Notice_2->GetChildByID<CN3UIString>("text_notice_name_02"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice2_Text_2,	m_pGroup_Notice_2->GetChildByID<CN3UIString>("text_notice_02"));
 
 		m_pGroup_Notice_2->SetVisible(false);
 	}
 
 	if (m_pGroup_Notice_3 != nullptr)
 	{
-		N3_VERIFY_UI_COMPONENT(m_pBtn_NoticeOK_3,		(CN3UIButton*) m_pGroup_Notice_3->GetChildByID("btn_ok"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Name_1,	(CN3UIString*) m_pGroup_Notice_3->GetChildByID("text_notice_name_01"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Text_1,	(CN3UIString*) m_pGroup_Notice_3->GetChildByID("text_notice_01"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Name_2,	(CN3UIString*) m_pGroup_Notice_3->GetChildByID("text_notice_name_02"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Text_2,	(CN3UIString*) m_pGroup_Notice_3->GetChildByID("text_notice_02"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Name_3,	(CN3UIString*) m_pGroup_Notice_3->GetChildByID("text_notice_name_03"));
-		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Text_3,	(CN3UIString*) m_pGroup_Notice_3->GetChildByID("text_notice_03"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_NoticeOK_3,		m_pGroup_Notice_3->GetChildByID<CN3UIButton>("btn_ok"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Name_1,	m_pGroup_Notice_3->GetChildByID<CN3UIString>("text_notice_name_01"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Text_1,	m_pGroup_Notice_3->GetChildByID<CN3UIString>("text_notice_01"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Name_2,	m_pGroup_Notice_3->GetChildByID<CN3UIString>("text_notice_name_02"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Text_2,	m_pGroup_Notice_3->GetChildByID<CN3UIString>("text_notice_02"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Name_3,	m_pGroup_Notice_3->GetChildByID<CN3UIString>("text_notice_name_03"));
+		N3_VERIFY_UI_COMPONENT(m_pText_Notice3_Text_3,	m_pGroup_Notice_3->GetChildByID<CN3UIString>("text_notice_03"));
 
 		m_pGroup_Notice_3->SetVisible(false);
 	}
 
-	N3_VERIFY_UI_COMPONENT(m_pStr_Premium,	(CN3UIString*) GetChildByID("premium"));
+	N3_VERIFY_UI_COMPONENT(m_pStr_Premium,		GetChildByID<CN3UIString>("premium"));
 
 	if (m_pStr_Premium != nullptr)
 		m_pStr_Premium->SetVisible(false);
@@ -247,15 +247,15 @@ bool CUILogIn_1298::Load(HANDLE hFile)
 	for (int i = 0; i < MAX_SERVERS; i++)
 	{
 		std::string szID = "server_" + std::to_string(i + 1);
-		N3_VERIFY_UI_COMPONENT(m_pServer_Group[i], m_pGroup_ServerList->GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pServer_Group[i],	m_pGroup_ServerList->GetChildByID(szID));
 
 		szID = "img_arrow" + std::to_string(i + 1);
-		N3_VERIFY_UI_COMPONENT(m_pArrow_Group[i], m_pGroup_ServerList->GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pArrow_Group[i],	m_pGroup_ServerList->GetChildByID(szID));
 		
-		N3_VERIFY_UI_COMPONENT(m_pList_Group[i], (CN3UIString*) m_pServer_Group[i]->GetChildByID("List_Server"));
+		N3_VERIFY_UI_COMPONENT(m_pList_Group[i],	m_pServer_Group[i]->GetChildByID<CN3UIString>("List_Server"));
 	}
 
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Connect, (CN3UIButton*) m_pGroup_ServerList->GetChildByID("Btn_Connect"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Connect,			m_pGroup_ServerList->GetChildByID<CN3UIButton>("Btn_Connect"));
 		
 	return true;
 }

--- a/Client/WarFare/UIMsgBoxOkCancel.cpp
+++ b/Client/WarFare/UIMsgBoxOkCancel.cpp
@@ -44,9 +44,9 @@ bool CUIMsgBoxOkCancel::Load(HANDLE hFile)
 	if (!CN3UIBase::Load(hFile))
 		return false;
 
-	N3_VERIFY_UI_COMPONENT(m_pBtn_OK,		(CN3UIButton*) GetChildByID("btn_ok"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel,	(CN3UIButton*) GetChildByID("btn_cancel"));
-	N3_VERIFY_UI_COMPONENT(m_pText_Msg,		(CN3UIString*) GetChildByID("text_msg"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_OK,		GetChildByID<CN3UIButton>("btn_ok"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel,	GetChildByID<CN3UIButton>("btn_cancel"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Msg,		GetChildByID<CN3UIString>("text_msg"));
 
 	return true;
 }

--- a/Client/WarFare/UIPartyOrForce.cpp
+++ b/Client/WarFare/UIPartyOrForce.cpp
@@ -72,7 +72,7 @@ bool CUIPartyOrForce::Load(HANDLE hFile)
 	for (int i = 0; i < MAX_PARTY_OR_FORCE; i++) // 빈곳을 찾자..
 	{
 		szID = fmt::format("progress_hp_{}", i);
-		N3_VERIFY_UI_COMPONENT(m_pProgress_HPs[i], (CN3UIProgress*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pProgress_HPs[i],			GetChildByID<CN3UIProgress>(szID));
 		if (m_pProgress_HPs[i] != nullptr)
 		{
 			m_pProgress_HPs[i]->SetVisible(false);
@@ -80,7 +80,7 @@ bool CUIPartyOrForce::Load(HANDLE hFile)
 		}
 
 		szID = fmt::format("progress_hp_{}_slow", i);
-		N3_VERIFY_UI_COMPONENT(m_pProgress_HPSlow[i], (CN3UIProgress*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pProgress_HPSlow[i],		GetChildByID<CN3UIProgress>(szID));
 		if (m_pProgress_HPSlow[i] != nullptr)
 		{
 			m_pProgress_HPSlow[i]->SetVisible(false);
@@ -88,7 +88,7 @@ bool CUIPartyOrForce::Load(HANDLE hFile)
 		}
 
 		szID = fmt::format("progress_hp_{}_drop", i);
-		N3_VERIFY_UI_COMPONENT(m_pProgress_HPReduce[i], (CN3UIProgress*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pProgress_HPReduce[i],		GetChildByID<CN3UIProgress>(szID));
 		if (m_pProgress_HPReduce[i] != nullptr)
 		{
 			m_pProgress_HPReduce[i]->SetVisible(false);
@@ -96,7 +96,7 @@ bool CUIPartyOrForce::Load(HANDLE hFile)
 		}
 
 		szID = fmt::format("progress_hp_{}_lasting", i);
-		N3_VERIFY_UI_COMPONENT(m_pProgress_HPLasting[i], (CN3UIProgress*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pProgress_HPLasting[i],	GetChildByID<CN3UIProgress>(szID));
 		if (m_pProgress_HPLasting[i] != nullptr)
 		{
 			m_pProgress_HPLasting[i]->SetVisible(false);
@@ -104,7 +104,7 @@ bool CUIPartyOrForce::Load(HANDLE hFile)
 		}
 
 		szID = fmt::format("progress_mp_{}_curse", i); 
-		N3_VERIFY_UI_COMPONENT(m_pProgress_MP[i], (CN3UIProgress*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pProgress_MP[i],			GetChildByID<CN3UIProgress>(szID));
 		if (m_pProgress_MP[i] != nullptr)
 		{
 			m_pProgress_MP[i]->SetVisible(false);
@@ -112,12 +112,12 @@ bool CUIPartyOrForce::Load(HANDLE hFile)
 		}
 
 		szID = fmt::format("static_name_{}", i);
-		N3_VERIFY_UI_COMPONENT(m_pStatic_IDs[i], (CN3UIStatic*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pStatic_IDs[i],			GetChildByID<CN3UIStatic>(szID));
 		if (m_pStatic_IDs[i] != nullptr)
 			m_pStatic_IDs[i]->SetVisible(false);
 
 		szID = fmt::format("Area_{}", i);
-		N3_VERIFY_UI_COMPONENT(m_pAreas[i], (CN3UIArea*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pAreas[i],					GetChildByID<CN3UIArea>(szID));
 	}
 
 	MemberInfoReInit();

--- a/Client/WarFare/UIQuestMenu.cpp
+++ b/Client/WarFare/UIQuestMenu.cpp
@@ -76,22 +76,22 @@ bool CUIQuestMenu::Load(HANDLE hFile)
 	if (!CN3UIBase::Load(hFile))
 		return false;
 
-	N3_VERIFY_UI_COMPONENT(m_pTextSample,	(CN3UIString*) GetChildByID("Text_Menu"));
-	N3_VERIFY_UI_COMPONENT(m_pTextTitle,	(CN3UIString*) GetChildByID("Text_Title"));
+	N3_VERIFY_UI_COMPONENT(m_pTextSample,	GetChildByID<CN3UIString>("Text_Menu"));
+	N3_VERIFY_UI_COMPONENT(m_pTextTitle,	GetChildByID<CN3UIString>("Text_Title"));
 
-	N3_VERIFY_UI_COMPONENT(m_pBtnClose,		(CN3UIButton*) GetChildByID("btn_close"));
-	N3_VERIFY_UI_COMPONENT(m_pStrNpcName,	(CN3UIString*) GetChildByID("Text_Npcname"));
-	N3_VERIFY_UI_COMPONENT(m_pScrollBar,	(CN3UIScrollBar*) GetChildByID("scroll"));
-	N3_VERIFY_UI_COMPONENT(m_pBtnMenu,		(CN3UIButton*) GetChildByID("btn_menu"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnClose,		GetChildByID<CN3UIButton>("btn_close"));
+	N3_VERIFY_UI_COMPONENT(m_pStrNpcName,	GetChildByID<CN3UIString>("Text_Npcname"));
+	N3_VERIFY_UI_COMPONENT(m_pScrollBar,	GetChildByID<CN3UIScrollBar>("scroll"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnMenu,		GetChildByID<CN3UIButton>("btn_menu"));
 
 	// the background image for the button
-	N3_VERIFY_UI_COMPONENT(m_pImageBtn,		(CN3UIImage*) GetChildByID("img_button_menu"));
+	N3_VERIFY_UI_COMPONENT(m_pImageBtn,		GetChildByID<CN3UIImage>("img_button_menu"));
 
 	// this is the bottom of the quest menu UI
-	N3_VERIFY_UI_COMPONENT(m_pImageBottom,	(CN3UIImage*) GetChildByID("img_Bottom"));
+	N3_VERIFY_UI_COMPONENT(m_pImageBottom,	GetChildByID<CN3UIImage>("img_Bottom"));
 
 	// this is the background image for the background image for the button
-	N3_VERIFY_UI_COMPONENT(m_pImageMenu,	(CN3UIImage*) GetChildByID("img_menu"));
+	N3_VERIFY_UI_COMPONENT(m_pImageMenu,	GetChildByID<CN3UIImage>("img_menu"));
 
 	// NOTE: some of these components are meant only to be copied
 	RemoveChild(m_pTextSample);

--- a/Client/WarFare/UIQuestTalk.cpp
+++ b/Client/WarFare/UIQuestTalk.cpp
@@ -115,16 +115,16 @@ bool CUIQuestTalk::Load(HANDLE hFile)
 	if (!CN3UIBase::Load(hFile))
 		return false;
 
-	N3_VERIFY_UI_COMPONENT(m_pTextTalk,			(CN3UIString*) GetChildByID("Text_Talk"));
-	N3_VERIFY_UI_COMPONENT(m_pBtnOk,			(CN3UIButton*) GetChildByID("btn_Ok_center"));
+	N3_VERIFY_UI_COMPONENT(m_pTextTalk,			GetChildByID<CN3UIString>("Text_Talk"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnOk,			GetChildByID<CN3UIButton>("btn_Ok_center"));
 
 	// NOTE(srmeier): new stuff:
-	N3_VERIFY_UI_COMPONENT(m_pBtnClose,			(CN3UIButton*) GetChildByID("btn_close"));
-	N3_VERIFY_UI_COMPONENT(m_pBtnUpperEvent,	(CN3UIButton*) GetChildByID("btn_UpperEvent"));
-	N3_VERIFY_UI_COMPONENT(m_pBtnNext,			(CN3UIButton*) GetChildByID("btn_Next"));
-	N3_VERIFY_UI_COMPONENT(m_pBtnOkRight,		(CN3UIButton*) GetChildByID("btn_Ok_right"));
-	N3_VERIFY_UI_COMPONENT(m_pBtnPre,			(CN3UIButton*) GetChildByID("btn_Pre"));
-	N3_VERIFY_UI_COMPONENT(m_pScrollBar,		(CN3UIScrollBar*) GetChildByID("scroll"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnClose,			GetChildByID<CN3UIButton>("btn_close"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnUpperEvent,	GetChildByID<CN3UIButton>("btn_UpperEvent"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnNext,			GetChildByID<CN3UIButton>("btn_Next"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnOkRight,		GetChildByID<CN3UIButton>("btn_Ok_right"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnPre,			GetChildByID<CN3UIButton>("btn_Pre"));
+	N3_VERIFY_UI_COMPONENT(m_pScrollBar,		GetChildByID<CN3UIScrollBar>("scroll"));
 	
 	if (m_pBtnUpperEvent != nullptr)
 		m_pBtnUpperEvent->SetVisible(false);

--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -1105,12 +1105,12 @@ void CUISkillTreeDlg::InitIconWnd(e_UIWND eWnd)
 {
 	CN3UIWndBase::InitIconWnd(eWnd);
 
-	N3_VERIFY_UI_COMPONENT(m_pStr_info,			(CN3UIString*) GetChildByID("string_info"));
-	N3_VERIFY_UI_COMPONENT(m_pStr_skill_mp,		(CN3UIString*) GetChildByID("string_skill_mp"));
-	N3_VERIFY_UI_COMPONENT(m_pStr_skill_point,	(CN3UIString*) GetChildByID("string_skill_point"));
-	N3_VERIFY_UI_COMPONENT(m_pStr_skill_item0,	(CN3UIString*) GetChildByID("string_skill_item0"));
-	N3_VERIFY_UI_COMPONENT(m_pStr_skill_item1,	(CN3UIString*) GetChildByID("string_skill_item1"));
-	N3_VERIFY_UI_COMPONENT(m_pStr_skill_item2,	(CN3UIString*) GetChildByID("string_skill_item2"));
+	N3_VERIFY_UI_COMPONENT(m_pStr_info,			GetChildByID<CN3UIString>("string_info"));
+	N3_VERIFY_UI_COMPONENT(m_pStr_skill_mp,		GetChildByID<CN3UIString>("string_skill_mp"));
+	N3_VERIFY_UI_COMPONENT(m_pStr_skill_point,	GetChildByID<CN3UIString>("string_skill_point"));
+	N3_VERIFY_UI_COMPONENT(m_pStr_skill_item0,	GetChildByID<CN3UIString>("string_skill_item0"));
+	N3_VERIFY_UI_COMPONENT(m_pStr_skill_item1,	GetChildByID<CN3UIString>("string_skill_item1"));
+	N3_VERIFY_UI_COMPONENT(m_pStr_skill_item2,	GetChildByID<CN3UIString>("string_skill_item2"));
 }
 
 void CUISkillTreeDlg::InitIconUpdate()
@@ -1263,12 +1263,12 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 
 	CN3UIButton* pButton = nullptr;
 
-	N3_VERIFY_UI_COMPONENT(pButton, (CN3UIButton*) GetChildByID("btn_public"));
+	N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_public"));
 	if (pButton != nullptr)
 		pButton->SetState(UI_STATE_BUTTON_NORMAL);
 
 	// Hide all existing buttons by default.
-	N3_VERIFY_UI_COMPONENT(pButton, (CN3UIButton*) GetChildByID("btn_master"));
+	N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));
 	if (pButton != nullptr)
 		pButton->SetVisible(false);
 

--- a/Client/WarFare/UITransactionDlg.cpp
+++ b/Client/WarFare/UITransactionDlg.cpp
@@ -202,13 +202,13 @@ void CUITransactionDlg::InitIconWnd(e_UIWND eWnd)
 
 	CN3UIWndBase::InitIconWnd(eWnd);
 
-	N3_VERIFY_UI_COMPONENT(m_pStrMyGold, (CN3UIString*) GetChildByID("string_item_name"));
+	N3_VERIFY_UI_COMPONENT(m_pStrMyGold,	GetChildByID<CN3UIString>("string_item_name"));
 	if(m_pStrMyGold) m_pStrMyGold->SetString("0");
 
-	N3_VERIFY_UI_COMPONENT(m_pUIInn, (CN3UIImage*) GetChildByID("img_inn"));
-	N3_VERIFY_UI_COMPONENT(m_pUIBlackSmith, (CN3UIImage*) GetChildByID("img_blacksmith"));
-	N3_VERIFY_UI_COMPONENT(m_pUIStore, (CN3UIImage*) GetChildByID("img_store"));
-	N3_VERIFY_UI_COMPONENT(m_pText_Weight, (CN3UIString*) GetChildByID("text_weight"));
+	N3_VERIFY_UI_COMPONENT(m_pUIInn,		GetChildByID<CN3UIImage>("img_inn"));
+	N3_VERIFY_UI_COMPONENT(m_pUIBlackSmith,	GetChildByID<CN3UIImage>("img_blacksmith"));
+	N3_VERIFY_UI_COMPONENT(m_pUIStore,		GetChildByID<CN3UIImage>("img_store"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Weight,	GetChildByID<CN3UIString>("text_weight"));
 }
 
 void CUITransactionDlg::InitIconUpdate()

--- a/Client/WarFare/UIUpgradeSelect.cpp
+++ b/Client/WarFare/UIUpgradeSelect.cpp
@@ -24,9 +24,9 @@ bool CUIUpgradeSelect::Load(
 	if (!CN3UIBase::Load(hFile))
 		return false;
 
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Upgrade_1,	(CN3UIButton*) GetChildByID("upgrade_1"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Upgrade_2,	(CN3UIButton*) GetChildByID("upgrade_2"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Close,		(CN3UIButton*) GetChildByID("btn_close"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Upgrade_1,	GetChildByID<CN3UIButton>("upgrade_1"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Upgrade_2,	GetChildByID<CN3UIButton>("upgrade_2"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Close,		GetChildByID<CN3UIButton>("btn_close"));
 
 	return true;
 }

--- a/Client/WarFare/UIVarious.cpp
+++ b/Client/WarFare/UIVarious.cpp
@@ -613,7 +613,7 @@ bool CUIKnights::Load(HANDLE hFile)
 	for (int i = 0; i < MAX_CLAN_GRADE; i++)
 	{
 		szID = fmt::format("image_grade{:02}", i);
-		N3_VERIFY_UI_COMPONENT(m_pImage_Grade[i], (CN3UIImage*) GetChildByID(szID));
+		N3_VERIFY_UI_COMPONENT(m_pImage_Grade[i], GetChildByID<CN3UIImage>(szID));
 
 		if (m_pImage_Grade[i] != nullptr)
 			m_pImage_Grade[i]->SetVisible(false);


### PR DESCRIPTION
 * Use std::string_view to reduce unnecessary allocations & length scans for 99% of lookups with hardcoded control names

 * Add template specializations (pre-implemented, to keep things fast and avoid unintentional lookups from unsupported specializations) for control types. This has 2 main benefits:
   1. We can pre-check the UI type before dealing with the string checks for potential performance gains.
   2. We can better verify that the UI is in fact the type that we're requesting (short of having to invoke more expensive runtime RTTI checks with dynamic_cast<>()), rather than just blindly casting it.