### PR TITLE
object event fail return, packet change to support wrong warp gate me…

### DIFF
--- a/Server/Ebenezer/User.cpp
+++ b/Server/Ebenezer/User.cpp
@@ -9790,6 +9790,12 @@ BOOL CUser::WarpListObjectEvent(short objectindex, short nid)
 	if (pEvent == nullptr)
 		return FALSE;
 
+	// If the warp gate belongs to a nation, which isn't us...
+	// or we're in the opposing nation's zone...
+	if ((pEvent->sBelong != 0 && pEvent->sBelong != GetNation())
+		|| (pMap->m_nZoneNumber != GetNation() && pMap->m_nZoneNumber <= ELMORAD))
+		return FALSE;
+
 	if (!GetWarpList(pEvent->sControlNpcID))
 		return FALSE;
 
@@ -9855,6 +9861,7 @@ void CUser::ObjectEvent(char* pBuf)
 
 fail_return:
 	SetByte(send_buff, WIZ_OBJECT_EVENT, send_index);
+	SetByte(send_buff, pEvent == nullptr ? 0 : pEvent->sType, send_index);
 	SetByte(send_buff, 0, send_index);
 	Send(send_buff, send_index);
 }

--- a/Server/Ebenezer/User.h
+++ b/Server/Ebenezer/User.h
@@ -376,6 +376,7 @@ public:
 	void LoginProcess(char* pBuf);
 	void Parsing(int len, char* pData);
 	void CloseProcess();
+	inline BYTE GetNation() const { return (m_pUserData != nullptr) ? m_pUserData->m_bNation : 0; };
 	CUser();
 	virtual ~CUser();
 };


### PR DESCRIPTION
…ssage

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Wrong warp gate message is not displayed because packet lack info.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
required info to display fail added to packet.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
Snoxd koserver's behavior imitated.

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
