### PR TITLE
GoldLose [negative check] [return type]

### DIFF
--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -11638,14 +11638,20 @@ void CUser::GoldGain(int gold)
 	Send(send_buff, send_index);
 }
 
-BOOL CUser::GoldLose(int gold)
+bool CUser::GoldLose(int gold)
 {
 	int send_index = 0;
 	char send_buff[256] = {};
 
+	if (m_pUserData->m_iGold < 0)
+		m_pUserData->m_iGold = 0;
+
+	if (gold < 0)
+		gold = 0;
+
 	// Insufficient gold!
 	if (m_pUserData->m_iGold < gold)
-		return FALSE;
+		return false;
 
 	m_pUserData->m_iGold -= gold;	// Subtract gold.
 
@@ -11655,7 +11661,7 @@ BOOL CUser::GoldLose(int gold)
 	SetDWORD(send_buff, m_pUserData->m_iGold, send_index);
 	Send(send_buff, send_index);
 
-	return TRUE;
+	return true;
 }
 
 BOOL CUser::CheckSkillPoint(BYTE skillnum, BYTE min, BYTE max)

--- a/Server/Ebenezer/User.h
+++ b/Server/Ebenezer/User.h
@@ -228,7 +228,7 @@ public:
 	BOOL CheckExistItem(int itemid, short count);
 	BOOL CheckWeight(int itemid, short count);
 	BOOL CheckSkillPoint(BYTE skillnum, BYTE min, BYTE max);
-	BOOL GoldLose(int gold);
+	bool GoldLose(int gold);
 	void GoldGain(int gold);
 	void SendItemWeight();
 	void ItemLogToAgent(const char* srcid, const char* tarid, int type, int64_t serial, int itemid, int count, int durability);


### PR DESCRIPTION
… bool from BOOL

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Does not check for negative values of both "gold" and "usergold". This can cause overflow when gold is send as negavite ur user having a negative gold.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
checks for negative gold and set as zero on the encounter. Return type is also changed from BOOL to bool.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
to avoid overflow and wrapping around.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
