### PR TITLE
change position of debug text, close debug text on demand while in ma…

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -84,7 +84,11 @@ enum eKeyMap {	KM_HOTKEY1 = DIK_1,
 				KM_SKILL_PAGE_5 = DIK_F5,
 				KM_SKILL_PAGE_6 = DIK_F6,
 				KM_SKILL_PAGE_7 = DIK_F7,
-				KM_SKILL_PAGE_8 = DIK_F8 };
+				KM_SKILL_PAGE_8 = DIK_F8,
+#ifdef _DEBUG
+				KM_TOGGLE_DEBUG_TEXT = DIK_ADD, // numpad +
+#endif // _DEBUG		
+}; 
 
 enum e_PlayerType { PLAYER_BASE = 0, PLAYER_NPC = 1, PLAYER_OTHER = 2, PLAYER_MYSELF = 3 };
 

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -720,9 +720,13 @@ void CGameProcMain::Render()
 	ACT_WORLD->RenderSkyWeather();							// 하늘 렌더링..
 	
 	CGameProcedure::Render(); // UI 나 그밖의 기본적인 것들 렌더링..
+#ifdef DEBUG
+	s_pUIMgr->RenderDebugText();
+#endif // DEBUG
+
 	if(m_pWarMessage) m_pWarMessage->RenderMessage();
 	if(s_pGameCursor) s_pGameCursor->Render();
-
+	
 	s_pEng->s_lpD3DDev->EndScene();
 	s_pEng->Present(CN3Base::s_hWndBase);
 }
@@ -1357,7 +1361,16 @@ void CGameProcMain::ProcessLocalInput(uint32_t dwMouseFlags)
 #if _DEBUG
 	if(s_pLocalInput->IsKeyPress(DIK_F12)) // 디버깅 테스트..
 		s_pEng->Lightning(); // 번개 치기..
+	
+	if (s_pLocalInput->IsKeyPress(KM_TOGGLE_DEBUG_TEXT))
+	{
+		if (s_pUIMgr->m_bDisplayDebugText)
+			s_pUIMgr->SetVisibleDebugText(false);
+		else
+			s_pUIMgr->SetVisibleDebugText(true);
+	}
 #endif
+
 }
 
 void CGameProcMain::ProcessPlayerInclination()											// 경사에 서 있을때..
@@ -3849,11 +3862,7 @@ void CGameProcMain::InitUI()
 	m_pUIStateBarAndMiniMap->Init(s_pUIMgr);
 	m_pUIStateBarAndMiniMap->LoadFromFile(pTbl->szStateBar);
 	m_pUIStateBarAndMiniMap->SetStyle(UISTYLE_FOCUS_UNABLE | UISTYLE_HIDE_UNABLE);
-#ifdef _DEBUG
-	m_pUIStateBarAndMiniMap->SetPos(0, 70); // 디버그 정보 표시때문에 조금 내린다....
-#else
 	m_pUIStateBarAndMiniMap->SetPos(0, 0);
-#endif
 
 	// 다용도 UI - 상태, 기사단관리, 퀘스트, 친구 관리등...
 	m_pUIVar->Init(s_pUIMgr);

--- a/Client/WarFare/UIManager.cpp
+++ b/Client/WarFare/UIManager.cpp
@@ -36,12 +36,11 @@ CUIManager::CUIManager()
 	m_dwMouseFlagsCur = 0;
 	m_bEnableOperation = true;					// UI 조작이 가능한 상태인가?
 	m_pUIFocused = nullptr;
+	m_bDoneSomething = false;					// UI 에서 조작을 했다...
 #ifdef _DEBUG
 	m_pDFont = nullptr;
-#endif;
-
-	m_bDoneSomething = false;					// UI 에서 조작을 했다...
 	m_bDisplayDebugText = true;
+#endif;
 }
 
 CUIManager::~CUIManager()

--- a/Client/WarFare/UIManager.cpp
+++ b/Client/WarFare/UIManager.cpp
@@ -41,6 +41,7 @@ CUIManager::CUIManager()
 #endif;
 
 	m_bDoneSomething = false;					// UI 에서 조작을 했다...
+	m_bDisplayDebugText = true;
 }
 
 CUIManager::~CUIManager()
@@ -192,6 +193,17 @@ void CUIManager::Render()
 	CN3UIBase::Render();	// 자식들 render
 	if (s_pTooltipCtrl) s_pTooltipCtrl->Render();	// tooltip render
 
+#ifdef _DEBUG
+	RenderDebugText();
+#endif // _DEBUG
+
+
+	this->RenderStateRestore();
+}
+
+#ifdef _DEBUG
+void CUIManager::RenderDebugText()
+{
 	/*
 	NOTE: there is a very weird issue with setting the render state and displaying text.
 	- when the debug info is being displayed and you change window focus weird shit happens
@@ -199,7 +211,13 @@ void CUIManager::Render()
 	every game procedure which is somewhat unwanted right now...
 	*/
 	////////////////////////////////////////////////////////
-#ifdef _DEBUG
+
+	if (!m_bDisplayDebugText)
+		return;
+
+	if (NULL == s_lpD3DDev) 
+		return;
+
 	if (m_pDFont == nullptr)
 	{
 		m_pDFont = new CDFont("굴림", 10);
@@ -246,20 +264,38 @@ void CUIManager::Render()
 		szDebugs[3].clear();
 	}
 
+	// positions for top right side of the screen
+
+	int maxWidth = 0;
 	for (int i = 0; i < 4; i++)
 	{
 		if (szDebugs[i].empty())
 			continue;
 
+		SIZE size;
+		if (m_pDFont->GetTextExtent(szDebugs[i], szDebugs[i].size(), &size))
+		{
+			if (size.cx > maxWidth)
+				maxWidth = size.cx;
+		}
+	}
+
+	float baseX = CGameBase::s_Options.iViewWidth - maxWidth - 10.0f;
+
+	for (int i = 0; i < 4; i++)
+	{
+		if (szDebugs[i].empty())
+			continue;
+
+		float y = 10.0f + i * 18;
 		m_pDFont->SetText(szDebugs[i]);
-		m_pDFont->DrawText(0.0f, 0.0f + i * 18, 0xFFFFFFFF, 0);
+		m_pDFont->DrawText(baseX, y, 0xFFFFFFFF, 0);
 		szDebugs[i].clear();
 	}
-#endif
-	////////////////////////////////////////////////////////
 
-	this->RenderStateRestore();
+	////////////////////////////////////////////////////////
 }
+#endif
 
 void CUIManager::RenderStateSet()
 {

--- a/Client/WarFare/UIManager.h
+++ b/Client/WarFare/UIManager.h
@@ -36,6 +36,9 @@ protected:
 
 public:
 	bool		m_bDoneSomething;		// UI 에서 조작을 했다...
+#ifdef _DEBUG
+	bool		m_bDisplayDebugText;
+#endif // _DEBUG
 
 public:
 	void UserMoveHideUIs();
@@ -59,7 +62,10 @@ public:
 	void		ReorderChildList();
 
 	bool		BroadcastIconDropMsg(__IconItemSkill* spItem);
-
+#ifdef _DEBUG
+	void RenderDebugText();
+	inline void SetVisibleDebugText(bool bState){m_bDisplayDebugText = bState;};
+#endif //_DEBUG
 	CUIManager();
 	virtual ~CUIManager();
 };


### PR DESCRIPTION
…ge with DIK_ADD

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Feature

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue -->
Debug text is problematic on debug mode, covering top side and pushing state bar from top for no reason.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR -->
user can hide debug text on debug mode with pressing numpad + , it is positioned right side of the screen so now no need to push statebar from its original possition.

## Why and how did I change this?
<!-- Please describe your reasoning and thought process for why and how you changed this -->
This feautre is useless when there is no need to track information provided by debug text. Hence, it should be possible to hide it when data is not needed. 

## Demo
<!-- If applicable (it won't always be applicable), screenshots or video of this change to help us get a better idea of what you're changing. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
