### PR TITLE
Update UI control lookups to be more type-safe

### DIFF
--- a/Client/WarFare/CountableItemEditDlg.cpp
+++ b/Client/WarFare/CountableItemEditDlg.cpp
@@ -160,9 +160,8 @@ void CCountableItemEditDlg::Open(e_UIWND eUW, e_UIWND_DISTRICT eUD, bool bCountG
 		szMsg = fmt::format_text_resource(IDS_EDIT_BOX_COUNT);
 
 	CN3UIString* pString = nullptr;
-	pString = (CN3UIString*)this->GetChildByID("String_PersonTradeEdit_Msg");
-	__ASSERT(pString, "NULL UI Component!!");
-	if (pString)
+	N3_VERIFY_UI_COMPONENT(pString, GetChildByID<CN3UIString>("String_PersonTradeEdit_Msg"));
+	if (pString != nullptr)
 		pString->SetString(szMsg);
 
 	RECT rc, rcThis;
@@ -172,10 +171,11 @@ void CCountableItemEditDlg::Open(e_UIWND eUW, e_UIWND_DISTRICT eUD, bool bCountG
 	this->SetQuantity(-1);
 
 	SetVisible(true);
-	CN3UIEdit* pEdit = (CN3UIEdit*)this->GetChildByID("edit_trade");
-	__ASSERT(pEdit, "NULL UI Component!!");
-	if(pEdit) pEdit->SetFocus();
 
+	CN3UIEdit* pEdit = nullptr;
+	N3_VERIFY_UI_COMPONENT(pEdit, GetChildByID<CN3UIEdit>("edit_trade"));
+	if (pEdit != nullptr)
+		pEdit->SetFocus();
 
 	m_eCallerWnd = eUW;
 	m_eCallerWndDistrict = eUD;
@@ -217,16 +217,16 @@ void CCountableItemEditDlg::Close()
 
 int	CCountableItemEditDlg::GetQuantity() // "edit_trade" Edit Control 에서 정수값을 얻오온다..
 {
-	CN3UIEdit* pEdit = (CN3UIEdit*)this->GetChildByID("edit_trade");
-	__ASSERT(pEdit, "NULL UI Component!!");
+	CN3UIEdit* pEdit = nullptr;
+	N3_VERIFY_UI_COMPONENT(pEdit, GetChildByID<CN3UIEdit>("edit_trade"));
 
 	return atoi(pEdit->GetString().c_str());
 }
 
 void CCountableItemEditDlg::SetQuantity(int iQuantity) // "edit_trade" Edit Control 에서 정수값을 문자열로 세팅한다..
 {
-	CN3UIEdit* pEdit = (CN3UIEdit*) GetChildByID("edit_trade");
-	__ASSERT(pEdit, "NULL UI Component!!");
+	CN3UIEdit* pEdit = nullptr;
+	N3_VERIFY_UI_COMPONENT(pEdit, GetChildByID<CN3UIEdit>("edit_trade"));
 
 	std::string buff;
 	if (iQuantity != -1)
@@ -259,8 +259,8 @@ bool CCountableItemEditDlg::Load(HANDLE hFile)
 {
 	if(false == CN3UIBase::Load(hFile)) return false;
 
-	m_pBtnOk	 = (CN3UIButton*)(this->GetChildByID("btn_ok"));		__ASSERT(m_pBtnOk, "NULL UI Component!!!");
-	m_pBtnCancel = (CN3UIButton*)(this->GetChildByID("btn_cancel"));	__ASSERT(m_pBtnCancel, "NULL UI Component!!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtnOk,		GetChildByID<CN3UIButton>("btn_ok"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnCancel,	GetChildByID<CN3UIButton>("btn_cancel"));
 
 	return true;
 }

--- a/Client/WarFare/SubProcPerTrade.cpp
+++ b/Client/WarFare/SubProcPerTrade.cpp
@@ -110,7 +110,7 @@ void CSubProcPerTrade::InitPerTradeDlg(CUIManager* pUIManager)
 	m_pUITradeEditDlg->SetState(UI_STATE_COMMON_NONE);
 
 	// 일단은 돈 아이콘으로 픽스.. ^^
-	m_pUITradeEditDlg->m_pArea = (CN3UIArea *)m_pUITradeEditDlg->GetChildByID("area_trade_icon");	__ASSERT(m_pUITradeEditDlg->m_pArea, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pUITradeEditDlg->m_pArea, m_pUITradeEditDlg->GetChildByID<CN3UIArea >("area_trade_icon"));
 
 	m_pUITradeEditDlg->m_pImageOfIcon = new CN3UIImage;
 	m_pUITradeEditDlg->m_pImageOfIcon->Init(m_pUITradeEditDlg);
@@ -199,15 +199,19 @@ void CSubProcPerTrade::SecureCodeBegin()
 	// 5.인풋을 막는다..	-> 해당 부분..	ok	(키입력과 메시지..)
 
 	// 6.거래창의 편집 Control의 값을 Clear..
-	CN3UIString* pStrMy = (CN3UIString* )m_pUIPerTradeDlg->GetChildByID("string_money_my");			__ASSERT(pStrMy, "NULL UI Component!!");
-	CN3UIString* pStrOther = (CN3UIString* )m_pUIPerTradeDlg->GetChildByID("string_money_other");	__ASSERT(pStrOther, "NULL UI Component!!");
+	CN3UIString* pStrMy = nullptr, *pStrOther = nullptr;
+	N3_VERIFY_UI_COMPONENT(pStrMy, m_pUIPerTradeDlg->GetChildByID<CN3UIString>("string_money_my"));
 	pStrMy->SetString("0");
+
+	N3_VERIFY_UI_COMPONENT(pStrOther, m_pUIPerTradeDlg->GetChildByID<CN3UIString>("string_money_other"));
 	pStrOther->SetString("0");
 
 	// 7.개인 거래 창의 처크 버튼들 원래대로..
-	CN3UIButton* pButtonMy = (CN3UIButton* )m_pUIPerTradeDlg->GetChildByID("btn_trade_my");			__ASSERT(pButtonMy, "NULL UI Component!!");
+	CN3UIButton* pButtonMy = nullptr, *pButtonOther = nullptr;
+	N3_VERIFY_UI_COMPONENT(pButtonMy, m_pUIPerTradeDlg->GetChildByID<CN3UIButton>("btn_trade_my"));
 	pButtonMy->SetState(UI_STATE_BUTTON_NORMAL);
-	CN3UIButton* pButtonOther = (CN3UIButton* )m_pUIPerTradeDlg->GetChildByID("btn_trade_other");	__ASSERT(pButtonOther, "NULL UI Component!!");
+
+	N3_VERIFY_UI_COMPONENT(pButtonOther, m_pUIPerTradeDlg->GetChildByID<CN3UIButton>("btn_trade_other"));
 	pButtonOther->SetState(UI_STATE_BUTTON_NORMAL);
 
 	// 8.상대방 거래 버튼은 Click할 수 없다. uif 자체 기능..
@@ -286,7 +290,8 @@ void CSubProcPerTrade::PerTradeCompleteCancel()							// 개인 거래 취소..
 	{
 		// 먼저 돈을 검사 한다..
 		// 거래 창의 내 현재 돈을 얻어 온다..
-		CN3UIString* pStrMy = (CN3UIString* )m_pUIPerTradeDlg->GetChildByID("string_money_my");		__ASSERT(pStrMy, "NULL UI Component!!");
+		CN3UIString* pStrMy = nullptr;
+		N3_VERIFY_UI_COMPONENT(pStrMy, m_pUIPerTradeDlg->GetChildByID<CN3UIString>("string_money_my"));
 		str = pStrMy->GetString();
 		iGold = atoi(str.c_str());
 
@@ -523,7 +528,8 @@ void CSubProcPerTrade::ItemCountEditOK()
 		iMyMoney;		// 인벤토리의 값..
 
 	// 거래 창의 내 현재 돈을 얻어 온다..
-	CN3UIString* pStrMy = (CN3UIString* )m_pUIPerTradeDlg->GetChildByID("string_money_my");	 __ASSERT(pStrMy, "NULL UI Component!!");
+	CN3UIString* pStrMy = nullptr;
+	N3_VERIFY_UI_COMPONENT(pStrMy, m_pUIPerTradeDlg->GetChildByID<CN3UIString>("string_money_my"));
 	str = pStrMy->GetString();
 	iGold = atoi(str.c_str());
 
@@ -625,7 +631,8 @@ void CSubProcPerTrade::SecureJobStuffByMyDecision()
 
 void CSubProcPerTrade::PerTradeOtherDecision()						// 다른 사람이 거래를 결정 했다..
 {
-	CN3UIButton* pButtonOther = (CN3UIButton* )m_pUIPerTradeDlg->GetChildByID("btn_trade_other");	 __ASSERT(pButtonOther, "NULL UI Component!!");
+	CN3UIButton* pButtonOther = nullptr;
+	N3_VERIFY_UI_COMPONENT(pButtonOther, m_pUIPerTradeDlg->GetChildByID<CN3UIButton>("btn_trade_other"));
 	pButtonOther->SetState(UI_STATE_BUTTON_DISABLE);
 }
 
@@ -672,7 +679,8 @@ void CSubProcPerTrade::ReceiveMsgPerTradeAdd(uint8_t bResult)
 				case PER_TRADE_ITEM_MONEY:
 					{
 						// 거래 창의 내 현재 돈을 얻어 온다..
-						CN3UIString* pStrMy = (CN3UIString* )m_pUIPerTradeDlg->GetChildByID("string_money_my");	 __ASSERT(pStrMy, "NULL UI Component!!");
+						CN3UIString* pStrMy = nullptr;
+						N3_VERIFY_UI_COMPONENT(pStrMy, m_pUIPerTradeDlg->GetChildByID<CN3UIString>("string_money_my"));
 						str = pStrMy->GetString();
 						iGold = atoi(str.c_str());
 
@@ -821,7 +829,8 @@ void CSubProcPerTrade::ReceiveMsgPerTradeOtherAdd(int iItemID, int iCount, int i
 	if ( iItemID == dwGold )
 	{
 		// 거래 창의 다른 사람의 현재 돈을 얻어 온다..
-		CN3UIString* pStrOther = (CN3UIString* )m_pUIPerTradeDlg->GetChildByID("string_money_other");	 __ASSERT(pStrOther, "NULL UI Component!!");
+		CN3UIString* pStrOther = nullptr;
+		N3_VERIFY_UI_COMPONENT(pStrOther, m_pUIPerTradeDlg->GetChildByID<CN3UIString>("string_money_other"));
 		str = pStrOther->GetString();
 		iGold = atoi(str.c_str());
 		

--- a/Client/WarFare/UICharacterCreate.cpp
+++ b/Client/WarFare/UICharacterCreate.cpp
@@ -83,10 +83,10 @@ bool CUICharacterCreate::Load(HANDLE hFile)
 	pInfoBase->eRace = RACE_UNKNOWN;
 	pInfoBase->eClass = CLASS_UNKNOWN;
 
-	m_pEdit_Name = (CN3UIEdit*)(this->GetChildByID("edit_name")); __ASSERT(m_pEdit_Name, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pEdit_Name, GetChildByID<CN3UIEdit>("edit_name"));
 	if(m_pEdit_Name) m_pEdit_Name->SetString("");
 	
-	m_pStr_Desc = (CN3UIString*)(this->GetChildByID("text_desc")); __ASSERT(m_pStr_Desc, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pStr_Desc, GetChildByID<CN3UIString>("text_desc"));
 	e_Nation eNation = pInfoBase->eNation;
 	if(m_pStr_Desc)
 	{
@@ -102,7 +102,7 @@ bool CUICharacterCreate::Load(HANDLE hFile)
 		}
 	}
 
-	m_pArea_Character = (CN3UIArea*)(this->GetChildByID("area_character")); __ASSERT(m_pArea_Character, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pArea_Character, GetChildByID<CN3UIArea>("area_character"));
 	
 	std::string szTexts[MAX_STATS] = { "text_str", "text_sta", "text_dex", "text_int", "text_map" };
 	std::string szAreas[MAX_STATS] = { "area_str", "area_sta", "area_dex", "area_int", "area_map" };
@@ -110,26 +110,26 @@ bool CUICharacterCreate::Load(HANDLE hFile)
 	uint32_t dwResrcIDs[MAX_STATS] = { IDS_NEWCHR_POW, IDS_NEWCHR_STA, IDS_NEWCHR_DEX, IDS_NEWCHR_INT, IDS_NEWCHR_MAP };
 	for(int i = 0; i < MAX_STATS; i++)
 	{
-		m_pStr_Stats[i] = (CN3UIString*)(this->GetChildByID(szTexts[i])); __ASSERT(m_pStr_Stats[i], "NULL UI Component!!");
-		m_pArea_Stats[i] = (CN3UIArea*)(this->GetChildByID(szAreas[i])); __ASSERT(m_pArea_Stats[i], "NULL UI Component!!");
-		m_pImg_Stats[i] = (CN3UIImage*)(this->GetChildByID(szImgs[i]));	__ASSERT(m_pImg_Stats[i], "NULL UI Component!!");
+		N3_VERIFY_UI_COMPONENT(m_pStr_Stats[i],		GetChildByID<CN3UIString>(szTexts[i]));
+		N3_VERIFY_UI_COMPONENT(m_pArea_Stats[i],	GetChildByID<CN3UIArea>(szAreas[i]));
+		N3_VERIFY_UI_COMPONENT(m_pImg_Stats[i],		GetChildByID<CN3UIImage>(szImgs[i]));
 
 		if (m_pArea_Stats[i] != nullptr)
 			m_pArea_Stats[i]->SetTooltipText(fmt::format_text_resource(dwResrcIDs[i]));
 	}
 
-	m_pStr_Bonus = (CN3UIString*)(this->GetChildByID("text_bonus")); __ASSERT(m_pStr_Bonus, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pStr_Bonus, GetChildByID<CN3UIString>("text_bonus"));
 	
 
-	m_pBtn_Face_Left =	(CN3UIButton*)(this->GetChildByID("btn_face_left"));	__ASSERT(m_pBtn_Face_Left, "NULL UI Component!!");
-	m_pBtn_Face_Right = (CN3UIButton*)(this->GetChildByID("btn_face_right"));	__ASSERT(m_pBtn_Face_Right, "NULL UI Component!!");
-	m_pBtn_Hair_Left =	(CN3UIButton*)(this->GetChildByID("btn_hair_left"));	__ASSERT(m_pBtn_Hair_Left, "NULL UI Component!!");
-	m_pBtn_Hair_Right = (CN3UIButton*)(this->GetChildByID("btn_hair_right"));	__ASSERT(m_pBtn_Hair_Right, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Face_Left, GetChildByID<CN3UIButton>("btn_face_left"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Face_Right, GetChildByID<CN3UIButton>("btn_face_right"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Hair_Left, GetChildByID<CN3UIButton>("btn_hair_left"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Hair_Right, GetChildByID<CN3UIButton>("btn_hair_right"));
 	
 	std::string szBtnIDs[MAX_RACE_SELECT];
 	uint32_t dwResrcID_Races[MAX_RACE_SELECT];
 
-	if(eNation==NATION_KARUS)
+	if (eNation == NATION_KARUS)
 	{
 		szBtnIDs[0] = "btn_race_ka_at";
 		szBtnIDs[1] = "btn_race_ka_tu";
@@ -140,7 +140,7 @@ bool CUICharacterCreate::Load(HANDLE hFile)
 		dwResrcID_Races[2] = IDS_NEWCHR_KA_WRINKLETUAREK; // 3218
 		dwResrcID_Races[3] = IDS_NEWCHR_KA_PURITUAREK; // 3214
 	}
-	else if(eNation==NATION_ELMORAD)
+	else // if (eNation == NATION_ELMORAD)
 	{
 		szBtnIDs[0] = "btn_race_el_ba";
 		szBtnIDs[1] = "btn_race_el_rm";
@@ -155,7 +155,7 @@ bool CUICharacterCreate::Load(HANDLE hFile)
 	for(int i = 0; i < MAX_RACE_SELECT; i++)
 	{
 		if(szBtnIDs[i].empty()) continue;
-		m_pBtn_Races[i] = (CN3UIButton*)(this->GetChildByID(szBtnIDs[i])); __ASSERT(m_pBtn_Races[i], "NULL UI Component!!");
+		N3_VERIFY_UI_COMPONENT(m_pBtn_Races[i], GetChildByID<CN3UIButton>(szBtnIDs[i]));
 
 		if (m_pBtn_Races[i] != nullptr)
 			m_pBtn_Races[i]->SetTooltipText(fmt::format_text_resource(dwResrcID_Races[i]));
@@ -164,25 +164,25 @@ bool CUICharacterCreate::Load(HANDLE hFile)
 	std::string szBtns[MAX_CLASS_SELECT] = { "btn_class_warrior", "btn_class_rogue", "btn_class_mage", "btn_class_priest" };
 	std::string szImgs2[MAX_CLASS_SELECT] = { "img_warrior", "img_rogue", "img_mage", "img_priest" };
 	uint32_t dwResrcID_Classes[MAX_CLASS_SELECT];
-	if(eNation==NATION_ELMORAD)
-	{
-		dwResrcID_Classes[0] = IDS_NEWCHR_EL_WARRIOR;
-		dwResrcID_Classes[1] = IDS_NEWCHR_EL_ROGUE;
-		dwResrcID_Classes[2] = IDS_NEWCHR_EL_MAGE;
-		dwResrcID_Classes[3] = IDS_NEWCHR_EL_PRIEST;
-	}
-	else if(eNation==NATION_KARUS)
+	if (eNation == NATION_KARUS)
 	{
 		dwResrcID_Classes[0] = IDS_NEWCHR_KA_WARRIOR;
 		dwResrcID_Classes[1] = IDS_NEWCHR_KA_ROGUE;
 		dwResrcID_Classes[2] = IDS_NEWCHR_KA_MAGE;
 		dwResrcID_Classes[3] = IDS_NEWCHR_KA_PRIEST;
 	}
+	else // if (eNation == NATION_ELMORAD)
+	{
+		dwResrcID_Classes[0] = IDS_NEWCHR_EL_WARRIOR;
+		dwResrcID_Classes[1] = IDS_NEWCHR_EL_ROGUE;
+		dwResrcID_Classes[2] = IDS_NEWCHR_EL_MAGE;
+		dwResrcID_Classes[3] = IDS_NEWCHR_EL_PRIEST;
+	}
 
 	for(int i = 0; i < MAX_CLASS_SELECT; i++)
 	{
-		m_pBtn_Classes[i] =	(CN3UIButton*)(this->GetChildByID(szBtns[i]));	__ASSERT(m_pBtn_Classes[i], "NULL UI Component!!");
-		m_pImg_Disable_Classes[i] = (CN3UIImage*)(this->GetChildByID(szImgs2[i]));	__ASSERT(m_pImg_Disable_Classes[i], "NULL UI Component!!");
+		N3_VERIFY_UI_COMPONENT(m_pBtn_Classes[i],			GetChildByID<CN3UIButton>(szBtns[i]));
+		N3_VERIFY_UI_COMPONENT(m_pImg_Disable_Classes[i],	GetChildByID<CN3UIImage>(szImgs2[i]));
 
 		if (m_pBtn_Classes[i] != nullptr)
 			m_pBtn_Classes[i]->SetTooltipText(fmt::format_text_resource(dwResrcID_Classes[i]));

--- a/Client/WarFare/UICharacterSelect.cpp
+++ b/Client/WarFare/UICharacterSelect.cpp
@@ -201,7 +201,7 @@ void CUICharacterSelect::DisplayChrInfo(__CharacterSelectInfo* pCSInfo)
 void CUICharacterSelect::DontDisplayInfo()
 {
 	CN3UIBase*	m_pUserInfoStr;
-	m_pUserInfoStr = GetChildByID("text00"); __ASSERT(m_pUserInfoStr, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pUserInfoStr, GetChildByID("text00"));
 
 	if ( m_pUserInfoStr ) m_pUserInfoStr->SetVisible(false);
 }

--- a/Client/WarFare/UIChat.cpp
+++ b/Client/WarFare/UIChat.cpp
@@ -258,9 +258,9 @@ void CUIChat::CreateLines()
 bool CUIChat::Load(HANDLE hFile)
 {
 	if (false == CN3UIBase::Load(hFile)) return false;
-	m_pChatOut		= (CN3UIString*)GetChildByID("text0");				__ASSERT(m_pChatOut, "NULL UI Component!!");
-	m_pScrollbar	= (CN3UIScrollBar*)GetChildByID("scroll");			__ASSERT(m_pScrollbar, "NULL UI Component!!");
-	m_pNoticeTitle	= (CN3UIString*)GetChildByID("text_notice_title");	__ASSERT(m_pNoticeTitle, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pChatOut, GetChildByID<CN3UIString>("text0"));
+	N3_VERIFY_UI_COMPONENT(m_pScrollbar, GetChildByID<CN3UIScrollBar>("scroll"));
+	N3_VERIFY_UI_COMPONENT(m_pNoticeTitle, GetChildByID<CN3UIString>("text_notice_title"));
 
 	m_rcChatOutRegion = m_pChatOut->GetRegion();
 	CreateLines();
@@ -268,18 +268,18 @@ bool CUIChat::Load(HANDLE hFile)
 	__ASSERT(0<m_iChatLineCount,"채팅창이 너무 작아요");
 
 	//son, chat_in
-	m_pEdit = (CN3UIEdit*)GetChildByID("edit0");				__ASSERT(m_pEdit, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pEdit, GetChildByID<CN3UIEdit>("edit0"));
 	m_pEdit->SetMaxString(256); // 채팅 문자열 길이 제한..
 	//son, chat_in
 
-	m_pBtn_Normal			= GetChildByID("btn_normal");			__ASSERT(m_pBtn_Normal, "NULL UI Component!!");
-	m_pBtn_Private			= GetChildByID("btn_private");			__ASSERT(m_pBtn_Private, "NULL UI Component!!");
-	m_pBtn_PartyOrForce		= GetChildByID("btn_party_force");		__ASSERT(m_pBtn_PartyOrForce, "NULL UI Component!!");
-	//m_pBtn_KnightsOrGuild = GetChildByID("btn_knights_guild");	__ASSERT(m_pBtn_KnightsOrGuild, "NULL UI Component!!");
-	m_pBtn_KnightsOrGuild	= GetChildByID("btn_knights");			__ASSERT(m_pBtn_KnightsOrGuild, "NULL UI Component!!");
-	m_pBtn_Shout			= GetChildByID("btn_shout");			__ASSERT(m_pBtn_Shout, "NULL UI Component!!");
-	m_pBtn_Check			= GetChildByID("btn_check_normal");		__ASSERT(m_pBtn_Check, "NULL UI Component!!");
-	m_pBtn_Fold				= GetChildByID("btn_off");				__ASSERT(m_pBtn_Fold, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Normal, GetChildByID("btn_normal"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Private, GetChildByID("btn_private"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_PartyOrForce, GetChildByID("btn_party_force"));
+	//N3_VERIFY_UI_COMPONENT(m_pBtn_KnightsOrGuild, GetChildByID("btn_knights_guild"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_KnightsOrGuild, GetChildByID("btn_knights"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Shout, GetChildByID("btn_shout"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Check, GetChildByID("btn_check_normal"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Fold, GetChildByID("btn_off"));
 
 	this->ChangeChattingMode(N3_CHAT_NORMAL); // 보통 채팅 모드이다..
 
@@ -826,7 +826,7 @@ CUIChat2::CUIChat2()
 bool CUIChat2::Load(HANDLE hFile)
 {
 	if (false == CN3UIBase::Load(hFile)) return false;
-	m_pBtn_Fold = GetChildByID("btn_on");			__ASSERT(m_pBtn_Fold, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Fold, GetChildByID("btn_on"));
 	return true;
 }
 

--- a/Client/WarFare/UIClassChange.cpp
+++ b/Client/WarFare/UIClassChange.cpp
@@ -56,15 +56,15 @@ bool CUIClassChange::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pBtn_Ok			= (CN3UIButton*)GetChildByID("Btn_Ok");			__ASSERT(m_pBtn_Ok,	"NULL UI Component!!");
-	m_pBtn_Cancel		= (CN3UIButton*)GetChildByID("Btn_Cancel");		__ASSERT(m_pBtn_Cancel, "NULL UI Component!!");
-	m_pBtn_Class0		= (CN3UIButton*)GetChildByID("Btn_Class0");		__ASSERT(m_pBtn_Class0,	"NULL UI Component!!");
-	m_pBtn_Class1		= (CN3UIButton*)GetChildByID("Btn_Class1");		__ASSERT(m_pBtn_Class1,	"NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Ok, GetChildByID<CN3UIButton>("Btn_Ok"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel, GetChildByID<CN3UIButton>("Btn_Cancel"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Class0, GetChildByID<CN3UIButton>("Btn_Class0"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Class1, GetChildByID<CN3UIButton>("Btn_Class1"));
 
-	m_pText_Warning		= (CN3UIString*)GetChildByID("Text_Waring");	__ASSERT(m_pText_Warning, "NULL UI Component!!");
-	m_pText_Info0		= (CN3UIString*)GetChildByID("Text_info0");		__ASSERT(m_pText_Info0, "NULL UI Component!!");
-	m_pText_Info1		= (CN3UIString*)GetChildByID("Text_info1");		__ASSERT(m_pText_Info1, "NULL UI Component!!");
-	m_pText_Message		= (CN3UIString*)GetChildByID("Text_Message");	__ASSERT(m_pText_Message, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_Warning, GetChildByID<CN3UIString>("Text_Waring"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Info0, GetChildByID<CN3UIString>("Text_info0"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Info1, GetChildByID<CN3UIString>("Text_info1"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Message, GetChildByID<CN3UIString>("Text_Message"));
 
 	return true;
 }

--- a/Client/WarFare/UIHelp.cpp
+++ b/Client/WarFare/UIHelp.cpp
@@ -43,7 +43,7 @@ bool CUIHelp::Load(HANDLE hFile)
 	for (int i = 0; i < MAX_HELP_PAGE; i++)
 	{
 		szID = fmt::format("Page{}", i);
-		m_pPages[i] = GetChildByID(szID);
+		N3_VERIFY_UI_COMPONENT(m_pPages[i], GetChildByID(szID));
 		if (m_pPages[i] != nullptr)
 		{
 			m_pPages[i]->SetVisible(0 == iPageCount);

--- a/Client/WarFare/UIHotKeyDlg.cpp
+++ b/Client/WarFare/UIHotKeyDlg.cpp
@@ -755,14 +755,16 @@ void CUIHotKeyDlg::ClassChangeHotkeyFlush()
 CN3UIString* CUIHotKeyDlg::GetTooltipStrControl(int iIndex)
 {
 	std::string str = std::to_string(iIndex + 10);
-	CN3UIString* pStr = (CN3UIString*) GetChildByID(str);	 __ASSERT(pStr, "NULL UI Component!!");
+	CN3UIString* pStr = nullptr;
+	N3_VERIFY_UI_COMPONENT(pStr, GetChildByID<CN3UIString>(str));
 	return pStr;
 }
 
 CN3UIString* CUIHotKeyDlg::GetCountStrControl(int iIndex)
 {
 	std::string str = std::to_string(iIndex);
-	CN3UIString* pStr = (CN3UIString*) GetChildByID(str);	 __ASSERT(pStr, "NULL UI Component!!");
+	CN3UIString* pStr = nullptr;
+	N3_VERIFY_UI_COMPONENT(pStr, GetChildByID<CN3UIString>(str));
 	return pStr;
 }
 

--- a/Client/WarFare/UIImageTooltipDlg.cpp
+++ b/Client/WarFare/UIImageTooltipDlg.cpp
@@ -59,10 +59,10 @@ void CUIImageTooltipDlg::InitPos()
 	for (int i = 0; i < MAX_TOOLTIP_COUNT; i++)
 	{
 		str = "string_" + std::to_string(i);
-		m_pStr[i] = (CN3UIString*) GetChildByID(str);	 __ASSERT(m_pStr[i], "NULL UI Component!!");
+		N3_VERIFY_UI_COMPONENT(m_pStr[i], GetChildByID<CN3UIString>(str));
 	}
 
-	m_pImg = (CN3UIImage*) GetChildByID("mins");	 __ASSERT(m_pImg, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pImg, GetChildByID<CN3UIImage>("mins"));
 }
 
 void CUIImageTooltipDlg::DisplayTooltipsDisable()

--- a/Client/WarFare/UIInventory.cpp
+++ b/Client/WarFare/UIInventory.cpp
@@ -388,13 +388,13 @@ void CUIInventory::Render()
 
 void CUIInventory::InitIconWnd(e_UIWND eWnd)
 {
-	m_pArea_User = (CN3UIArea *)GetChildByID("area_char"); __ASSERT(m_pArea_User, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pArea_User, GetChildByID<CN3UIArea>("area_char"));
 	if(nullptr == m_pArea_User) return;
 
-	m_pArea_Destroy = (CN3UIArea *)GetChildByID("area_samma"); __ASSERT(m_pArea_Destroy, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pArea_Destroy, GetChildByID<CN3UIArea>("area_samma"));
 	if(nullptr == m_pArea_Destroy) return;
 
-	m_pText_Weight		= (CN3UIString*)GetChildByID("text_weight");	__ASSERT(m_pText_Weight	, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_Weight, GetChildByID<CN3UIString>("text_weight"));
 	__TABLE_UI_RESRC* pTblUI = CGameBase::s_pTbl_UI.Find(CGameBase::s_pPlayer->m_InfoBase.eNation);
 	__ASSERT(pTblUI, "NULL Pointer UI Table");
 
@@ -547,8 +547,8 @@ uint32_t CUIInventory::MouseProc(uint32_t dwFlags, const POINT& ptCur, const POI
 
 	if (m_bDestoyDlgAlive)	
 	{ 
-		CN3UIImage* pImg = (CN3UIImage* )m_pArea_Destroy->GetChildByID("img_Destroy");
-		__ASSERT(pImg, "NULL UI Component!!");
+		CN3UIImage* pImg = nullptr;
+		N3_VERIFY_UI_COMPONENT(pImg, m_pArea_Destroy->GetChildByID<CN3UIImage>("img_Destroy"));
 
 		if (!pImg) return dwRet;
 		if (!pImg->IsIn(ptCur.x, ptCur.y))
@@ -2829,14 +2829,16 @@ bool CUIInventory::OnKeyPress(int iKey)
 		{
 		case DIK_RETURN:
 			{
-				CN3UIButton* pBtnDestroyOk = (CN3UIButton* )m_pArea_Destroy->GetChildByID("btn_Destroy_ok");
+				CN3UIButton* pBtnDestroyOk = nullptr;
+				N3_VERIFY_UI_COMPONENT(pBtnDestroyOk, m_pArea_Destroy->GetChildByID<CN3UIButton>("btn_Destroy_ok"));
 				if(pBtnDestroyOk) m_pArea_Destroy->ReceiveMessage(pBtnDestroyOk, UIMSG_BUTTON_CLICK);
 				else return false;
 			}
 			return true;
 		case DIK_ESCAPE:
 			{
-				CN3UIButton* pBtnDestroyCancel = (CN3UIButton* )m_pArea_Destroy->GetChildByID("btn_Destroy_cancel");
+				CN3UIButton* pBtnDestroyCancel = nullptr;
+				N3_VERIFY_UI_COMPONENT(pBtnDestroyCancel, m_pArea_Destroy->GetChildByID<CN3UIButton>("btn_Destroy_cancel"));
 				if(pBtnDestroyCancel) m_pArea_Destroy->ReceiveMessage(pBtnDestroyCancel, UIMSG_BUTTON_CLICK);
 				else return false;
 			}

--- a/Client/WarFare/UIItemExchange.cpp
+++ b/Client/WarFare/UIItemExchange.cpp
@@ -80,8 +80,8 @@ bool CUIItemExchange::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pImage_Repair		= (CN3UIImage*)GetChildByID("img_repair");
-	m_pImage_Exchange	= (CN3UIImage*)GetChildByID("img_change");
+	m_pImage_Repair		= GetChildByID<CN3UIImage>("img_repair");
+	m_pImage_Exchange	= GetChildByID<CN3UIImage>("img_change");
 
 	return true;
 }
@@ -279,8 +279,8 @@ bool CUIItemExchange::ReceiveIconDrop(__IconItemSkill* spItem, POINT ptCur)
 
 void CUIItemExchange::UpdateGoldValue()
 {
-	CN3UIString* pStrGold = (CN3UIString*) GetChildByID("string_gold");
-	__ASSERT(pStrGold, "NULL UI Component!!");
+	CN3UIString* pStrGold = nullptr;
+	N3_VERIFY_UI_COMPONENT(pStrGold, GetChildByID<CN3UIString>("string_gold"));
 
 	// 돈 업데이트..	
 	if (pStrGold != nullptr)

--- a/Client/WarFare/UIKnightsOperation.cpp
+++ b/Client/WarFare/UIKnightsOperation.cpp
@@ -68,16 +68,16 @@ bool CUIKnightsOperation::Load(HANDLE hFile)
 {
 	if(false == CN3UIBase::Load(hFile)) return false;
 
-	m_pBtn_Up = (CN3UIButton*)(this->GetChildByID("btn_up"));		__ASSERT(m_pBtn_Up, "NULL UI Component!!");
-	m_pBtn_Down = (CN3UIButton*)(this->GetChildByID("btn_down"));	__ASSERT(m_pBtn_Down, "NULL UI Component!!");
-	m_pBtn_Close = (CN3UIButton*)(this->GetChildByID("btn_close"));	__ASSERT(m_pBtn_Close, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Up, GetChildByID<CN3UIButton>("btn_up"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Down, GetChildByID<CN3UIButton>("btn_down"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Close, GetChildByID<CN3UIButton>("btn_close"));
 
-	m_pList_Knights =		(CN3UIList*)(this->GetChildByID("List_Knights"));		__ASSERT(m_pList_Knights, "NULL UI Component!!");
-	m_pBtn_Join =			(CN3UIButton*)(this->GetChildByID("Btn_Join"));			__ASSERT(m_pBtn_Join, "NULL UI Component!!");
-	m_pBtn_Create =			(CN3UIButton*)(this->GetChildByID("Btn_Create"));		__ASSERT(m_pBtn_Create, "NULL UI Component!!");
-	m_pBtn_Destroy =		(CN3UIButton*)(this->GetChildByID("Btn_Destroy"));		__ASSERT(m_pBtn_Destroy, "NULL UI Component!!");
-	m_pBtn_Withdraw =		(CN3UIButton*)(this->GetChildByID("Btn_Withdraw"));		__ASSERT(m_pBtn_Withdraw, "NULL UI Component!!");
-	m_pEdit_KnightsName =	(CN3UIEdit*)(this->GetChildByID("Edit_KnightsName"));	__ASSERT(m_pEdit_KnightsName, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pList_Knights, GetChildByID<CN3UIList>("List_Knights"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Join, GetChildByID<CN3UIButton>("Btn_Join"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Create, GetChildByID<CN3UIButton>("Btn_Create"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Destroy, GetChildByID<CN3UIButton>("Btn_Destroy"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Withdraw, GetChildByID<CN3UIButton>("Btn_Withdraw"));
+	N3_VERIFY_UI_COMPONENT(m_pEdit_KnightsName, GetChildByID<CN3UIEdit>("Edit_KnightsName"));
 
 	return true;
 }

--- a/Client/WarFare/UIMessageBox.cpp
+++ b/Client/WarFare/UIMessageBox.cpp
@@ -57,13 +57,13 @@ bool CUIMessageBox::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 	
-	m_pBtn_OK = (CN3UIButton*)GetChildByID("Btn_OK"); __ASSERT(m_pBtn_OK, "NULL UI Component!!");
-	m_pBtn_Yes = (CN3UIButton*)GetChildByID("Btn_Yes"); __ASSERT(m_pBtn_Yes, "NULL UI Component!!");
-	m_pBtn_No = (CN3UIButton*)GetChildByID("Btn_No"); __ASSERT(m_pBtn_No, "NULL UI Component!!");
-	m_pBtn_Cancel = (CN3UIButton*)GetChildByID("Btn_Cancel"); __ASSERT(m_pBtn_Cancel, "NULL UI Component!!");
-	m_pText_Message = (CN3UIString*)GetChildByID("Text_Message"); __ASSERT(m_pText_Message, "NULL UI Component!!");
-	m_pText_Title = (CN3UIString*)GetChildByID("Text_Title"); __ASSERT(m_pText_Title, "NULL UI Component!!");
-	m_pEdit_Common = (CN3UIEdit*)GetChildByID("Edit_Common"); __ASSERT(m_pEdit_Common, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_OK, GetChildByID<CN3UIButton>("Btn_OK"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Yes, GetChildByID<CN3UIButton>("Btn_Yes"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_No, GetChildByID<CN3UIButton>("Btn_No"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel, GetChildByID<CN3UIButton>("Btn_Cancel"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Message, GetChildByID<CN3UIString>("Text_Message"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Title, GetChildByID<CN3UIString>("Text_Title"));
+	N3_VERIFY_UI_COMPONENT(m_pEdit_Common, GetChildByID<CN3UIEdit>("Edit_Common"));
 
 	return true;
 }

--- a/Client/WarFare/UIMessageWnd.cpp
+++ b/Client/WarFare/UIMessageWnd.cpp
@@ -118,9 +118,9 @@ BOOL CUIMessageWnd::MoveOffset(int iOffsetX, int iOffsetY)
 bool CUIMessageWnd::Load(HANDLE hFile)
 {
 	if (false == CN3UIBase::Load(hFile)) return false;
-	m_pChatOut = (CN3UIString*)GetChildByID("text_message");	__ASSERT(m_pChatOut, "NULL UI Component!!");
-	m_pScrollbar = (CN3UIScrollBar*)GetChildByID("scroll");		__ASSERT(m_pScrollbar, "NULL UI Component!!");
-	m_pBtn_Fold = (CN3UIBase*)GetChildByID("btn_off");	__ASSERT(m_pBtn_Fold, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pChatOut, GetChildByID<CN3UIString>("text_message"));
+	N3_VERIFY_UI_COMPONENT(m_pScrollbar, GetChildByID<CN3UIScrollBar>("scroll"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Fold, GetChildByID("btn_off"));
 
 	m_rcChatOutRegion = m_pChatOut->GetRegion();
 	CreateLines();
@@ -445,7 +445,7 @@ CUIMessageWnd2::CUIMessageWnd2()
 bool CUIMessageWnd2::Load(HANDLE hFile)
 {
 	if (false == CN3UIBase::Load(hFile)) return false;
-	m_pBtn_Fold = GetChildByID("btn_on");			__ASSERT(m_pBtn_Fold, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Fold, GetChildByID("btn_on"));
 	return true;
 }
 

--- a/Client/WarFare/UINPCChangeEvent.cpp
+++ b/Client/WarFare/UINPCChangeEvent.cpp
@@ -57,10 +57,10 @@ bool CUINPCChangeEvent::Load(HANDLE hFile)
 
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pBtn_Change		= (CN3UIButton*)GetChildByID("Btn_change");		__ASSERT(m_pBtn_Change,	"NULL UI Component!!");
-	m_pBtn_Repoint0		= (CN3UIButton*)GetChildByID("Btn_repoint0");	__ASSERT(m_pBtn_Repoint0, "NULL UI Component!!");
-	m_pBtn_Repoint1		= (CN3UIButton*)GetChildByID("Btn_repoint1");	__ASSERT(m_pBtn_Repoint1,	"NULL UI Component!!");
-	m_pBtn_Close		= (CN3UIButton*)GetChildByID("Btn_close");		__ASSERT(m_pBtn_Close,	"NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Change, GetChildByID<CN3UIButton>("Btn_change"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Repoint0, GetChildByID<CN3UIButton>("Btn_repoint0"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Repoint1, GetChildByID<CN3UIButton>("Btn_repoint1"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Close, GetChildByID<CN3UIButton>("Btn_close"));
 
 	// UIPointInitDlg.. ^^
 	e_Nation eNation = CGameBase::s_pPlayer->m_InfoBase.eNation; // 국가....

--- a/Client/WarFare/UINPCEvent.cpp
+++ b/Client/WarFare/UINPCEvent.cpp
@@ -46,9 +46,9 @@ bool CUINPCEvent::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pBtn_Repair	= (CN3UIButton*)GetChildByID("Btn_Repair");		__ASSERT(m_pBtn_Repair, "NULL UI Component!!");
-	m_pText_Repair	= (CN3UIString*)GetChildByID("Text_Repair");	__ASSERT(m_pText_Repair, "NULL UI Component!!");
-	m_pText_Title	= (CN3UIString*)GetChildByID("Text_Title");		__ASSERT(m_pText_Title, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Repair, GetChildByID<CN3UIButton>("Btn_Repair"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Repair, GetChildByID<CN3UIString>("Text_Repair"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Title, GetChildByID<CN3UIString>("Text_Title"));
 
 	return true;
 }

--- a/Client/WarFare/UINationSelectDlg.cpp
+++ b/Client/WarFare/UINationSelectDlg.cpp
@@ -32,9 +32,9 @@ bool CUINationSelectDlg::Load(HANDLE hFile)
 {
 	bool bSuccess = CN3UIBase::Load(hFile);
 
-	m_pBtnKarus = this->GetChildByID("btn_karus_selection");	__ASSERT(m_pBtnKarus, "NULL UI Component!!");
-	m_pBtnElmorad = this->GetChildByID("btn_elmo_selection");	__ASSERT(m_pBtnElmorad, "NULL UI Component!!"); // 
-	m_pBtnBack = this->GetChildByID("btn_back");	__ASSERT(m_pBtnElmorad, "NULL UI Component!!"); // 
+	N3_VERIFY_UI_COMPONENT(m_pBtnKarus, GetChildByID("btn_karus_selection"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnElmorad, GetChildByID("btn_elmo_selection")); // 
+	N3_VERIFY_UI_COMPONENT(m_pBtnBack, GetChildByID("btn_back")); // 
 	RECT rc = this->GetRegion();
 	int iX = ((int)s_CameraData.vp.Width - (rc.right - rc.left))/2;
 	int iY = ((int)s_CameraData.vp.Height - (rc.bottom - rc.top))/2;

--- a/Client/WarFare/UINotice.cpp
+++ b/Client/WarFare/UINotice.cpp
@@ -43,9 +43,9 @@ bool CUINotice::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pText_Notice = (CN3UIString*)GetChildByID("Text_Notice");
-	m_pScrollBar = (CN3UIScrollBar*)GetChildByID("ScrollBar");
-	m_pBtn_OK = (CN3UIButton*)GetChildByID("Btn_Quit"); //m_pBtn_OK = (CN3UIButton*)GetChildByID("Btn_OK");
+	m_pText_Notice = GetChildByID<CN3UIString>("Text_Notice");
+	m_pScrollBar = GetChildByID<CN3UIScrollBar>("ScrollBar");
+	m_pBtn_OK = GetChildByID<CN3UIButton>("Btn_Quit");
 
 	if(m_pScrollBar) 
 	{

--- a/Client/WarFare/UIPartyBBS.cpp
+++ b/Client/WarFare/UIPartyBBS.cpp
@@ -61,25 +61,24 @@ bool CUIPartyBBS::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-//	m_pList_Infos = (CN3UIList*)(this->GetChildByID("List_Friends"));					__ASSERT(m_pList_Infos, "NULL UI Component!!!");
-	m_pBtn_PageUp = (CN3UIButton*)(this->GetChildByID("btn_page_up"));					__ASSERT(m_pBtn_PageUp, "NULL UI Component!!!");
-	m_pBtn_PageDown = (CN3UIButton*)(this->GetChildByID("btn_page_down"));				__ASSERT(m_pBtn_PageDown, "NULL UI Component!!!");
-	m_pBtn_Refresh = (CN3UIButton*)(this->GetChildByID("btn_refresh"));					__ASSERT(m_pBtn_Refresh, "NULL UI Component!!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_PageUp, GetChildByID<CN3UIButton>("btn_page_up"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_PageDown, GetChildByID<CN3UIButton>("btn_page_down"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Refresh, GetChildByID<CN3UIButton>("btn_refresh"));
 	
-	m_pBtn_Close = (CN3UIButton*)(this->GetChildByID("btn_exit"));						__ASSERT(m_pBtn_Close, "NULL UI Component!!!");
-	m_pBtn_Register = (CN3UIButton*)(this->GetChildByID("btn_add"));					__ASSERT(m_pBtn_Register, "NULL UI Component!!!");
-	m_pBtn_RegisterCancel = (CN3UIButton*)(this->GetChildByID("btn_delete"));			__ASSERT(m_pBtn_RegisterCancel, "NULL UI Component!!!");
-	m_pBtn_Whisper = (CN3UIButton*)(this->GetChildByID("btn_whisper"));					__ASSERT(m_pBtn_Whisper, "NULL UI Component!!!");
-	m_pBtn_Party = (CN3UIButton*)(this->GetChildByID("btn_Party"));						__ASSERT(m_pBtn_Party, "NULL UI Component!!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Close, GetChildByID<CN3UIButton>("btn_exit"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Register, GetChildByID<CN3UIButton>("btn_add"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_RegisterCancel, GetChildByID<CN3UIButton>("btn_delete"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Whisper, GetChildByID<CN3UIButton>("btn_whisper"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Party, GetChildByID<CN3UIButton>("btn_Party"));
 
 
-	m_pText_Page = (CN3UIString*)(this->GetChildByID("string_page"));					__ASSERT(m_pText_Page, "NULL UI Component!!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_Page, GetChildByID<CN3UIString>("string_page"));
 
 	std::string szID;
 	for (int i = 0; i < PARTY_BBS_MAXSTRING; i++)
 	{
 		szID = fmt::format("text_{:02}", i);
-		m_pText[i] = (CN3UIString*) GetChildByID(szID);
+		N3_VERIFY_UI_COMPONENT(m_pText[i], GetChildByID<CN3UIString>(szID));
 	}
 
 	m_iCurPage = 0; // 현재 페이지..

--- a/Client/WarFare/UIPartyBBSSelector.cpp
+++ b/Client/WarFare/UIPartyBBSSelector.cpp
@@ -68,8 +68,8 @@ bool CUIPartyBBSSelector::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pBtn_WantPartyMember	= (CN3UIButton*)GetChildByID("Btn_WantParty");			__ASSERT(m_pBtn_WantPartyMember,	"NULL UI Component!!");
-	m_pBtn_WantParty		= (CN3UIButton*)GetChildByID("Btn_WantPartyMember");	__ASSERT(m_pBtn_WantParty,	"NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_WantPartyMember, GetChildByID<CN3UIButton>("Btn_WantParty"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_WantParty, GetChildByID<CN3UIButton>("Btn_WantPartyMember"));
 
 	return true;
 }

--- a/Client/WarFare/UIPerTradeDlg.cpp
+++ b/Client/WarFare/UIPerTradeDlg.cpp
@@ -219,7 +219,7 @@ void CUIPerTradeDlg::InitIconWnd(e_UIWND eWnd)
 	pButton = (CN3UIButton* )GetChildButtonByName(szFN);
 	if(pButton) pButton->SetState(UI_STATE_BUTTON_NORMAL);
 
-	m_pStrMyGold    = (CN3UIString* )GetChildByID("string_money_inv"); __ASSERT(m_pStrMyGold, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pStrMyGold, GetChildByID<CN3UIString>("string_money_inv"));
 	if(m_pStrMyGold)
 		m_pStrMyGold->SetString("0");
 }

--- a/Client/WarFare/UIPointInitDlg.cpp
+++ b/Client/WarFare/UIPointInitDlg.cpp
@@ -47,10 +47,10 @@ bool CUIPointInitDlg::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pBtn_Ok			= (CN3UIButton*)GetChildByID("btn_ok");			__ASSERT(m_pBtn_Ok,	"NULL UI Component!!");
-	m_pBtn_Cancel		= (CN3UIButton*)GetChildByID("btn_cancel");		__ASSERT(m_pBtn_Cancel, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Ok, GetChildByID<CN3UIButton>("btn_ok"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel, GetChildByID<CN3UIButton>("btn_cancel"));
 
-	m_pText_NeedGold	= (CN3UIString*)GetChildByID("string_gold");	__ASSERT(m_pText_NeedGold,	"NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_NeedGold, GetChildByID<CN3UIString>("string_gold"));
 
 	return true;
 }

--- a/Client/WarFare/UIRepairTooltipDlg.cpp
+++ b/Client/WarFare/UIRepairTooltipDlg.cpp
@@ -46,17 +46,13 @@ void CUIRepairTooltipDlg::Release()
 
 void CUIRepairTooltipDlg::InitPos()
 {
-	m_pStr[0] = (CN3UIString* )GetChildByID("string_repairgold");				//이름 
-	__ASSERT(m_pStr[0], "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pStr[0], GetChildByID<CN3UIString>("string_repairgold"));				//이름 
 	m_pStr[0]->SetString("0");	
-	m_pStr[1] = (CN3UIString* )GetChildByID("string_dur_max");					//이름 
-	__ASSERT(m_pStr[1], "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pStr[1], GetChildByID<CN3UIString>("string_dur_max"));					//이름 
 	m_pStr[1]->SetString("0");	
-	m_pStr[2] = (CN3UIString* )GetChildByID("string_dur_current");				//이름 
-	__ASSERT(m_pStr[2], "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pStr[2], GetChildByID<CN3UIString>("string_dur_current"));				//이름 
 	m_pStr[2]->SetString("0");	
-	m_pStr[3] = (CN3UIString* )GetChildByID("string_title");					//이름 
-	__ASSERT(m_pStr[3], "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pStr[3], GetChildByID<CN3UIString>("string_title"));					//이름 
 	m_pStr[3]->SetString("0");	
 	BackupStrColor();
 }

--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -463,7 +463,7 @@ void CUISkillTreeDlg::PointPushUpButton(int iValue)
 	int iSkillPoint;
 	std::string str;
 	CN3UIString* pStrName, *pStrName2;
-	pStrName = (CN3UIString* )GetChildByID("string_skillpoint"); __ASSERT(pStrName, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>("string_skillpoint"));
 	str = pStrName->GetString();
 	iSkillExtra = atoi(str.c_str());
 
@@ -631,35 +631,35 @@ void CUISkillTreeDlg::PointPushUpButton(int iValue)
 	switch(iValue)	
 	{
 		case 1:			
-			pStrName2 = (CN3UIString* )GetChildByID("string_0"); __ASSERT(pStrName2, "NULL UI Component!!");
+			N3_VERIFY_UI_COMPONENT(pStrName2, GetChildByID<CN3UIString>("string_0"));
 			break;
 
 		case 2:
-			pStrName2 = (CN3UIString* )GetChildByID("string_1"); __ASSERT(pStrName2, "NULL UI Component!!");
+			N3_VERIFY_UI_COMPONENT(pStrName2, GetChildByID<CN3UIString>("string_1"));
 			break;
 
 		case 3:
-			pStrName2 = (CN3UIString* )GetChildByID("string_2"); __ASSERT(pStrName2, "NULL UI Component!!");
+			N3_VERIFY_UI_COMPONENT(pStrName2, GetChildByID<CN3UIString>("string_2"));
 			break;
 
 		case 4:
-			pStrName2 = (CN3UIString* )GetChildByID("string_3"); __ASSERT(pStrName2, "NULL UI Component!!");
+			N3_VERIFY_UI_COMPONENT(pStrName2, GetChildByID<CN3UIString>("string_3"));
 			break;
 
 		case 5:
-			pStrName2 = (CN3UIString* )GetChildByID("string_4"); __ASSERT(pStrName2, "NULL UI Component!!");
+			N3_VERIFY_UI_COMPONENT(pStrName2, GetChildByID<CN3UIString>("string_4"));
 			break;
 
 		case 6:
-			pStrName2 = (CN3UIString* )GetChildByID("string_5"); __ASSERT(pStrName2, "NULL UI Component!!");
+			N3_VERIFY_UI_COMPONENT(pStrName2, GetChildByID<CN3UIString>("string_5"));
 			break;
 
 		case 7:
-			pStrName2 = (CN3UIString* )GetChildByID("string_6"); __ASSERT(pStrName2, "NULL UI Component!!");
+			N3_VERIFY_UI_COMPONENT(pStrName2, GetChildByID<CN3UIString>("string_6"));
 			break;
 
 		case 8:
-			pStrName2 = (CN3UIString* )GetChildByID("string_7"); __ASSERT(pStrName2, "NULL UI Component!!");
+			N3_VERIFY_UI_COMPONENT(pStrName2, GetChildByID<CN3UIString>("string_7"));
 			break;
 
 	}
@@ -778,21 +778,21 @@ void CUISkillTreeDlg::CheckButtonTooltipRenderEnable()
 	RECT rect[MAX_SKILL_KIND_OF]; 
 	memset(rect, 0, sizeof(RECT)*MAX_SKILL_KIND_OF);
 
-	rect[SKILL_DEF_BASIC]		= ((CN3UIButton* )GetChildByID("btn_public"))->GetClickRect();
+	rect[SKILL_DEF_BASIC]		= GetChildByID<CN3UIButton>("btn_public")->GetClickRect();
 
 	switch ( CGameBase::s_pPlayer->m_InfoBase.eNation )
 	{
 		case NATION_ELMORAD:
-			rect[SKILL_DEF_SPECIAL0]	= ((CN3UIButton* )GetChildByID("btn_blade0"))->GetClickRect();
-			rect[SKILL_DEF_SPECIAL1]	= ((CN3UIButton* )GetChildByID("btn_blade1"))->GetClickRect();
-			rect[SKILL_DEF_SPECIAL2]	= ((CN3UIButton* )GetChildByID("btn_blade2"))->GetClickRect();
-			rect[SKILL_DEF_SPECIAL3]	= ((CN3UIButton* )GetChildByID("btn_master"))->GetClickRect();
+			rect[SKILL_DEF_SPECIAL0]	= GetChildByID<CN3UIButton>("btn_blade0")->GetClickRect();
+			rect[SKILL_DEF_SPECIAL1]	= GetChildByID<CN3UIButton>("btn_blade1")->GetClickRect();
+			rect[SKILL_DEF_SPECIAL2]	= GetChildByID<CN3UIButton>("btn_blade2")->GetClickRect();
+			rect[SKILL_DEF_SPECIAL3]	= GetChildByID<CN3UIButton>("btn_master")->GetClickRect();
 			break;
 		case NATION_KARUS:
-			rect[SKILL_DEF_SPECIAL0]	= ((CN3UIButton* )GetChildByID("btn_berserker0"))->GetClickRect();
-			rect[SKILL_DEF_SPECIAL1]	= ((CN3UIButton* )GetChildByID("btn_berserker1"))->GetClickRect();
-			rect[SKILL_DEF_SPECIAL2]	= ((CN3UIButton* )GetChildByID("btn_berserker2"))->GetClickRect();
-			rect[SKILL_DEF_SPECIAL3]	= ((CN3UIButton* )GetChildByID("btn_master"))->GetClickRect();
+			rect[SKILL_DEF_SPECIAL0]	= GetChildByID<CN3UIButton>("btn_berserker0")->GetClickRect();
+			rect[SKILL_DEF_SPECIAL1]	= GetChildByID<CN3UIButton>("btn_berserker1")->GetClickRect();
+			rect[SKILL_DEF_SPECIAL2]	= GetChildByID<CN3UIButton>("btn_berserker2")->GetClickRect();
+			rect[SKILL_DEF_SPECIAL3]	= GetChildByID<CN3UIButton>("btn_master")->GetClickRect();
 			break;
 	}
 
@@ -1220,24 +1220,42 @@ void CUISkillTreeDlg::PageButtonInitialize()
 	SetPageInCharRegion();		
 	
 	// 서버에게 받은 값으로 세팅.. m_iSkillInfo[MAX_SKILL_FROM_SERVER];										// 서버로 받는 슬롯 정보..	
-	CN3UIString* pStrName = (CN3UIString* )GetChildByID("string_skillpoint"); __ASSERT(pStrName, "NULL UI Component!!");
-	pStrName->SetStringAsInt(m_iSkillInfo[0]);
-	pStrName = (CN3UIString* )GetChildByID("string_0"); __ASSERT(pStrName, "NULL UI Component!!");
-	if(pStrName) pStrName->SetStringAsInt(m_iSkillInfo[1]);
-	pStrName = (CN3UIString* )GetChildByID("string_1"); __ASSERT(pStrName, "NULL UI Component!!");
-	if(pStrName) pStrName->SetStringAsInt(m_iSkillInfo[2]);
-	pStrName = (CN3UIString* )GetChildByID("string_2"); __ASSERT(pStrName, "NULL UI Component!!");
-	if(pStrName) pStrName->SetStringAsInt(m_iSkillInfo[3]);
-	pStrName = (CN3UIString* )GetChildByID("string_3"); __ASSERT(pStrName, "NULL UI Component!!");
-	if(pStrName) pStrName->SetStringAsInt(m_iSkillInfo[4]);
-	pStrName = (CN3UIString* )GetChildByID("string_4"); __ASSERT(pStrName, "NULL UI Component!!");
-	if(pStrName) pStrName->SetStringAsInt(m_iSkillInfo[5]);
-	pStrName = (CN3UIString* )GetChildByID("string_5"); __ASSERT(pStrName, "NULL UI Component!!");
-	if(pStrName) pStrName->SetStringAsInt(m_iSkillInfo[6]);
-	pStrName = (CN3UIString* )GetChildByID("string_6"); __ASSERT(pStrName, "NULL UI Component!!");
-	if(pStrName) pStrName->SetStringAsInt(m_iSkillInfo[7]);
-//	pStrName = (CN3UIString* )GetChildByID("string_7"); __ASSERT(pStrName, "NULL UI Component!!");
-//	if(pStrName) pStrName->SetStringAsInt(m_iSkillInfo[8]);
+	CN3UIString* pStrName = nullptr;
+	N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>("string_skillpoint"));
+	if (pStrName != nullptr)
+		pStrName->SetStringAsInt(m_iSkillInfo[0]);
+
+	N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>("string_0"));
+	if (pStrName != nullptr)
+		pStrName->SetStringAsInt(m_iSkillInfo[1]);
+
+	N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>("string_1"));
+	if (pStrName != nullptr)
+		pStrName->SetStringAsInt(m_iSkillInfo[2]);
+
+	N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>("string_2"));
+	if (pStrName != nullptr)
+		pStrName->SetStringAsInt(m_iSkillInfo[3]);
+
+	N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>("string_3"));
+	if (pStrName != nullptr)
+		pStrName->SetStringAsInt(m_iSkillInfo[4]);
+
+	N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>("string_4"));
+	if (pStrName != nullptr)
+		pStrName->SetStringAsInt(m_iSkillInfo[5]);
+
+	N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>("string_5"));
+	if (pStrName != nullptr)
+		pStrName->SetStringAsInt(m_iSkillInfo[6]);
+
+	N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>("string_6"));
+	if (pStrName != nullptr)
+		pStrName->SetStringAsInt(m_iSkillInfo[7]);
+
+	// N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>("string_7"));
+	// if (pStrName != nullptr)
+	//	pStrName->SetStringAsInt(m_iSkillInfo[8]);
     
 	ButtonVisibleStateSet();
 }
@@ -1275,152 +1293,152 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 	switch (CGameBase::s_pPlayer->m_InfoBase.eNation)
 	{
 		case NATION_ELMORAD:
-			pButton = (CN3UIButton*) GetChildByID("btn_ranger0");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_ranger1");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_ranger2");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_blade0");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_blade1");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_blade2");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_mage0");			ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_mage1");			ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_mage2");			ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_cleric0");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_cleric1");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_cleric2");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_ranger0");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_ranger1");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_ranger2");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_blade0");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_blade1");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_blade2");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_mage0");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_mage1");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_mage2");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_cleric0");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_cleric1");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_cleric2");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_0;
 			break;
 
 		case NATION_KARUS:
-			pButton = (CN3UIButton*) GetChildByID("btn_hunter0");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_hunter1");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_hunter2");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_hunter3");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_berserker0");	ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_berserker1");	ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_berserker2");	ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_berserker3");	ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_sorcerer0");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_sorcerer1");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_sorcerer2");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_sorcerer3");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_shaman0");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_shaman1");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_shaman2");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_shaman3");		ASSET_0;
-			pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_hunter0");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_hunter1");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_hunter2");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_hunter3");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_berserker0");	ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_berserker1");	ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_berserker2");	ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_berserker3");	ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_sorcerer0");	ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_sorcerer1");	ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_sorcerer2");	ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_sorcerer3");	ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_shaman0");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_shaman1");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_shaman2");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_shaman3");		ASSET_0;
+			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_0;
 			break;
 	}
 
 	if (m_iCurKindOf == 0)
 	{
-		pButton = (CN3UIButton*) GetChildByID("btn_public");
+		pButton = GetChildByID<CN3UIButton>("btn_public");
 		pButton->SetState(UI_STATE_BUTTON_DOWN);
 	}
 
 	switch (CGameBase::s_pPlayer->m_InfoBase.eClass)
 	{
 		case CLASS_KA_BERSERKER:
-			pButton = (CN3UIButton*) GetChildByID("btn_berserker0");	ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_berserker1");	ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_berserker2");	ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_berserker0");	ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_berserker1");	ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_berserker2");	ASSET_3;
 			break;
 
 		case CLASS_KA_GUARDIAN:
-			pButton = (CN3UIButton*) GetChildByID("btn_berserker0");	ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_berserker1");	ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_berserker2");	ASSET_3;
-			pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_4;
+			pButton = GetChildByID<CN3UIButton>("btn_berserker0");	ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_berserker1");	ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_berserker2");	ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
 			break;
 
 		case CLASS_KA_HUNTER:
-			pButton = (CN3UIButton*) GetChildByID("btn_hunter0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_hunter1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_hunter2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_hunter0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_hunter1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_hunter2");		ASSET_3;
 			break;
 
 		case CLASS_KA_PENETRATOR:
-			pButton = (CN3UIButton*) GetChildByID("btn_hunter0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_hunter1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_hunter2");		ASSET_3;
-			pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_4;
+			pButton = GetChildByID<CN3UIButton>("btn_hunter0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_hunter1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_hunter2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
 			break;
 
 		case CLASS_KA_SHAMAN:
-			pButton = (CN3UIButton*) GetChildByID("btn_shaman0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_shaman1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_shaman2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_shaman0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_shaman1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_shaman2");		ASSET_3;
 			break;
 
 		case CLASS_KA_DARKPRIEST:
-			pButton = (CN3UIButton*) GetChildByID("btn_shaman0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_shaman1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_shaman2");		ASSET_3;
-			pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_4;
+			pButton = GetChildByID<CN3UIButton>("btn_shaman0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_shaman1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_shaman2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
 			break;
 
 		case CLASS_KA_SORCERER:
-			pButton = (CN3UIButton*) GetChildByID("btn_sorcerer0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_sorcerer1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_sorcerer2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_sorcerer0");	ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_sorcerer1");	ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_sorcerer2");	ASSET_3;
 			break;
 
 		case CLASS_KA_NECROMANCER:
-			pButton = (CN3UIButton*) GetChildByID("btn_sorcerer0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_sorcerer1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_sorcerer2");		ASSET_3;
-			pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_4;
+			pButton = GetChildByID<CN3UIButton>("btn_sorcerer0");	ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_sorcerer1");	ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_sorcerer2");	ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
 			break;
 
 		case CLASS_EL_BLADE:
-			pButton = (CN3UIButton*) GetChildByID("btn_blade0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_blade1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_blade2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_blade0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_blade1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_blade2");		ASSET_3;
 			break;
 
 		case CLASS_EL_PROTECTOR:
-			pButton = (CN3UIButton*) GetChildByID("btn_blade0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_blade1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_blade2");		ASSET_3;
-			pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_4;
+			pButton = GetChildByID<CN3UIButton>("btn_blade0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_blade1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_blade2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
 			break;
 
 		case CLASS_EL_RANGER:
-			pButton = (CN3UIButton*) GetChildByID("btn_ranger0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_ranger1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_ranger2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_ranger0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_ranger1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_ranger2");		ASSET_3;
 			break;
 
 		case CLASS_EL_ASSASIN:
-			pButton = (CN3UIButton*) GetChildByID("btn_ranger0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_ranger1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_ranger2");		ASSET_3;
-			pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_4;
+			pButton = GetChildByID<CN3UIButton>("btn_ranger0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_ranger1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_ranger2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
 			break;
 
 		case CLASS_EL_MAGE:
-			pButton = (CN3UIButton*) GetChildByID("btn_mage0");			ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_mage1");			ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_mage2");			ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_mage0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_mage1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_mage2");		ASSET_3;
 			break;
 
 		case CLASS_EL_ENCHANTER:
-			pButton = (CN3UIButton*) GetChildByID("btn_mage0");			ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_mage1");			ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_mage2");			ASSET_3;
-			pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_4;
+			pButton = GetChildByID<CN3UIButton>("btn_mage0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_mage1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_mage2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
 			break;
 
 		case CLASS_EL_CLERIC:
-			pButton = (CN3UIButton*) GetChildByID("btn_cleric0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_cleric1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_cleric2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_cleric0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_cleric1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_cleric2");		ASSET_3;
 			break;
 
 		case CLASS_EL_DRUID:
-			pButton = (CN3UIButton*) GetChildByID("btn_cleric0");		ASSET_1;
-			pButton = (CN3UIButton*) GetChildByID("btn_cleric1");		ASSET_2;
-			pButton = (CN3UIButton*) GetChildByID("btn_cleric2");		ASSET_3;
-			pButton = (CN3UIButton*) GetChildByID("btn_master");		ASSET_4;
+			pButton = GetChildByID<CN3UIButton>("btn_cleric0");		ASSET_1;
+			pButton = GetChildByID<CN3UIButton>("btn_cleric1");		ASSET_2;
+			pButton = GetChildByID<CN3UIButton>("btn_cleric2");		ASSET_3;
+			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
 			break;
 	}
 }
@@ -1646,21 +1664,22 @@ void CUISkillTreeDlg::SetPageInIconRegion(int iKindOf, int iPageNum)		// 아이�
 		if ( m_pMySkillTree[m_iCurKindOf][m_iCurSkillPage][k] != nullptr )
 		{
 			str = "string_list_" + std::to_string(k);
-			pStrName = (CN3UIString* )GetChildByID(str);	 __ASSERT(pStrName, "NULL UI Component!!");
+			N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>(str));
 			pStrName->SetString(m_pMySkillTree[m_iCurKindOf][m_iCurSkillPage][k]->pSkill->szName);
 			pStrName->SetVisible(true);
 		}
 		else
 		{
 			str = "string_list_" + std::to_string(k);
-			pStrName = (CN3UIString* )GetChildByID(str);	 __ASSERT(pStrName, "NULL UI Component!!");
+			N3_VERIFY_UI_COMPONENT(pStrName, GetChildByID<CN3UIString>(str));
 			pStrName->SetVisible(false);
 		}
 	}
 
 	ButtonVisibleStateSet();
 
-	CN3UIString* pStr = (CN3UIString*) GetChildByID("string_page");	__ASSERT(pStr, "NULL UI Component!!");
+	CN3UIString* pStr = nullptr;
+	N3_VERIFY_UI_COMPONENT(pStr, GetChildByID<CN3UIString>("string_page"));
 	if (pStr != nullptr)
 		pStr->SetStringAsInt(iPageNum + 1);
 }

--- a/Client/WarFare/UIStateBar.cpp
+++ b/Client/WarFare/UIStateBar.cpp
@@ -34,6 +34,9 @@ CUIStateBar::CUIStateBar()
 {
 	m_pText_Position = nullptr;
 	m_pProgress_HP = nullptr;
+	m_pProgress_HP_slow = nullptr;
+	m_pProgress_HP_drop = nullptr;
+	m_pProgress_HP_lasting = nullptr;
 	m_pProgress_MSP = nullptr;
 	m_pProgress_ExpC = nullptr;
 	m_pProgress_ExpP = nullptr;
@@ -97,6 +100,9 @@ void CUIStateBar::Release()
 
 	m_pText_Position = nullptr;
 	m_pProgress_HP = nullptr;
+	m_pProgress_HP_slow = nullptr;
+	m_pProgress_HP_drop = nullptr;
+	m_pProgress_HP_lasting = nullptr;
 	m_pProgress_MSP = nullptr;
 	m_pProgress_ExpC = nullptr;
 	m_pProgress_ExpP = nullptr;
@@ -124,19 +130,20 @@ bool CUIStateBar::Load(HANDLE hFile)
 	if (!CN3UIBase::Load(hFile))
 		return false;
 
-	CN3UIString* pText = (CN3UIString*) (this->GetChildByID("Text_Version")); __ASSERT(pText, "NULL UI Component!!");
+	CN3UIString* pText = nullptr;
+	N3_VERIFY_UI_COMPONENT(pText, GetChildByID<CN3UIString>("Text_Version"));
 	if (pText != nullptr)
 	{
 		std::string version = fmt::format("Ver. {:.3f}", CURRENT_VERSION / 1000.0f);
 		pText->SetString(version);
 	}
 
-	m_pText_Position =	(CN3UIString*)(this->GetChildByID("Text_Position"));	__ASSERT(m_pText_Position, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_Position, GetChildByID<CN3UIString>("Text_Position"));
 
-	m_pProgress_HP =	(CN3UIProgress*)(this->GetChildByID("Progress_HP"));	__ASSERT(m_pProgress_HP, "NULL UI Component!!");
-	m_pProgress_MSP =	(CN3UIProgress*)(this->GetChildByID("Progress_MSP"));	__ASSERT(m_pProgress_MSP, "NULL UI Component!!");
-	m_pProgress_ExpC =	(CN3UIProgress*)(this->GetChildByID("Progress_ExpC"));	__ASSERT(m_pProgress_ExpC, "NULL UI Component!!");
-	m_pProgress_ExpP =	(CN3UIProgress*)(this->GetChildByID("Progress_ExpP"));	__ASSERT(m_pProgress_ExpP, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pProgress_HP, GetChildByID<CN3UIProgress>("Progress_HP"));
+	N3_VERIFY_UI_COMPONENT(m_pProgress_MSP, GetChildByID<CN3UIProgress>("Progress_MSP"));
+	N3_VERIFY_UI_COMPONENT(m_pProgress_ExpC, GetChildByID<CN3UIProgress>("Progress_ExpC"));
+	N3_VERIFY_UI_COMPONENT(m_pProgress_ExpP, GetChildByID<CN3UIProgress>("Progress_ExpP"));
 	
 	if(m_pProgress_HP) m_pProgress_HP->SetRange(0, 100);
 	if(m_pProgress_MSP) m_pProgress_MSP->SetRange(0, 100);
@@ -145,55 +152,50 @@ bool CUIStateBar::Load(HANDLE hFile)
 
 	// NOTE: new components not previously used
 
-	//CN3UIProgress* m_pProgress_HP_poison = (CN3UIProgress*)(this->GetChildByID("Progress_HP_poison"));	__ASSERT(m_pProgress_HP_poison, "NULL UI Component!!");
-	CN3UIProgress* m_pProgress_HP_poison = (CN3UIProgress*)(this->GetChildByID("Progress_HP_slow"));
-	__ASSERT(m_pProgress_HP_poison, "NULL UI Component!!");
-	if (m_pProgress_HP_poison) {
-		m_pProgress_HP_poison->SetRange(0, 100);
-		m_pProgress_HP_poison->SetVisible(false);
+	N3_VERIFY_UI_COMPONENT(m_pProgress_HP_slow, GetChildByID<CN3UIProgress>("Progress_HP_slow"));
+	if (m_pProgress_HP_slow != nullptr)
+	{
+		m_pProgress_HP_slow->SetRange(0, 100);
+		m_pProgress_HP_slow->SetVisible(false);
 	}
 
-	//CN3UIProgress* m_pProgress_HP_curse = (CN3UIProgress*)(this->GetChildByID("Progress_HP_curse"));	__ASSERT(m_pProgress_HP_curse, "NULL UI Component!!");
-	CN3UIProgress* m_pProgress_HP_curse = (CN3UIProgress*)(this->GetChildByID("Progress_HP_drop"));
-	__ASSERT(m_pProgress_HP_curse, "NULL UI Component!!");
-	if (m_pProgress_HP_curse) {
-		m_pProgress_HP_curse->SetRange(0, 100);
-		m_pProgress_HP_curse->SetVisible(false);
+	N3_VERIFY_UI_COMPONENT(m_pProgress_HP_drop, GetChildByID<CN3UIProgress>("Progress_HP_drop"));
+	if (m_pProgress_HP_drop != nullptr)
+	{
+		m_pProgress_HP_drop->SetRange(0, 100);
+		m_pProgress_HP_drop->SetVisible(false);
 	}
 
-	CN3UIProgress* m_pProgress_HP_lasting = (CN3UIProgress*)(this->GetChildByID("Progress_HP_lasting"));
-	__ASSERT(m_pProgress_HP_curse, "NULL UI Component!!");
-	if (m_pProgress_HP_lasting) {
+	N3_VERIFY_UI_COMPONENT(m_pProgress_HP_lasting, GetChildByID<CN3UIProgress>("Progress_HP_lasting"));
+	if (m_pProgress_HP_lasting != nullptr)
+	{
 		m_pProgress_HP_lasting->SetRange(0, 100);
 		m_pProgress_HP_lasting->SetVisible(false);
 	}
 
 	// NOTE: new components to display the text
-	m_pText_HP = (CN3UIString*)GetChildByID("Text_HP");
-	__ASSERT(m_pText_HP, "NULL UI Component!!");
-	m_pText_MP = (CN3UIString*)GetChildByID("Text_MSP");
-	__ASSERT(m_pText_MP, "NULL UI Component!!");
-	m_pText_Exp = (CN3UIString*)GetChildByID("Text_ExpP");
-	__ASSERT(m_pText_Exp, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_HP, GetChildByID<CN3UIString>("Text_HP"));
+	N3_VERIFY_UI_COMPONENT(m_pText_MP, GetChildByID<CN3UIString>("Text_MSP"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Exp, GetChildByID<CN3UIString>("Text_ExpP"));
 
-	CN3UIString* m_pText_SysTime = (CN3UIString*)GetChildByID("SystemTime");
+	CN3UIString* m_pText_SysTime = GetChildByID<CN3UIString>("SystemTime");
 	if (m_pText_SysTime) m_pText_SysTime->SetVisible(false);
 
-	m_pText_FPS = (CN3UIString*)GetChildByID("string_fps");
+	m_pText_FPS = GetChildByID<CN3UIString>("string_fps");
 
 	// MiniMap
-	m_pGroup_MiniMap = GetChildByID("Group_MiniMap"); __ASSERT(m_pGroup_MiniMap, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pGroup_MiniMap, GetChildByID("Group_MiniMap"));
 	if(m_pGroup_MiniMap)
 	{
 		m_pGroup_MiniMap->SetVisible(false);
 
-		m_pImage_Map =		(CN3UIImage*)(m_pGroup_MiniMap->GetChildByID("Img_MiniMap"));	__ASSERT(m_pImage_Map, "NULL UI Component!!");
-		m_pBtn_ZoomIn =		(CN3UIButton*)(m_pGroup_MiniMap->GetChildByID("Btn_ZoomIn"));	__ASSERT(m_pBtn_ZoomIn, "NULL UI Component!!");
-		m_pBtn_ZoomOut =	(CN3UIButton*)(m_pGroup_MiniMap->GetChildByID("Btn_ZoomOut"));	__ASSERT(m_pBtn_ZoomOut, "NULL UI Component!!");
+		N3_VERIFY_UI_COMPONENT(m_pImage_Map, GetChildByID<CN3UIImage>("Img_MiniMap"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_ZoomIn, GetChildByID<CN3UIButton>("Btn_ZoomIn"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_ZoomOut, GetChildByID<CN3UIButton>("Btn_ZoomOut"));
 	}
 
-	m_pBtn_Quest = (CN3UIButton*)(GetChildByID("btn_quest"));
-	m_pBtn_Power = (CN3UIButton*)(GetChildByID("btn_power"));
+	m_pBtn_Quest = GetChildByID<CN3UIButton>("btn_quest");
+	m_pBtn_Power = GetChildByID<CN3UIButton>("btn_power");
 
 	return true;
 }

--- a/Client/WarFare/UIStateBar.h
+++ b/Client/WarFare/UIStateBar.h
@@ -38,6 +38,10 @@ protected:
 
 	CN3UIString*	m_pText_Position;
 	CN3UIProgress*	m_pProgress_HP;
+	CN3UIProgress*	m_pProgress_HP_slow;
+	CN3UIProgress*	m_pProgress_HP_drop;
+	CN3UIProgress*	m_pProgress_HP_lasting;
+
 	CN3UIProgress*	m_pProgress_MSP;
 	CN3UIProgress*	m_pProgress_ExpC;
 	CN3UIProgress*	m_pProgress_ExpP;

--- a/Client/WarFare/UITargetBar.cpp
+++ b/Client/WarFare/UITargetBar.cpp
@@ -8,7 +8,11 @@
 
 CUITargetBar::CUITargetBar()
 {
-	m_pProgressHP = nullptr;
+	m_pProgress_HP = nullptr;
+	m_pProgress_HP_slow = nullptr;
+	m_pProgress_HP_drop = nullptr;
+	m_pProgress_HP_lasting = nullptr;
+
 	m_pStringID = nullptr;
 	m_fTimeSendPacketLast = 0;
 }
@@ -21,7 +25,10 @@ void CUITargetBar::Release()
 {
 	CN3UIBase::Release();
 
-	m_pProgressHP = nullptr;
+	m_pProgress_HP = nullptr;
+	m_pProgress_HP_slow = nullptr;
+	m_pProgress_HP_drop = nullptr;
+	m_pProgress_HP_lasting = nullptr;
 	m_pStringID = nullptr;
 	m_fTimeSendPacketLast = 0;
 }
@@ -30,12 +37,12 @@ void CUITargetBar::UpdateHP(int iHP, int iHPMax, bool bUpdateImmediately)
 {
 	__ASSERT(iHPMax > 0, "Invalid Max HP");
 	if(iHP < 0 || iHPMax <= 0) return;
-	if(nullptr == m_pProgressHP) return;
+	if(nullptr == m_pProgress_HP) return;
 
 	int iPercentage = iHP * 100 / iHPMax;
 
-	if(bUpdateImmediately) m_pProgressHP->SetCurValue(iPercentage);
-	else m_pProgressHP->SetCurValue(iPercentage, 0.5f, 50.0f);				// 1초뒤에 초당 50 의 속도로 변하게 한다.
+	if(bUpdateImmediately) m_pProgress_HP->SetCurValue(iPercentage);
+	else m_pProgress_HP->SetCurValue(iPercentage, 0.5f, 50.0f);				// 1초뒤에 초당 50 의 속도로 변하게 한다.
 	return;
 }
 
@@ -52,38 +59,41 @@ bool CUITargetBar::Load(HANDLE hFile)
 	CN3UIString* amountStr = new CN3UIString();
 	amountStr->Init(this);
 
-    m_pProgressHP = (CN3UIProgress*)GetChildByID("pro_target");	__ASSERT(m_pProgressHP, "NULL UI Component!!");
-	m_pStringID = (CN3UIString*)GetChildByID("text_target");	__ASSERT(m_pStringID, "NULL UI Component!!");
+    N3_VERIFY_UI_COMPONENT(m_pProgress_HP, GetChildByID<CN3UIProgress>("pro_target"));
+	N3_VERIFY_UI_COMPONENT(m_pStringID, GetChildByID<CN3UIString>("text_target"));
 
-	if(m_pProgressHP) m_pProgressHP->SetRange(0, 100);
-	if(m_pStringID) // 폰트를 바꾼다.
+	if (m_pProgress_HP != nullptr)
+		m_pProgress_HP->SetRange(0, 100);
+
+	// 폰트를 바꾼다.
+	if (m_pStringID != nullptr)
 	{
 		std::string szFontID = fmt::format_text_resource(IDS_FONT_ID);
-		
+
 		uint32_t dwH = m_pStringID->GetFontHeight();
 		m_pStringID->SetFont(szFontID, dwH, FALSE, FALSE);
 	}
 
 	// NOTE: new target health bars depending on poison or curse
-	CN3UIProgress* m_pProgressHP_posion = (CN3UIProgress*)GetChildByID("Progress_HP_slow");
-	__ASSERT(m_pProgressHP_posion, "NULL UI Component!!");
-	if (m_pProgressHP_posion) {
-		m_pProgressHP_posion->SetRange(0, 100);
-		m_pProgressHP_posion->SetVisible(false);
+	N3_VERIFY_UI_COMPONENT(m_pProgress_HP_slow, GetChildByID<CN3UIProgress>("Progress_HP_slow"));
+	if (m_pProgress_HP_slow != nullptr)
+	{
+		m_pProgress_HP_slow->SetRange(0, 100);
+		m_pProgress_HP_slow->SetVisible(false);
 	}
 
-	CN3UIProgress* m_pProgressHP_curse = (CN3UIProgress*)GetChildByID("Progress_HP_drop");
-	__ASSERT(m_pProgressHP_curse, "NULL UI Component!!");
-	if (m_pProgressHP_curse) {
-		m_pProgressHP_curse->SetRange(0, 100);
-		m_pProgressHP_curse->SetVisible(false);
+	N3_VERIFY_UI_COMPONENT(m_pProgress_HP_drop, GetChildByID<CN3UIProgress>("Progress_HP_drop"));
+	if (m_pProgress_HP_drop != nullptr)
+	{
+		m_pProgress_HP_drop->SetRange(0, 100);
+		m_pProgress_HP_drop->SetVisible(false);
 	}
 
-	CN3UIProgress* m_pProgressHP_lasting = (CN3UIProgress*)GetChildByID("Progress_HP_lasting");
-	__ASSERT(m_pProgressHP_lasting, "NULL UI Component!!");
-	if (m_pProgressHP_lasting) {
-		m_pProgressHP_lasting->SetRange(0, 100);
-		m_pProgressHP_lasting->SetVisible(false);
+	N3_VERIFY_UI_COMPONENT(m_pProgress_HP_lasting, GetChildByID<CN3UIProgress>("Progress_HP_lasting"));
+	if (m_pProgress_HP_lasting != nullptr)
+	{
+		m_pProgress_HP_lasting->SetRange(0, 100);
+		m_pProgress_HP_lasting->SetVisible(false);
 	}
 
 	return true;

--- a/Client/WarFare/UITargetBar.h
+++ b/Client/WarFare/UITargetBar.h
@@ -14,8 +14,11 @@
 class CUITargetBar : public CN3UIBase
 {
 public:
-	class CN3UIProgress*	m_pProgressHP;
-	class CN3UIString *		m_pStringID;
+	CN3UIProgress*	m_pProgress_HP;
+	CN3UIProgress*	m_pProgress_HP_slow;
+	CN3UIProgress*	m_pProgress_HP_drop;
+	CN3UIProgress*	m_pProgress_HP_lasting;
+	CN3UIString*	m_pStringID;
 	float m_fTimeSendPacketLast; // 이걸 기준으로 1초에 한번씩 타겟의 정보 요청..
 
 public:

--- a/Client/WarFare/UITradeBBSEditDlg.cpp
+++ b/Client/WarFare/UITradeBBSEditDlg.cpp
@@ -65,11 +65,11 @@ bool CUITradeBBSEditDlg::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pEditTitle		= (CN3UIEdit*)(this->GetChildByID("edit_name"));	__ASSERT(m_pEditTitle, "NULL UI Component!!!");
-	m_pEditPrice		= (CN3UIEdit*)(this->GetChildByID("edit_price"));	__ASSERT(m_pEditPrice, "NULL UI Component!!!");
-	m_pEditExplanation	= (CN3UIEdit*)(this->GetChildByID("edit_memo"));	__ASSERT(m_pEditExplanation, "NULL UI Component!!!");
-	m_pBtn_Ok			= (CN3UIButton*)(this->GetChildByID("btn_Ok"));		__ASSERT(m_pBtn_Ok, "NULL UI Component!!!");
-	m_pBtn_Cancel		= (CN3UIButton*)(this->GetChildByID("btn_Cancel"));	__ASSERT(m_pBtn_Cancel, "NULL UI Component!!!");
+	N3_VERIFY_UI_COMPONENT(m_pEditTitle, GetChildByID<CN3UIEdit>("edit_name"));
+	N3_VERIFY_UI_COMPONENT(m_pEditPrice, GetChildByID<CN3UIEdit>("edit_price"));
+	N3_VERIFY_UI_COMPONENT(m_pEditExplanation, GetChildByID<CN3UIEdit>("edit_memo"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Ok, GetChildByID<CN3UIButton>("btn_Ok"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel, GetChildByID<CN3UIButton>("btn_Cancel"));
 
 	m_pEditTitle->SetMaxString(18);
 	m_pEditPrice->SetMaxString(8);

--- a/Client/WarFare/UITradeBBSSelector.cpp
+++ b/Client/WarFare/UITradeBBSSelector.cpp
@@ -64,9 +64,9 @@ bool CUITradeBBSSelector::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pBtn_BBSSell	= (CN3UIButton*)GetChildByID("btn_sell");		__ASSERT(m_pBtn_BBSSell,	"NULL UI Component!!");
-	m_pBtn_BBSBuy	= (CN3UIButton*)GetChildByID("btn_buy");		__ASSERT(m_pBtn_BBSBuy,	"NULL UI Component!!");
-	m_pBtn_BBSCancel = (CN3UIButton*)GetChildByID("btn_cancel");	__ASSERT(m_pBtn_BBSCancel,	"NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_BBSSell, GetChildByID<CN3UIButton>("btn_sell"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_BBSBuy, GetChildByID<CN3UIButton>("btn_buy"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_BBSCancel, GetChildByID<CN3UIButton>("btn_cancel"));
 
 	return true;
 }

--- a/Client/WarFare/UITradeEditDlg.cpp
+++ b/Client/WarFare/UITradeEditDlg.cpp
@@ -48,16 +48,16 @@ void CUITradeEditDlg::Release()
 
 int	CUITradeEditDlg::GetQuantity() // "edit_trade" Edit Control 에서 정수값을 얻오온다..
 {
-	CN3UIEdit* pEdit = (CN3UIEdit*)this->GetChildByID("edit_trade");
-	__ASSERT(pEdit, "NULL UI Component!!");
+	CN3UIEdit* pEdit = nullptr;
+	N3_VERIFY_UI_COMPONENT(pEdit, GetChildByID<CN3UIEdit>("edit_trade"));
 
 	return atoi(pEdit->GetString().c_str());
 }
 
 void CUITradeEditDlg::SetQuantity(int iQuantity) // "edit_trade" Edit Control 에서 정수값을 문자열로 세팅한다..
 {
-	CN3UIEdit* pEdit = (CN3UIEdit*) GetChildByID("edit_trade");
-	__ASSERT(pEdit, "NULL UI Component!!");
+	CN3UIEdit* pEdit = nullptr;
+	N3_VERIFY_UI_COMPONENT(pEdit, GetChildByID<CN3UIEdit>("edit_trade"));
 
 	std::string buff = std::to_string(iQuantity);
 	pEdit->SetString(buff);
@@ -88,18 +88,16 @@ void CUITradeEditDlg::Open(bool bCountGold)
 		szMsg = fmt::format_text_resource(IDS_EDIT_BOX_COUNT);
 
 	CN3UIString* pString = nullptr;
-	pString = (CN3UIString*)this->GetChildByID("String_PersonTradeEdit_Msg");
+	N3_VERIFY_UI_COMPONENT(pString, GetChildByID<CN3UIString>("String_PersonTradeEdit_Msg"));
 	__ASSERT(pString, "NULL UI Component!!");
 	if (pString)
 		pString->SetString(szMsg);
 
 	SetVisible(true);
 
-	//this_ui_add_start
-	CN3UIEdit* pEdit = (CN3UIEdit*)this->GetChildByID("edit_trade");
-	__ASSERT(pEdit, "NULL UI Component!!");
+	CN3UIEdit* pEdit = nullptr;
+	N3_VERIFY_UI_COMPONENT(pEdit, GetChildByID<CN3UIEdit>("edit_trade"));
 	if(pEdit) pEdit->SetFocus();
-	//this_ui_add_end
 
 	RECT rc, rcThis;
 	int iCX, iCY;

--- a/Client/WarFare/UITradeExplanation.cpp
+++ b/Client/WarFare/UITradeExplanation.cpp
@@ -76,10 +76,10 @@ bool CUITradeExplanation::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pBtn_PageUp		= (CN3UIButton*)(this->GetChildByID("btn_pageup"));		__ASSERT(m_pBtn_PageUp, "NULL UI Component!!!");
-	m_pBtn_PageDown		= (CN3UIButton*)(this->GetChildByID("btn_pagedown"));	__ASSERT(m_pBtn_PageDown, "NULL UI Component!!!");
-	m_pBtn_Close		= (CN3UIButton*)(this->GetChildByID("btn_close"));		__ASSERT(m_pBtn_Close, "NULL UI Component!!!");
-	m_pText_Explanation	= (CN3UIString*)(this->GetChildByID("Text_Title"));		__ASSERT(m_pText_Explanation, "NULL UI Component!!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_PageUp, GetChildByID<CN3UIButton>("btn_pageup"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_PageDown, GetChildByID<CN3UIButton>("btn_pagedown"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Close, GetChildByID<CN3UIButton>("btn_close"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Explanation, GetChildByID<CN3UIString>("Text_Title"));
 
 	return true;
 }

--- a/Client/WarFare/UITradeList.cpp
+++ b/Client/WarFare/UITradeList.cpp
@@ -42,17 +42,17 @@ bool CUITradeList::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pScrollbar = (CN3UIScrollBar*)GetChildByID("scroll");//	__ASSERT(m_pScrollbar, "NULL UI Component!!");
+	m_pScrollbar = GetChildByID<CN3UIScrollBar>("scroll");//	__ASSERT(m_pScrollbar, "NULL UI Component!!");
 
-	m_pStr_List[0] = (CN3UIString*)GetChildByID("string_list0");//	__ASSERT(m_pStr_List[0], "NULL UI Component!!");
-	m_pStr_List[1] = (CN3UIString*)GetChildByID("string_list1");//	__ASSERT(m_pStr_List[1], "NULL UI Component!!");
-	m_pStr_List[2] = (CN3UIString*)GetChildByID("string_list2");//	__ASSERT(m_pStr_List[2], "NULL UI Component!!");
-	m_pStr_List[3] = (CN3UIString*)GetChildByID("string_list3");//	__ASSERT(m_pStr_List[3], "NULL UI Component!!");
-	m_pStr_List[4] = (CN3UIString*)GetChildByID("string_list4");//	__ASSERT(m_pStr_List[4], "NULL UI Component!!");
-	m_pStr_List[5] = (CN3UIString*)GetChildByID("string_list5");//	__ASSERT(m_pStr_List[5], "NULL UI Component!!");
-	m_pStr_List[6] = (CN3UIString*)GetChildByID("string_list6");//	__ASSERT(m_pStr_List[6], "NULL UI Component!!");
-	m_pStr_List[7] = (CN3UIString*)GetChildByID("string_list7");//	__ASSERT(m_pStr_List[7], "NULL UI Component!!");
-	m_pStr_List[8] = (CN3UIString*)GetChildByID("string_list8");//	__ASSERT(m_pStr_List[8], "NULL UI Component!!");
+	m_pStr_List[0] = GetChildByID<CN3UIString>("string_list0");//	__ASSERT(m_pStr_List[0], "NULL UI Component!!");
+	m_pStr_List[1] = GetChildByID<CN3UIString>("string_list1");//	__ASSERT(m_pStr_List[1], "NULL UI Component!!");
+	m_pStr_List[2] = GetChildByID<CN3UIString>("string_list2");//	__ASSERT(m_pStr_List[2], "NULL UI Component!!");
+	m_pStr_List[3] = GetChildByID<CN3UIString>("string_list3");//	__ASSERT(m_pStr_List[3], "NULL UI Component!!");
+	m_pStr_List[4] = GetChildByID<CN3UIString>("string_list4");//	__ASSERT(m_pStr_List[4], "NULL UI Component!!");
+	m_pStr_List[5] = GetChildByID<CN3UIString>("string_list5");//	__ASSERT(m_pStr_List[5], "NULL UI Component!!");
+	m_pStr_List[6] = GetChildByID<CN3UIString>("string_list6");//	__ASSERT(m_pStr_List[6], "NULL UI Component!!");
+	m_pStr_List[7] = GetChildByID<CN3UIString>("string_list7");//	__ASSERT(m_pStr_List[7], "NULL UI Component!!");
+	m_pStr_List[8] = GetChildByID<CN3UIString>("string_list8");//	__ASSERT(m_pStr_List[8], "NULL UI Component!!");
 
 	return true;
 }

--- a/Client/WarFare/UITradeSellBBS.cpp
+++ b/Client/WarFare/UITradeSellBBS.cpp
@@ -69,28 +69,27 @@ bool CUITradeSellBBS::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-//	m_pList_Infos			= (CN3UIList*)(this->GetChildByID("List_Friends"));		__ASSERT(m_pList_Infos, "NULL UI Component!!!");
-	m_pBtn_PageUp			= (CN3UIButton*)(this->GetChildByID("btn_page_up"));	__ASSERT(m_pBtn_PageUp, "NULL UI Component!!!");
-	m_pBtn_PageDown			= (CN3UIButton*)(this->GetChildByID("btn_page_down"));	__ASSERT(m_pBtn_PageDown, "NULL UI Component!!!");
-	m_pBtn_Refresh			= (CN3UIButton*)(this->GetChildByID("btn_refresh"));	__ASSERT(m_pBtn_Refresh, "NULL UI Component!!!");
-	m_pBtn_Close			= (CN3UIButton*)(this->GetChildByID("btn_exit"));		__ASSERT(m_pBtn_Close, "NULL UI Component!!!");
-	m_pBtn_Register			= (CN3UIButton*)(this->GetChildByID("btn_add"));		__ASSERT(m_pBtn_Register, "NULL UI Component!!!");
-	m_pBtn_Whisper			= (CN3UIButton*)(this->GetChildByID("btn_whisper"));	__ASSERT(m_pBtn_Whisper, "NULL UI Component!!!");
-	m_pBtn_Trade			= (CN3UIButton*)(this->GetChildByID("btn_sale"));		__ASSERT(m_pBtn_Trade, "NULL UI Component!!!");
-	m_pBtn_RegisterCancel	= (CN3UIButton*)(this->GetChildByID("btn_delete"));		__ASSERT(m_pBtn_RegisterCancel, "NULL UI Component!!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_PageUp, GetChildByID<CN3UIButton>("btn_page_up"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_PageDown, GetChildByID<CN3UIButton>("btn_page_down"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Refresh, GetChildByID<CN3UIButton>("btn_refresh"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Close, GetChildByID<CN3UIButton>("btn_exit"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Register, GetChildByID<CN3UIButton>("btn_add"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Whisper, GetChildByID<CN3UIButton>("btn_whisper"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Trade, GetChildByID<CN3UIButton>("btn_sale"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_RegisterCancel, GetChildByID<CN3UIButton>("btn_delete"));
 
-	m_pImage_Sell			= (CN3UIImage*)(this->GetChildByID("img_sell gold"));	__ASSERT(m_pImage_Sell, "NULL UI Component!!!");
-	m_pImage_Buy			= (CN3UIImage*)(this->GetChildByID("img_buy gold"));	__ASSERT(m_pImage_Buy, "NULL UI Component!!!");
-	m_pImage_Sell_Title		= (CN3UIImage*)(this->GetChildByID("img_sell"));		__ASSERT(m_pImage_Sell_Title, "NULL UI Component!!!");
-	m_pImage_Buy_Title		= (CN3UIImage*)(this->GetChildByID("img_buy"));			__ASSERT(m_pImage_Buy_Title, "NULL UI Component!!!");
+	N3_VERIFY_UI_COMPONENT(m_pImage_Sell, GetChildByID<CN3UIImage>("img_sell gold"));
+	N3_VERIFY_UI_COMPONENT(m_pImage_Buy, GetChildByID<CN3UIImage>("img_buy gold"));
+	N3_VERIFY_UI_COMPONENT(m_pImage_Sell_Title, GetChildByID<CN3UIImage>("img_sell"));
+	N3_VERIFY_UI_COMPONENT(m_pImage_Buy_Title, GetChildByID<CN3UIImage>("img_buy"));
 
-	m_pString_Page			= (CN3UIString*)(this->GetChildByID("string_page"));	__ASSERT(m_pString_Page, "NULL UI Component!!!");
+	N3_VERIFY_UI_COMPONENT(m_pString_Page, GetChildByID<CN3UIString>("string_page"));
 
 	std::string szID;
 	for(int i = 0; i < TRADE_BBS_MAXSTRING; i++)
 	{
 		szID = fmt::format("text_{:02}", i);
-		m_pText[i] = (CN3UIString*) GetChildByID(szID);
+		N3_VERIFY_UI_COMPONENT(m_pText[i], GetChildByID<CN3UIString>(szID));
 	}
 
 	m_iCurPage = 0; // 현재 페이지..

--- a/Client/WarFare/UITransactionDlg.cpp
+++ b/Client/WarFare/UITransactionDlg.cpp
@@ -357,7 +357,8 @@ void CUITransactionDlg::EnterTransactionState()
 	InitIconUpdate();
 	m_iCurPage = 0;
 
-	CN3UIString* pStr = (CN3UIString*) GetChildByID("string_page");
+	CN3UIString* pStr = nullptr;
+	N3_VERIFY_UI_COMPONENT(pStr, GetChildByID<CN3UIString>("string_page"));
 	if (pStr != nullptr)
 		pStr->SetStringAsInt(m_iCurPage + 1);
 
@@ -1470,7 +1471,7 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 			if(m_iCurPage<0)
 				m_iCurPage = 0;
 
-			pStr = (CN3UIString*) GetChildByID("string_page");
+			N3_VERIFY_UI_COMPONENT(pStr, GetChildByID<CN3UIString>("string_page"));
 			if (pStr != nullptr)
 				pStr->SetStringAsInt(m_iCurPage + 1);
 
@@ -1502,7 +1503,7 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 			if (m_iCurPage >= MAX_ITEM_TRADE_PAGE)
 				m_iCurPage = MAX_ITEM_TRADE_PAGE-1;
 
-			pStr = (CN3UIString*) GetChildByID("string_page");
+			N3_VERIFY_UI_COMPONENT(pStr, GetChildByID<CN3UIString>("string_page"));
 			if (pStr != nullptr)
 				pStr->SetStringAsInt(m_iCurPage + 1);
 
@@ -1678,9 +1679,9 @@ bool CUITransactionDlg::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pBtnClose		= (CN3UIButton*)(this->GetChildByID("btn_close"));		__ASSERT(m_pBtnClose, "NULL UI Component!!");
-	m_pBtnPageUp	= (CN3UIButton*)(this->GetChildByID("btn_page_up"));	__ASSERT(m_pBtnPageUp, "NULL UI Component!!");
-	m_pBtnPageDown	= (CN3UIButton*)(this->GetChildByID("btn_page_down"));	__ASSERT(m_pBtnPageDown, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtnClose, GetChildByID<CN3UIButton>("btn_close"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnPageUp, GetChildByID<CN3UIButton>("btn_page_up"));
+	N3_VERIFY_UI_COMPONENT(m_pBtnPageDown, GetChildByID<CN3UIButton>("btn_page_down"));
 
 	return true;
 }

--- a/Client/WarFare/UIVarious.cpp
+++ b/Client/WarFare/UIVarious.cpp
@@ -131,47 +131,47 @@ bool CUIState::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pText_ID			= (CN3UIString*)GetChildByID("Text_ID");			__ASSERT(m_pText_ID	, "NULL UI Component!!");
-	m_pText_Level		= (CN3UIString*)GetChildByID("Text_Level");			__ASSERT(m_pText_Level	, "NULL UI Component!!");
-	m_pText_RealmPoint	= (CN3UIString*)GetChildByID("Text_RealmPoint");	__ASSERT(m_pText_RealmPoint, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_ID, GetChildByID<CN3UIString>("Text_ID"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Level, GetChildByID<CN3UIString>("Text_Level"));
+	N3_VERIFY_UI_COMPONENT(m_pText_RealmPoint, GetChildByID<CN3UIString>("Text_RealmPoint"));
 
-	m_pText_Class		= (CN3UIString*)GetChildByID("Text_Class");		__ASSERT(m_pText_Class	, "NULL UI Component!!");
-	m_pText_Race		= (CN3UIString*)GetChildByID("Text_Race");		__ASSERT(m_pText_Race		, "NULL UI Component!!");
-	m_pText_Nation		= (CN3UIString*)GetChildByID("Text_Nation");	__ASSERT(m_pText_Nation	, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_Class, GetChildByID<CN3UIString>("Text_Class"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Race, GetChildByID<CN3UIString>("Text_Race"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Nation, GetChildByID<CN3UIString>("Text_Nation"));
 
-	m_pText_HP			= (CN3UIString*)GetChildByID("Text_HP");		__ASSERT(m_pText_HP		, "NULL UI Component!!");
-	m_pText_MP			= (CN3UIString*)GetChildByID("Text_MP");		__ASSERT(m_pText_MP		, "NULL UI Component!!");
-	m_pText_Exp			= (CN3UIString*)GetChildByID("Text_Exp");		__ASSERT(m_pText_Exp		, "NULL UI Component!!");
-	m_pText_AP			= (CN3UIString*)GetChildByID("Text_AP");		__ASSERT(m_pText_AP		, "NULL UI Component!!");
-	m_pText_GP			= (CN3UIString*)GetChildByID("Text_GP");		__ASSERT(m_pText_GP		, "NULL UI Component!!");
-	m_pText_Weight		= (CN3UIString*)GetChildByID("Text_Weight");	__ASSERT(m_pText_Weight	, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_HP, GetChildByID<CN3UIString>("Text_HP"));
+	N3_VERIFY_UI_COMPONENT(m_pText_MP, GetChildByID<CN3UIString>("Text_MP"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Exp, GetChildByID<CN3UIString>("Text_Exp"));
+	N3_VERIFY_UI_COMPONENT(m_pText_AP, GetChildByID<CN3UIString>("Text_AP"));
+	N3_VERIFY_UI_COMPONENT(m_pText_GP, GetChildByID<CN3UIString>("Text_GP"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Weight, GetChildByID<CN3UIString>("Text_Weight"));
 
-	m_pText_BonusPoint		= (CN3UIString*)GetChildByID("Text_BonusPoint"); __ASSERT(m_pText_BonusPoint	, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_BonusPoint, GetChildByID<CN3UIString>("Text_BonusPoint"));
 
-	m_pBtn_Strength		= (CN3UIButton*)GetChildByID("Btn_Strength");		__ASSERT(m_pBtn_Strength	, "NULL UI Component!!");
-	m_pBtn_Stamina		= (CN3UIButton*)GetChildByID("Btn_Stamina");		__ASSERT(m_pBtn_Stamina	, "NULL UI Component!!");
-	m_pBtn_Dexterity	= (CN3UIButton*)GetChildByID("Btn_Dexterity");		__ASSERT(m_pBtn_Dexterity	, "NULL UI Component!!");
-	m_pBtn_MagicAttak	= (CN3UIButton*)GetChildByID("Btn_MagicAttack");	__ASSERT(m_pBtn_MagicAttak	, "NULL UI Component!!");
-	m_pBtn_Intelligence	= (CN3UIButton*)GetChildByID("Btn_Intelligence");	__ASSERT(m_pBtn_Intelligence, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Strength, GetChildByID<CN3UIButton>("Btn_Strength"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Stamina, GetChildByID<CN3UIButton>("Btn_Stamina"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Dexterity, GetChildByID<CN3UIButton>("Btn_Dexterity"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_MagicAttak, GetChildByID<CN3UIButton>("Btn_MagicAttack"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Intelligence, GetChildByID<CN3UIButton>("Btn_Intelligence"));
 
-	m_pText_Strength	= (CN3UIString*)GetChildByID("Text_Strength");		__ASSERT(m_pText_Strength	, "NULL UI Component!!");
-	m_pText_Stamina		= (CN3UIString*)GetChildByID("Text_Stamina");		__ASSERT(m_pText_Stamina	, "NULL UI Component!!");
-	m_pText_Dexterity	= (CN3UIString*)GetChildByID("Text_Dexterity");		__ASSERT(m_pText_Dexterity, "NULL UI Component!!");
-	m_pText_MagicAttak	= (CN3UIString*)GetChildByID("Text_MagicAttack");	__ASSERT(m_pText_MagicAttak, "NULL UI Component!!");
-	m_pText_Intelligence = (CN3UIString*)GetChildByID("Text_Intelligence");	__ASSERT(m_pText_Intelligence, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_Strength, GetChildByID<CN3UIString>("Text_Strength"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Stamina, GetChildByID<CN3UIString>("Text_Stamina"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Dexterity, GetChildByID<CN3UIString>("Text_Dexterity"));
+	N3_VERIFY_UI_COMPONENT(m_pText_MagicAttak, GetChildByID<CN3UIString>("Text_MagicAttack"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Intelligence, GetChildByID<CN3UIString>("Text_Intelligence"));
 
-	m_pText_RegistFire	= (CN3UIString*)GetChildByID("Text_RegistFire");	__ASSERT(m_pText_RegistFire, "NULL UI Component!!");
-	m_pText_RegistMagic	= (CN3UIString*)GetChildByID("Text_RegistMagic");	__ASSERT(m_pText_RegistMagic, "NULL UI Component!!");
-	m_pText_RegistIce	= (CN3UIString*)GetChildByID("Text_RegistIce");		__ASSERT(m_pText_RegistIce, "NULL UI Component!!");
-	m_pText_RegistCurse	= (CN3UIString*)GetChildByID("Text_RegistCurse");	__ASSERT(m_pText_RegistCurse, "NULL UI Component!!");
-	m_pText_RegistLight  = (CN3UIString*)GetChildByID("Text_RegistLightR");	__ASSERT(m_pText_RegistLight , "NULL UI Component!!");
-	m_pText_RegistPoison = (CN3UIString*)GetChildByID("Text_RegistPoison");	__ASSERT(m_pText_RegistPoison, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pText_RegistFire, GetChildByID<CN3UIString>("Text_RegistFire"));
+	N3_VERIFY_UI_COMPONENT(m_pText_RegistMagic, GetChildByID<CN3UIString>("Text_RegistMagic"));
+	N3_VERIFY_UI_COMPONENT(m_pText_RegistIce, GetChildByID<CN3UIString>("Text_RegistIce"));
+	N3_VERIFY_UI_COMPONENT(m_pText_RegistCurse, GetChildByID<CN3UIString>("Text_RegistCurse"));
+	N3_VERIFY_UI_COMPONENT(m_pText_RegistLight, GetChildByID<CN3UIString>("Text_RegistLightR"));
+	N3_VERIFY_UI_COMPONENT(m_pText_RegistPoison, GetChildByID<CN3UIString>("Text_RegistPoison"));
 
-	m_pImg_Str  = GetChildByID("img_str");	__ASSERT(m_pImg_Str, "NULL UI Component!!");
-	m_pImg_Sta	= GetChildByID("img_sta");	__ASSERT(m_pImg_Sta, "NULL UI Component!!");
-	m_pImg_Dex  = GetChildByID("img_dex");	__ASSERT(m_pImg_Dex , "NULL UI Component!!");
-	m_pImg_Int	= GetChildByID("img_int");	__ASSERT(m_pImg_Int, "NULL UI Component!!");
-	m_pImg_MAP	= GetChildByID("img_map");	__ASSERT(m_pImg_MAP, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pImg_Str, GetChildByID("img_str"));
+	N3_VERIFY_UI_COMPONENT(m_pImg_Sta, GetChildByID("img_sta"));
+	N3_VERIFY_UI_COMPONENT(m_pImg_Dex, GetChildByID("img_dex"));
+	N3_VERIFY_UI_COMPONENT(m_pImg_Int, GetChildByID("img_int"));
+	N3_VERIFY_UI_COMPONENT(m_pImg_MAP, GetChildByID("img_map"));
 
 	return true;
 }
@@ -1040,17 +1040,17 @@ bool CUIFriends::Load(HANDLE hFile)
 {
 	if(false == CN3UIBase::Load(hFile)) return false;
 
-	m_pList_Friends		= (CN3UIList*)this->GetChildByID("List_Friends");		__ASSERT(m_pList_Friends, "NULL UI Component!!");
-	m_pText_Page		= (CN3UIString*)this->GetChildByID("String_Page");		__ASSERT(m_pText_Page, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pList_Friends, GetChildByID<CN3UIList>("List_Friends"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Page, GetChildByID<CN3UIString>("String_Page"));
 
-	m_pBtn_NextPage		= (CN3UIButton*)(this->GetChildByID("Btn_Page_Down"));	__ASSERT(m_pBtn_NextPage, "NULL UI Component!!");
-	m_pBtn_PrevPage		= (CN3UIButton*)(this->GetChildByID("Btn_Page_Up"));	__ASSERT(m_pBtn_PrevPage, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_NextPage, GetChildByID<CN3UIButton>("Btn_Page_Down"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_PrevPage, GetChildByID<CN3UIButton>("Btn_Page_Up"));
 	
-	m_pBtn_Refresh		= (CN3UIButton*)this->GetChildByID("Btn_Refresh");	__ASSERT(m_pBtn_Refresh, "NULL UI Component!!");
-	m_pBtn_Party		= (CN3UIButton*)this->GetChildByID("Btn_Party");	__ASSERT(m_pBtn_Party, "NULL UI Component!!");
-	m_pBtn_Whisper		= (CN3UIButton*)this->GetChildByID("Btn_Whisper");	__ASSERT(m_pBtn_Whisper, "NULL UI Component!!");
-	m_pBtn_Add			= (CN3UIButton*)this->GetChildByID("Btn_Add");		__ASSERT(m_pBtn_Add, "NULL UI Component!!");
-	m_pBtn_Delete		= (CN3UIButton*)this->GetChildByID("Btn_Delete");	__ASSERT(m_pBtn_Delete, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Refresh, GetChildByID<CN3UIButton>("Btn_Refresh"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Party, GetChildByID<CN3UIButton>("Btn_Party"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Whisper, GetChildByID<CN3UIButton>("Btn_Whisper"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Add, GetChildByID<CN3UIButton>("Btn_Add"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Delete, GetChildByID<CN3UIButton>("Btn_Delete"));
 
 	std::string szFN = CGameProcedure::s_szAccount + "_" + CGameProcedure::s_szServer + ".txt"; // 파일이름은 계정_서버.txt 로 한다.
 	FILE* pFile = fopen(szFN.c_str(), "r");
@@ -1428,11 +1428,11 @@ bool CUIVarious::Load(HANDLE hFile)
 {
 	if(CN3UIBase::Load(hFile)==false) return false;
 
-	m_pBtn_Knights = (CN3UIButton*)(this->GetChildByID("btn_clan"));		__ASSERT(m_pBtn_Knights, "NULL UI Component!!");
-	m_pBtn_State =	(CN3UIButton*)(this->GetChildByID("Btn_State"));		__ASSERT(m_pBtn_State, "NULL UI Component!!");
-	m_pBtn_Quest =	(CN3UIButton*)(this->GetChildByID("Btn_Quest"));		__ASSERT(m_pBtn_Quest, "NULL UI Component!!");
-	m_pBtn_Friends = (CN3UIButton*)(this->GetChildByID("Btn_Friends"));		__ASSERT(m_pBtn_Friends, "NULL UI Component!!");
-	m_pBtn_Close =	(CN3UIButton*)(this->GetChildByID("Btn_Close"));		__ASSERT(m_pBtn_Close, "NULL UI Component!!");
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Knights, GetChildByID<CN3UIButton>("btn_clan"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_State, GetChildByID<CN3UIButton>("Btn_State"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Quest, GetChildByID<CN3UIButton>("Btn_Quest"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Friends, GetChildByID<CN3UIButton>("Btn_Friends"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Close, GetChildByID<CN3UIButton>("Btn_Close"));
 
 	// 아직 UI 가 안되어 있으니 막자..
 	if(m_pBtn_Quest) m_pBtn_Quest->SetState(UI_STATE_BUTTON_DISABLE);


### PR DESCRIPTION
Prefer checked N3_VERIFY_UI_COMPONENT() [for assertions, which need restoring...] and GetChildByID<type> for strict type safety.

This applies to all controls already loaded with a specified type.