### PR TITLE
GM R attack on AI

### DIFF
--- a/Server/AIServer/Define.h
+++ b/Server/AIServer/Define.h
@@ -50,9 +50,10 @@
 //
 //	User Authority
 //
-#define MANAGER_USER	0	// 운영자, 관리자
-#define GENERAL_USER	1	// 일반유저
-
+constexpr int USER_TYPE_GM = 0;				// game master
+constexpr int USER_TYPE_NORMAL = 1;			// normal user
+constexpr int GM_R_DAMAGE = 30000;			// basic attack damage of GM
+constexpr bool BOOST_GM_R_DAMAGE = true;	// activate or deactivate GM R Damage
 // Npc InOut
 #define NPC_IN					0X01
 #define NPC_OUT					0X02

--- a/Server/AIServer/GameSocket.cpp
+++ b/Server/AIServer/GameSocket.cpp
@@ -322,7 +322,7 @@ void CGameSocket::RecvUserInfo(char* pBuf)
 	pUser->m_bMagicTypeRightHand = bTypeRight;
 	pUser->m_sMagicAmountLeftHand = sAmountLeft;
 	pUser->m_sMagicAmountRightHand = sAmountRight;
-	pUser->m_byIsOP = bAuthority;
+	pUser->m_byIsGM = bAuthority;
 //
 
 	spdlog::debug("GameSocket::RecvUserInfo: userId={} charId={}", uid, strName);
@@ -426,7 +426,7 @@ void CGameSocket::RecvUserInOut(char* pBuf)
 		pUser->m_curz = pUser->m_fWill_z = fZ;
 
 		//bFlag = pUser->IsOpIDCheck(strName);
-		//if(bFlag)	pUser->m_byIsOP = 1;
+		//if(bFlag)	pUser->m_byIsGM = 1;
 
 		// region out
 		if (bType == 2)
@@ -981,7 +981,7 @@ void CGameSocket::RecvUserInfoAllData(char* pBuf)
 		pUser->m_fHitrate = fHitAgi;
 		pUser->m_fAvoidrate = fAvoidAgi;
 		pUser->m_sAC = sAC;
-		pUser->m_byIsOP = bAuthority;
+		pUser->m_byIsGM = bAuthority;
 		pUser->m_bLive = USER_LIVE;
 
 		if (sPartyIndex != -1)

--- a/Server/AIServer/Npc.cpp
+++ b/Server/AIServer/Npc.cpp
@@ -2563,7 +2563,7 @@ float CNpc::FindEnemyExpand(int nRX, int nRZ, float fCompDis, int nType)
 				continue;
 
 			// 운영자 무시
-			if (pUser->m_byIsOP == MANAGER_USER)
+			if (pUser->m_byIsGM == USER_TYPE_GM)
 				continue;
 
 			vUser.Set(pUser->m_curx, pUser->m_cury, pUser->m_curz);
@@ -3518,7 +3518,7 @@ int CNpc::Attack(CIOCPort* pIOCP)
 		}
 
 		// 운영자는 공격을 안하게..
-		if (pUser->m_byIsOP == MANAGER_USER)
+		if (pUser->m_byIsGM == USER_TYPE_GM)
 		{
 			InitTarget();
 			m_NpcState = NPC_MOVING;
@@ -3766,7 +3766,7 @@ int CNpc::LongAndMagicAttack(CIOCPort* pIOCP)
 		}
 
 		// 운영자는 공격을 안하게..
-		if (pUser->m_byIsOP == MANAGER_USER)
+		if (pUser->m_byIsGM == USER_TYPE_GM)
 		{
 			InitTarget();
 			m_NpcState = NPC_MOVING;
@@ -3874,7 +3874,7 @@ int CNpc::TracingAttack(CIOCPort* pIOCP)		// 0:attack fail, 1:attack success
 			return 0;
 
 		// 운영자는 공격을 안하게..
-		if (pUser->m_byIsOP == MANAGER_USER)
+		if (pUser->m_byIsGM == USER_TYPE_GM)
 			return 0;
 
 		// 명중이면 //Damage 처리 ----------------------------------------------------------------//
@@ -4447,7 +4447,7 @@ void CNpc::ChangeTarget(int nAttackType, CUser* pUser, CIOCPort* pIOCP)
 		return;
 
 	// 운영자는 무시...^^
-	if (pUser->m_byIsOP == MANAGER_USER)
+	if (pUser->m_byIsGM == USER_TYPE_GM)
 		return;
 	
 	// 성문 NPC는 공격처리 안하게

--- a/Server/AIServer/User.cpp
+++ b/Server/AIServer/User.cpp
@@ -104,7 +104,7 @@ void CUser::Initialize()
 	m_sPartyTotalLevel = 0;
 	m_byPartyTotalMan = 0;
 	m_sPartyNumber = -1;
-	m_byIsOP = 0;
+	m_byIsGM = 0;
 	m_lUsed = 0;
 	InitNpcAttack();
 
@@ -117,6 +117,7 @@ void CUser::Initialize()
 void CUser::Attack(int sid, int tid)
 {
 	CNpc* pNpc = m_pMain->m_NpcMap.GetData(tid - NPC_BAND);
+	CUser* pUser = m_pMain->GetUserPtr(sid - USER_BAND);
 	if (pNpc == nullptr)
 		return;
 
@@ -146,6 +147,12 @@ void CUser::Attack(int sid, int tid)
 
 	if (m_pMain->m_byTestMode)
 		nFinalDamage = 3000;	// sungyong test
+
+	// game master
+	if (IsGM() && BOOST_GM_R_DAMAGE)
+	{
+		nFinalDamage = GM_R_DAMAGE;
+	}
 
 	// Calculate Target HP	 -------------------------------------------------------//
 	short sOldNpcHP = pNpc->m_iHP;

--- a/Server/AIServer/User.h
+++ b/Server/AIServer/User.h
@@ -80,7 +80,7 @@ public:
 
 	short  m_sSurroundNpcNumber[8];		// Npc 다굴~
 
-	BYTE   m_byIsOP;					// 운영자인지를 판단..
+	BYTE   m_byIsGM;					// 운영자인지를 판단..
 	long   m_lUsed;						// 포인터 사용유무.. (1:사용중.. 접근 허락치 않음. 0:사용해도 무방)
 
 	BOOL		m_bLogOut;				// Logout 중인가?
@@ -115,7 +115,7 @@ public:
 	void SendSystemMsg(const std::string_view msg, BYTE type, int nWho);
 	void SendAll(const char* pBuf, int nLength);						// game server로 패킷 전송...
 	BOOL IsOpIDCheck(char* szName);
-
+	inline bool IsGM() const{ return m_byIsGM == USER_TYPE_GM; };
 	CUser();
 	virtual ~CUser();
 };


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
GM R attack damage does not work on mobs after recent changes on server files.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
GM R damage works.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
m_byIsOP renamed as m_byIsGM
inline function IsGM added for AIserver
related define macro is replaced with constexpr
MANAGER_USER renamed as USER_TYPE_GM
NORMAL_USER renamed as USER_TYPE_NORMAL
to set damage output new variable is added ( GM_R_DAMAGE )
to open & close feature new variable is added ( BOOST_GM_R_DAMAGE )

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
