### PR TITLE
UICmdEdit to N3_VERIFY_UI_COMPONENT & spacing

### DIFF
--- a/Client/WarFare/UICmdEdit.cpp
+++ b/Client/WarFare/UICmdEdit.cpp
@@ -33,12 +33,14 @@ CUICmdEdit::~CUICmdEdit()
 
 bool CUICmdEdit::Load(HANDLE hFile)
 {
-	if (CN3UIBase::Load(hFile) == false) return false;
+	if (CN3UIBase::Load(hFile) == false) 
+		return false;
+	
+	N3_VERIFY_UI_COMPONENT(m_pText_Title, (CN3UIString*) GetChildByID("Text_cmd"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Ok,	  (CN3UIButton*) GetChildByID("btn_ok"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel, (CN3UIButton*) GetChildByID("btn_cancel"));
+	N3_VERIFY_UI_COMPONENT(m_pEdit_Box,	  (CN3UIEdit*)	 GetChildByID("edit_cmd"));
 
-	m_pText_Title = (CN3UIString*)GetChildByID("Text_cmd");			__ASSERT(m_pText_Title, "NULL UI Component!!");
-	m_pBtn_Ok = (CN3UIButton*)GetChildByID("btn_ok");				__ASSERT(m_pBtn_Ok, "NULL UI Component!!");
-	m_pBtn_Cancel = (CN3UIButton*)GetChildByID("btn_cancel");		__ASSERT(m_pBtn_Cancel, "NULL UI Component!!");
-	m_pEdit_Box = (CN3UIEdit*)GetChildByID("edit_cmd");				__ASSERT(m_pEdit_Box, "NULL UI Component!!");
 	return true;
 }
 
@@ -49,8 +51,8 @@ bool CUICmdEdit::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 		if (pSender == m_pBtn_Ok)
 		{
 			m_szArg1 = m_pEdit_Box->GetString();
-			std::string tempCmdStr = "/" + m_pText_Title->GetString() + " " + m_szArg1;
-			CGameProcedure::s_pProcMain->ParseChattingCommand(tempCmdStr);
+			std::string strTempCmd = "/" + m_pText_Title->GetString() + " " + m_szArg1;
+			CGameProcedure::s_pProcMain->ParseChattingCommand(strTempCmd);
 			SetVisible(false);
 			return true;
 		}
@@ -77,7 +79,8 @@ void CUICmdEdit::Open(std::string msg)
 
 void CUICmdEdit::SetVisible(bool bVisible)
 {
-	if (bVisible == this->IsVisible()) return;
+	if (bVisible == this->IsVisible()) 
+		return;
 
 	if (!bVisible)
 	{


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Code style update (formatting, renaming)

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
uses __ASSERT macro 

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
N3_VERIFY macro is used

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
UI elements should be loaded same in all sections of client.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
