### PR TITLE
Restore _ASSERT behaviour

### DIFF
--- a/Client/N3Base/My_3DStruct.h
+++ b/Client/N3Base/My_3DStruct.h
@@ -1113,31 +1113,17 @@ const uint32_t OBJ_ANIM_CONTROL			= 0x40000000;
 #include "CrtDbg.h"
 
 #ifndef _DEBUG
-#define __ASSERT(expr, expMessage) \
-if(!(expr)) {\
-	printf("ERROR-> %s\n%s: %d\n\n", expMessage, __FILE__, __LINE__);\
-}
-
+#define __ASSERT(expr, expMessage)
 #else
-
-#define __ASSERT(expr, expMessage) \
-if(!(expr)) {\
-	printf("ERROR-> %s\n%s: %d\n\n", expMessage, __FILE__, __LINE__);\
-}
-
-/*
 #define __ASSERT(expr, expMessage) \
 if(!(expr)) \
 { \
-	_CrtDbgReport(_CRT_ASSERT, __FILE__, __LINE__, "N3 Custom Assert Functon", expMessage); \
-	char __szErr[512]; \
-	sprintf(__szErr, "  ---- N3 Assert Warning (File:%s, Line:%d) ---- \n", __FILE__, __LINE__); \
-	OutputDebugString(__szErr); \
-	sprintf(__szErr, "    : %s\n", expMessage); \
-	OutputDebugString(__szErr); \
-	_CrtDbgBreak(); \
+	/*_CrtDbgReport(_CRT_ASSERT, __FILE__, __LINE__, "N3 Custom Assert Function", expMessage);*/ \
+	char __szErr[512] = {}; \
+	snprintf(__szErr, sizeof(__szErr), "%s(%d): %s\n", __FILE__, __LINE__, expMessage); \
+	OutputDebugStringA(__szErr); \
+	/*_CrtDbgBreak();*/ \
 }
-*/
 #endif
 
 

--- a/Client/N3Base/My_3DStruct.h
+++ b/Client/N3Base/My_3DStruct.h
@@ -1116,13 +1116,13 @@ const uint32_t OBJ_ANIM_CONTROL			= 0x40000000;
 #define __ASSERT(expr, expMessage)
 #else
 #define __ASSERT(expr, expMessage) \
-if(!(expr)) \
+if (!(expr)) \
 { \
-	/*_CrtDbgReport(_CRT_ASSERT, __FILE__, __LINE__, "N3 Custom Assert Function", expMessage);*/ \
+	_CrtDbgReport(_CRT_ASSERT, __FILE__, __LINE__, "N3 Custom Assert Function", expMessage); \
 	char __szErr[512] = {}; \
 	snprintf(__szErr, sizeof(__szErr), "%s(%d): %s\n", __FILE__, __LINE__, expMessage); \
 	OutputDebugStringA(__szErr); \
-	/*_CrtDbgBreak();*/ \
+	_CrtDbgBreak(); \
 }
 #endif
 

--- a/Client/N3Base/N3FXPartBase.h
+++ b/Client/N3Base/N3FXPartBase.h
@@ -14,11 +14,10 @@
 #include "N3Texture.h"
 
 class CN3FXBundle;
-
 class CN3FXPartBase : public CN3BaseFileAccess  
 {
 public:
-	static constexpr int SUPPORTED_PART_BASE_VERSION = 2;
+	static constexpr int SUPPORTED_PART_BASE_VERSION = 4; // supported as far as reading only
 
 //멤버 변수들..
 	int				m_iVersion;			//	자료의 버전..
@@ -40,7 +39,7 @@ public:
 	__Vector3		m_vCurrVelocity;
 	__Vector3		m_vCurrPos;
 
-	uint32_t			m_dwState;			//	현재 파트의 상태..
+	uint32_t		m_dwState;			//	현재 파트의 상태..
 	__Vector3		m_vPos;				//	번들에서 파트의 위치.
 
 	bool			m_bOnGround;		//바닥에 붙어서 갈 것인가...
@@ -54,16 +53,16 @@ public:
 	float			m_fFadeOut;
 	float			m_fFadeIn;
 
-	uint32_t			m_dwRenderFlag;
+	uint32_t		m_dwRenderFlag;
 
-	uint32_t			m_dwSrcBlend;
-	uint32_t			m_dwDestBlend;
+	uint32_t		m_dwSrcBlend;
+	uint32_t		m_dwDestBlend;
 	BOOL			m_bAlpha;
 
-	uint32_t			m_dwZEnable;
-	uint32_t			m_dwZWrite;
-	uint32_t			m_dwLight;
-	uint32_t			m_dwDoubleSide;
+	uint32_t		m_dwZEnable;
+	uint32_t		m_dwZWrite;
+	uint32_t		m_dwLight;
+	uint32_t		m_dwDoubleSide;
 		
 protected:
 	virtual bool	IsDead();

--- a/Client/N3Base/N3FXPartBillBoard.h
+++ b/Client/N3Base/N3FXPartBillBoard.h
@@ -10,7 +10,7 @@
 class CN3FXPartBillBoard : public CN3FXPartBase  
 {
 public:
-	static constexpr int SUPPORTED_PART_VERSION = 5;
+	static constexpr int SUPPORTED_PART_VERSION = 9; // supported as far as reading only
 
 	int					m_iNum;				//	보드의 갯수.
 	float				m_fSizeX;			//	보드의 크기

--- a/Client/N3Base/N3FXPartBottomBoard.h
+++ b/Client/N3Base/N3FXPartBottomBoard.h
@@ -17,7 +17,7 @@
 class CN3FXPartBottomBoard : public CN3FXPartBase  
 {
 public:
-	static constexpr int SUPPORTED_PART_VERSION = 1;
+	static constexpr int SUPPORTED_PART_VERSION = 3; // supported as far as reading only
 
 	float				m_fSizeX;			//	보드의 크기
 	float				m_fSizeZ;

--- a/Client/N3Base/N3FXPartMesh.h
+++ b/Client/N3Base/N3FXPartMesh.h
@@ -8,11 +8,10 @@
 #include "N3FXPartBase.h"
 
 class CN3FXShape;
-
 class CN3FXPartMesh : public CN3FXPartBase
 {
 public:
-	static constexpr int SUPPORTED_PART_VERSION = 5;
+	static constexpr int SUPPORTED_PART_VERSION = 9; // supported as far as reading only
 
 	CN3FXShape*	m_pShape;
 	CN3FXShape*	m_pRefShape;

--- a/Client/N3Base/N3FXPartParticles.h
+++ b/Client/N3Base/N3FXPartParticles.h
@@ -12,18 +12,17 @@
 
 class CN3FXParticle;
 class CN3FXShape;
-
 class CN3FXPartParticles : public CN3FXPartBase  
 {
 public:
-	static constexpr int SUPPORTED_PART_VERSION = 5;
+	static constexpr int SUPPORTED_PART_VERSION = 11; // supported as far as reading only
 
 	//related whole particle system...
 	__VertexXyzColorT1			m_vUnit[NUM_VERTEX_PARTICLE];
-	//uint16_t						m_wUnitIB[6];
+	//uint16_t					m_wUnitIB[6];
 
 	__VertexXyzColorT1*			m_pVB;
-	//uint16_t*						m_pIB;
+	//uint16_t*					m_pIB;
 
 	__Matrix44					m_mtxVI;				//	inverse view mtx..
 
@@ -44,7 +43,7 @@ public:
 	__Vector3					m_MaxCreateRange;		//	파티클 생성 자유도 범위..max..
 
 	//emitter...
-	uint32_t						m_dwEmitType;			//	발사형태..(spread, gather)..
+	uint32_t					m_dwEmitType;			//	발사형태..(spread, gather)..
 	PARTICLEEMITCONDITION		m_uEmitCon;				//	발사형태에 따른 필요 데이타..
 	__Vector3					m_vEmitterDir;
 	__Vector3					m_vPrevShapePos;
@@ -58,7 +57,7 @@ public:
 	float		m_fPtGravity;		//중력가속도..
 
 	//related particle color....
-	uint32_t		m_dwChangeColor[NUM_KEY_COLOR];
+	uint32_t	m_dwChangeColor[NUM_KEY_COLOR];
 	bool		m_bChangeColor;
 
 	//related animation key
@@ -80,6 +79,7 @@ public:
 	float m_fPtRangeMin;
 	float m_fPtRangeMax;
 	// N3FXParticle needs implementation of these methods
+
 protected:
 	void	Rotate();
 	void	Scaling();

--- a/Client/WarFare/BirdMng.cpp
+++ b/Client/WarFare/BirdMng.cpp
@@ -42,15 +42,8 @@ void CBirdMng::LoadFromFile(const std::string& szFN)
 
 	if(szFN.empty()) return;
 	FILE* stream = fopen(szFN.c_str(), "r"); //text파일로 만든다 
-
-	if(nullptr == stream)
-	{
-#if _DEBUG
-		std::string szErr = fmt::format("failed to open file - {}", szFN);
-		__ASSERT(stream, szErr.c_str());
-#endif
+	if (stream == nullptr)
 		return;
-	}
 
 	int i;
 	char szRrcName[_MAX_PATH];

--- a/Client/WarFare/UIClassChange.cpp
+++ b/Client/WarFare/UIClassChange.cpp
@@ -30,16 +30,12 @@ CUIClassChange::CUIClassChange()
 {
 	m_pBtn_Ok		= nullptr;
 	m_pBtn_Cancel	= nullptr;
-	m_pBtn_Class0		= nullptr;
-	m_pBtn_Class1		= nullptr;
+	m_pBtn_Class	= nullptr;
 
 	m_pText_Warning	= nullptr;
-	m_pText_Info0		= nullptr;
-	m_pText_Info1		= nullptr;
+	m_pText_Info	= nullptr;
 	m_pText_Title	= nullptr;
 	m_pText_Message	= nullptr;
-
-	m_eClassChangeState	= UISTATE_NORMAL;
 }
 
 CUIClassChange::~CUIClassChange()
@@ -47,23 +43,17 @@ CUIClassChange::~CUIClassChange()
 
 }
 
-void CUIClassChange::Release()
-{
-	CN3UIBase::Release();
-}
-
 bool CUIClassChange::Load(HANDLE hFile)
 {
-	if(CN3UIBase::Load(hFile)==false) return false;
+	if (!CN3UIBase::Load(hFile))
+		return false;
 
 	N3_VERIFY_UI_COMPONENT(m_pBtn_Ok, GetChildByID<CN3UIButton>("Btn_Ok"));
 	N3_VERIFY_UI_COMPONENT(m_pBtn_Cancel, GetChildByID<CN3UIButton>("Btn_Cancel"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Class0, GetChildByID<CN3UIButton>("Btn_Class0"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Class1, GetChildByID<CN3UIButton>("Btn_Class1"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Class, GetChildByID<CN3UIButton>("Btn_Class"));
 
 	N3_VERIFY_UI_COMPONENT(m_pText_Warning, GetChildByID<CN3UIString>("Text_Waring"));
-	N3_VERIFY_UI_COMPONENT(m_pText_Info0, GetChildByID<CN3UIString>("Text_info0"));
-	N3_VERIFY_UI_COMPONENT(m_pText_Info1, GetChildByID<CN3UIString>("Text_info1"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Info, GetChildByID<CN3UIString>("Text_info"));
 	N3_VERIFY_UI_COMPONENT(m_pText_Message, GetChildByID<CN3UIString>("Text_Message"));
 
 	return true;
@@ -71,12 +61,10 @@ bool CUIClassChange::Load(HANDLE hFile)
 
 void CUIClassChange::Open(int iCode)
 {
-	m_eClassChangeState	= UISTATE_NORMAL;
-
 	SetVisible(true);
 
-	__InfoPlayerBase*	pInfoBase = &(CGameBase::s_pPlayer->m_InfoBase);
-	__InfoPlayerMySelf*	pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
+	__InfoPlayerBase*	pInfoBase = &CGameBase::s_pPlayer->m_InfoBase;
+	__InfoPlayerMySelf*	pInfoExt = &CGameBase::s_pPlayer->m_InfoExt;
 
 	std::string szSuccess, szNotYet, szAlready, szItemInSlot;
 	szSuccess = fmt::format_text_resource(IDS_CLASS_CHANGE_SUCCESS);
@@ -86,12 +74,10 @@ void CUIClassChange::Open(int iCode)
 
 	m_pBtn_Ok->SetVisible(false);
 	m_pBtn_Cancel->SetVisible(false);
-	m_pBtn_Class0->SetVisible(false);
-	m_pBtn_Class1->SetVisible(false);
+	m_pBtn_Class->SetVisible(false);
 
 	m_pText_Warning->SetVisible(false);
-	m_pText_Info0->SetVisible(false);
-	m_pText_Info1->SetVisible(false);
+	m_pText_Info->SetVisible(false);
 	m_pText_Message->SetVisible(true);
 
 	std::string szClassTmp;
@@ -100,47 +86,37 @@ void CUIClassChange::Open(int iCode)
 	{
 		case N3_SP_CLASS_CHANGE_SUCCESS:
 			m_pText_Message->SetString(szSuccess);
-			m_pBtn_Class0->SetVisible(true);
-			m_pBtn_Class1->SetVisible(true);
+			m_pBtn_Class->SetVisible(true);
 			m_pBtn_Cancel->SetVisible(true);
 
-			m_pText_Info0->SetVisible(true);
-			m_pText_Info1->SetVisible(true);
+			m_pText_Info->SetVisible(true);
 
 			m_eClass = pInfoBase->eClass;
 			switch ( pInfoBase->eClass )
 			{
 				case CLASS_KA_WARRIOR:
-					CGameBase::GetTextByClass(CLASS_KA_BERSERKER, szClassTmp); m_pText_Info0->SetString(szClassTmp);
-					CGameBase::GetTextByClass(CLASS_KA_GUARDIAN, szClassTmp); m_pText_Info1->SetString(szClassTmp);
+					CGameBase::GetTextByClass(CLASS_KA_BERSERKER, szClassTmp); m_pText_Info->SetString(szClassTmp);
 					break;
 				case CLASS_KA_ROGUE:
-					CGameBase::GetTextByClass(CLASS_KA_HUNTER, szClassTmp); m_pText_Info0->SetString(szClassTmp);
-					CGameBase::GetTextByClass(CLASS_KA_PENETRATOR, szClassTmp); m_pText_Info1->SetString(szClassTmp);
+					CGameBase::GetTextByClass(CLASS_KA_HUNTER, szClassTmp); m_pText_Info->SetString(szClassTmp);
 					break;
 				case CLASS_KA_WIZARD:
-					CGameBase::GetTextByClass(CLASS_KA_SORCERER, szClassTmp); m_pText_Info0->SetString(szClassTmp);
-					CGameBase::GetTextByClass(CLASS_KA_NECROMANCER, szClassTmp); m_pText_Info1->SetString(szClassTmp);
+					CGameBase::GetTextByClass(CLASS_KA_SORCERER, szClassTmp); m_pText_Info->SetString(szClassTmp);
 					break;
 				case CLASS_KA_PRIEST:
-					CGameBase::GetTextByClass(CLASS_KA_SHAMAN, szClassTmp); m_pText_Info0->SetString(szClassTmp);
-					CGameBase::GetTextByClass(CLASS_KA_DARKPRIEST, szClassTmp); m_pText_Info1->SetString(szClassTmp);
+					CGameBase::GetTextByClass(CLASS_KA_SHAMAN, szClassTmp); m_pText_Info->SetString(szClassTmp);
 					break;
 				case CLASS_EL_WARRIOR:
-					CGameBase::GetTextByClass(CLASS_EL_BLADE, szClassTmp); m_pText_Info0->SetString(szClassTmp);
-					CGameBase::GetTextByClass(CLASS_EL_PROTECTOR, szClassTmp); m_pText_Info1->SetString(szClassTmp);
+					CGameBase::GetTextByClass(CLASS_EL_BLADE, szClassTmp); m_pText_Info->SetString(szClassTmp);
 					break;
 				case CLASS_EL_ROGUE:
-					CGameBase::GetTextByClass(CLASS_EL_RANGER, szClassTmp); m_pText_Info0->SetString(szClassTmp);
-					CGameBase::GetTextByClass(CLASS_EL_ASSASIN, szClassTmp); m_pText_Info1->SetString(szClassTmp);
+					CGameBase::GetTextByClass(CLASS_EL_RANGER, szClassTmp); m_pText_Info->SetString(szClassTmp);
 					break;
 				case CLASS_EL_WIZARD:
-					CGameBase::GetTextByClass(CLASS_EL_MAGE, szClassTmp); m_pText_Info0->SetString(szClassTmp);
-					CGameBase::GetTextByClass(CLASS_EL_ENCHANTER, szClassTmp); m_pText_Info1->SetString(szClassTmp);
+					CGameBase::GetTextByClass(CLASS_EL_MAGE, szClassTmp); m_pText_Info->SetString(szClassTmp);
 					break;
 				case CLASS_EL_PRIEST:
-					CGameBase::GetTextByClass(CLASS_EL_CLERIC, szClassTmp); m_pText_Info0->SetString(szClassTmp);
-					CGameBase::GetTextByClass(CLASS_EL_DRUID, szClassTmp); m_pText_Info1->SetString(szClassTmp);
+					CGameBase::GetTextByClass(CLASS_EL_CLERIC, szClassTmp); m_pText_Info->SetString(szClassTmp);
 					break;
 			}
 			break;
@@ -169,20 +145,14 @@ bool CUIClassChange::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 
 	if (dwMsg == UIMSG_BUTTON_CLICK)					
 	{
-		if(pSender == m_pBtn_Ok)
+		if (pSender == m_pBtn_Ok
+			|| pSender == m_pBtn_Cancel)
 		{
-			if (m_eClassChangeState == UISTATE_NORMAL)
-				Close();
-			else
-				ChangeToNormalState();
-		}
-
-		else if(pSender == m_pBtn_Cancel)
 			Close();
-
-		else if(pSender == m_pBtn_Class0)
+		}
+		else if (pSender == m_pBtn_Class)
 		{
-			switch ( pInfoBase->eClass )
+			switch (pInfoBase->eClass)
 			{
 				case CLASS_KA_WARRIOR:
 					pInfoBase->eClass = CLASS_KA_BERSERKER;
@@ -216,7 +186,7 @@ bool CUIClassChange::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 			int iOffset = 0;
 			CAPISocket::MP_AddByte(byBuff, iOffset, WIZ_CLASS_CHANGE);
 			CAPISocket::MP_AddByte(byBuff, iOffset, N3_SP_CLASS_CHANGE_REQ);
-			CAPISocket::MP_AddShort(byBuff, iOffset, (int16_t)pInfoBase->eClass);
+			CAPISocket::MP_AddShort(byBuff, iOffset, (int16_t) pInfoBase->eClass);
 			CGameProcedure::s_pSocket->Send(byBuff, iOffset);
 
 			CGameProcedure::s_pProcMain->m_pUISkillTreeDlg->InitIconUpdate();
@@ -225,11 +195,6 @@ bool CUIClassChange::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 			CGameProcedure::s_pProcMain->m_pUIHotKeyDlg->ClassChangeHotkeyFlush();
 			Close();
 		}
-
-		else if(pSender == m_pBtn_Class1)
-		{
-			ChangeToWarningState();
-		}
 	}
 
 	return true;
@@ -237,15 +202,13 @@ bool CUIClassChange::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
 
 void CUIClassChange::Close()
 {
-	m_eClassChangeState	= UISTATE_NORMAL;
-
 	SetVisible(false);
 }
 
 void CUIClassChange::RestorePrevClass()
 {
-	__InfoPlayerBase*	pInfoBase = &(CGameBase::s_pPlayer->m_InfoBase);
-	__InfoPlayerMySelf*	pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
+	__InfoPlayerBase*	pInfoBase = &CGameBase::s_pPlayer->m_InfoBase;
+	__InfoPlayerMySelf*	pInfoExt = &CGameBase::s_pPlayer->m_InfoExt;
 
 	pInfoBase->eClass = m_eClass;
 	CGameProcedure::s_pProcMain->m_pUISkillTreeDlg->InitIconUpdate();
@@ -253,42 +216,13 @@ void CUIClassChange::RestorePrevClass()
 	CGameProcedure::s_pProcMain->m_pUIVar->UpdateAllStates(pInfoBase, pInfoExt); // 상태창 수치를 모두 적용
 }
 
-void CUIClassChange::ChangeToWarningState()
-{
-	m_eClassChangeState	= UISTATE_WARNING;
-
-	m_pBtn_Ok->SetVisible(true);
-	m_pBtn_Cancel->SetVisible(false);
-	m_pBtn_Class0->SetVisible(false);
-	m_pBtn_Class1->SetVisible(false);
-
-	m_pText_Warning->SetVisible(true);
-	m_pText_Info0->SetVisible(false);
-	m_pText_Info1->SetVisible(false);
-	m_pText_Message->SetVisible(false);
-}
-
 void CUIClassChange::ChangeToNormalState()
 {
-	m_eClassChangeState	= UISTATE_NORMAL;
-
 	m_pBtn_Ok->SetVisible(false);
 	m_pBtn_Cancel->SetVisible(true);
-	m_pBtn_Class0->SetVisible(true);
-	m_pBtn_Class1->SetVisible(true);
+	m_pBtn_Class->SetVisible(true);
 
 	m_pText_Warning->SetVisible(false);
-	m_pText_Info0->SetVisible(true);
-	m_pText_Info1->SetVisible(true);
+	m_pText_Info->SetVisible(true);
 	m_pText_Message->SetVisible(true);
 }
-
-
-//this_ui_add_start
-void CUIClassChange::SetVisibleWithNoSound(bool bVisible, bool bWork, bool bReFocus)
-{
-	CN3UIBase::SetVisibleWithNoSound(bVisible, bWork, bReFocus);
-
-	m_eClassChangeState	= UISTATE_NORMAL;
-}
-//this_ui_add_end

--- a/Client/WarFare/UIClassChange.h
+++ b/Client/WarFare/UIClassChange.h
@@ -13,30 +13,22 @@
 
 #include <N3Base/N3UIBase.h>
 
-enum e_ClassChangeState {	UISTATE_NORMAL = 1, UISTATE_WARNING	};
-
 //////////////////////////////////////////////////////////////////////
 
 class CUIClassChange : public CN3UIBase  
 {
 	CN3UIButton*		m_pBtn_Ok;
 	CN3UIButton*		m_pBtn_Cancel;
-	CN3UIButton*		m_pBtn_Class0;
-	CN3UIButton*		m_pBtn_Class1;
+	CN3UIButton*		m_pBtn_Class;
 	
 	CN3UIString*		m_pText_Warning;
-	CN3UIString*		m_pText_Info0;
-	CN3UIString*		m_pText_Info1;
+	CN3UIString*		m_pText_Info;
 	CN3UIString*		m_pText_Title;
 	CN3UIString*		m_pText_Message;
 
 	e_Class				m_eClass;
-	e_ClassChangeState	m_eClassChangeState;
 
 public:
-	void SetVisibleWithNoSound(bool bVisible, bool bWork = false, bool bReFocus = false);
-	void Release();
-
 	CUIClassChange();
 	virtual ~CUIClassChange();
 

--- a/Client/WarFare/UIHelp.h
+++ b/Client/WarFare/UIHelp.h
@@ -14,7 +14,7 @@
 class CUIHelp : public CN3UIBase  
 {
 public:
-	static constexpr int MAX_HELP_PAGE = 4;
+	static constexpr int MAX_HELP_PAGE = 3;
 
 	CN3UIBase* m_pPages[MAX_HELP_PAGE];
 

--- a/Client/WarFare/UINPCChangeEvent.h
+++ b/Client/WarFare/UINPCChangeEvent.h
@@ -17,14 +17,13 @@
 
 class CUINPCChangeEvent : public CN3UIBase
 {
-	CN3UIButton*		m_pBtn_Change;
 	CN3UIButton*		m_pBtn_Repoint0;
 	CN3UIButton*		m_pBtn_Repoint1;
 	CN3UIButton*		m_pBtn_Close;
 
 	CUIPointInitDlg*	m_pDlg;
 
-	bool					 m_bSendedAllPoint;
+	bool				 m_bSendedAllPoint;
 
 public:
 	bool OnKeyPress(int iKey);
@@ -40,7 +39,6 @@ public:
 	void	Open();
 	void	Close();
 
-	void	ClassChange();
 	void	PointChangePriceQuery(bool bAllPoint);
 	void	ReceivePriceFromServer(int iGold);
 };

--- a/Client/WarFare/UIPartyBBS.cpp
+++ b/Client/WarFare/UIPartyBBS.cpp
@@ -59,27 +59,30 @@ CUIPartyBBS::~CUIPartyBBS()
 
 bool CUIPartyBBS::Load(HANDLE hFile)
 {
-	if(CN3UIBase::Load(hFile)==false) return false;
+	if (!CN3UIBase::Load(hFile))
+		return false;
 
-	N3_VERIFY_UI_COMPONENT(m_pBtn_PageUp, GetChildByID<CN3UIButton>("btn_page_up"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_PageDown, GetChildByID<CN3UIButton>("btn_page_down"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Refresh, GetChildByID<CN3UIButton>("btn_refresh"));
+	// NOTE: This entire UI is outdated. It no longer remotely resembles the original UI.
+#if 0
+	N3_VERIFY_UI_COMPONENT(m_pBtn_PageUp,			GetChildByID<CN3UIButton>("btn_page_up"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_PageDown,			GetChildByID<CN3UIButton>("btn_page_down"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Refresh,			GetChildByID<CN3UIButton>("btn_refresh"));
 	
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Close, GetChildByID<CN3UIButton>("btn_exit"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Register, GetChildByID<CN3UIButton>("btn_add"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_RegisterCancel, GetChildByID<CN3UIButton>("btn_delete"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Whisper, GetChildByID<CN3UIButton>("btn_whisper"));
-	N3_VERIFY_UI_COMPONENT(m_pBtn_Party, GetChildByID<CN3UIButton>("btn_Party"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Close,			GetChildByID<CN3UIButton>("btn_exit"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Register,			GetChildByID<CN3UIButton>("btn_add"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_RegisterCancel,	GetChildByID<CN3UIButton>("btn_delete"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Whisper,			GetChildByID<CN3UIButton>("btn_whisper"));
+	N3_VERIFY_UI_COMPONENT(m_pBtn_Party,			GetChildByID<CN3UIButton>("btn_Party"));
 
-
-	N3_VERIFY_UI_COMPONENT(m_pText_Page, GetChildByID<CN3UIString>("string_page"));
+	N3_VERIFY_UI_COMPONENT(m_pText_Page,			GetChildByID<CN3UIString>("string_page"));
 
 	std::string szID;
 	for (int i = 0; i < PARTY_BBS_MAXSTRING; i++)
 	{
 		szID = fmt::format("text_{:02}", i);
-		N3_VERIFY_UI_COMPONENT(m_pText[i], GetChildByID<CN3UIString>(szID));
+		N3_VERIFY_UI_COMPONENT(m_pText[i],			GetChildByID<CN3UIString>(szID));
 	}
+#endif
 
 	m_iCurPage = 0; // 현재 페이지..
 

--- a/Client/WarFare/UISkillTreeDlg.cpp
+++ b/Client/WarFare/UISkillTreeDlg.cpp
@@ -1264,19 +1264,19 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 {
 // temp macro..
 #define ASSET_0 {	\
-	__ASSERT(pButton, "NULL UI Component!!"); if (!pButton) return;	pButton->SetVisible(false);	pButton->SetState(UI_STATE_BUTTON_NORMAL); \
+	if (!pButton) return;	pButton->SetVisible(false);	pButton->SetState(UI_STATE_BUTTON_NORMAL); \
 }
 #define ASSET_1 {	\
-	__ASSERT(pButton, "NULL UI Component!!"); if (!pButton) return;	pButton->SetVisible(true);	if ( m_iCurKindOf == 1 )	pButton->SetState(UI_STATE_BUTTON_DOWN);	\
+	if (!pButton) return;	pButton->SetVisible(true);	if ( m_iCurKindOf == 1 )	pButton->SetState(UI_STATE_BUTTON_DOWN);	\
 }
 #define ASSET_2 {	\
-	__ASSERT(pButton, "NULL UI Component!!"); if (!pButton) return;	pButton->SetVisible(true);	if ( m_iCurKindOf == 2 )	pButton->SetState(UI_STATE_BUTTON_DOWN);	\
+	if (!pButton) return;	pButton->SetVisible(true);	if ( m_iCurKindOf == 2 )	pButton->SetState(UI_STATE_BUTTON_DOWN);	\
 }
 #define ASSET_3 {	\
-	__ASSERT(pButton, "NULL UI Component!!"); if (!pButton) return;	pButton->SetVisible(true);	if ( m_iCurKindOf == 3 )	pButton->SetState(UI_STATE_BUTTON_DOWN);	\
+	if (!pButton) return;	pButton->SetVisible(true);	if ( m_iCurKindOf == 3 )	pButton->SetState(UI_STATE_BUTTON_DOWN);	\
 }
 #define ASSET_4 {	\
-	__ASSERT(pButton, "NULL UI Component!!"); if (!pButton) return;	pButton->SetVisible(true);	if ( m_iCurKindOf == 4 )	pButton->SetState(UI_STATE_BUTTON_DOWN);	\
+	if (!pButton) return;	pButton->SetVisible(true);	if ( m_iCurKindOf == 4 )	pButton->SetState(UI_STATE_BUTTON_DOWN);	\
 }
 
 	CN3UIButton* pButton = nullptr;
@@ -1293,152 +1293,152 @@ void CUISkillTreeDlg::ButtonVisibleStateSet()
 	switch (CGameBase::s_pPlayer->m_InfoBase.eNation)
 	{
 		case NATION_ELMORAD:
-			pButton = GetChildByID<CN3UIButton>("btn_ranger0");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_ranger1");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_ranger2");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_blade0");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_blade1");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_blade2");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_mage0");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_mage1");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_mage2");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_cleric0");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_cleric1");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_cleric2");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_ranger0"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_ranger1"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_ranger2"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_blade0"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_blade1"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_blade2"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_mage0"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_mage1"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_mage2"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_cleric0"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_cleric1"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_cleric2"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));		ASSET_0;
 			break;
 
 		case NATION_KARUS:
-			pButton = GetChildByID<CN3UIButton>("btn_hunter0");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_hunter1");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_hunter2");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_hunter3");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_berserker0");	ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_berserker1");	ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_berserker2");	ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_berserker3");	ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_sorcerer0");	ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_sorcerer1");	ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_sorcerer2");	ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_sorcerer3");	ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_shaman0");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_shaman1");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_shaman2");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_shaman3");		ASSET_0;
-			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_hunter0"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_hunter1"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_hunter2"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_hunter3"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_berserker0"));	ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_berserker1"));	ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_berserker2"));	ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_berserker3"));	ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_sorcerer0"));	ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_sorcerer1"));	ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_sorcerer2"));	ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_sorcerer3"));	ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_shaman0"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_shaman1"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_shaman2"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_shaman3"));		ASSET_0;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));		ASSET_0;
 			break;
 	}
 
 	if (m_iCurKindOf == 0)
 	{
-		pButton = GetChildByID<CN3UIButton>("btn_public");
+		N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_public"));
 		pButton->SetState(UI_STATE_BUTTON_DOWN);
 	}
 
 	switch (CGameBase::s_pPlayer->m_InfoBase.eClass)
 	{
 		case CLASS_KA_BERSERKER:
-			pButton = GetChildByID<CN3UIButton>("btn_berserker0");	ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_berserker1");	ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_berserker2");	ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_berserker0"));	ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_berserker1"));	ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_berserker2"));	ASSET_3;
 			break;
 
 		case CLASS_KA_GUARDIAN:
-			pButton = GetChildByID<CN3UIButton>("btn_berserker0");	ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_berserker1");	ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_berserker2");	ASSET_3;
-			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_berserker0"));	ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_berserker1"));	ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_berserker2"));	ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));		ASSET_4;
 			break;
 
 		case CLASS_KA_HUNTER:
-			pButton = GetChildByID<CN3UIButton>("btn_hunter0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_hunter1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_hunter2");		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_hunter0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_hunter1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_hunter2"));		ASSET_3;
 			break;
 
 		case CLASS_KA_PENETRATOR:
-			pButton = GetChildByID<CN3UIButton>("btn_hunter0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_hunter1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_hunter2");		ASSET_3;
-			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_hunter0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_hunter1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_hunter2"));		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));		ASSET_4;
 			break;
 
 		case CLASS_KA_SHAMAN:
-			pButton = GetChildByID<CN3UIButton>("btn_shaman0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_shaman1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_shaman2");		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_shaman0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_shaman1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_shaman2"));		ASSET_3;
 			break;
 
 		case CLASS_KA_DARKPRIEST:
-			pButton = GetChildByID<CN3UIButton>("btn_shaman0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_shaman1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_shaman2");		ASSET_3;
-			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_shaman0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_shaman1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_shaman2"));		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));		ASSET_4;
 			break;
 
 		case CLASS_KA_SORCERER:
-			pButton = GetChildByID<CN3UIButton>("btn_sorcerer0");	ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_sorcerer1");	ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_sorcerer2");	ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_sorcerer0"));	ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_sorcerer1"));	ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_sorcerer2"));	ASSET_3;
 			break;
 
 		case CLASS_KA_NECROMANCER:
-			pButton = GetChildByID<CN3UIButton>("btn_sorcerer0");	ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_sorcerer1");	ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_sorcerer2");	ASSET_3;
-			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_sorcerer0"));	ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_sorcerer1"));	ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_sorcerer2"));	ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));		ASSET_4;
 			break;
 
 		case CLASS_EL_BLADE:
-			pButton = GetChildByID<CN3UIButton>("btn_blade0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_blade1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_blade2");		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_blade0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_blade1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_blade2"));		ASSET_3;
 			break;
 
 		case CLASS_EL_PROTECTOR:
-			pButton = GetChildByID<CN3UIButton>("btn_blade0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_blade1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_blade2");		ASSET_3;
-			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_blade0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_blade1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_blade2"));		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));		ASSET_4;
 			break;
 
 		case CLASS_EL_RANGER:
-			pButton = GetChildByID<CN3UIButton>("btn_ranger0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_ranger1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_ranger2");		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_ranger0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_ranger1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_ranger2"));		ASSET_3;
 			break;
 
 		case CLASS_EL_ASSASIN:
-			pButton = GetChildByID<CN3UIButton>("btn_ranger0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_ranger1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_ranger2");		ASSET_3;
-			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_ranger0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_ranger1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_ranger2"));		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));		ASSET_4;
 			break;
 
 		case CLASS_EL_MAGE:
-			pButton = GetChildByID<CN3UIButton>("btn_mage0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_mage1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_mage2");		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_mage0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_mage1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_mage2"));		ASSET_3;
 			break;
 
 		case CLASS_EL_ENCHANTER:
-			pButton = GetChildByID<CN3UIButton>("btn_mage0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_mage1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_mage2");		ASSET_3;
-			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_mage0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_mage1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_mage2"));		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));		ASSET_4;
 			break;
 
 		case CLASS_EL_CLERIC:
-			pButton = GetChildByID<CN3UIButton>("btn_cleric0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_cleric1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_cleric2");		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_cleric0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_cleric1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_cleric2"));		ASSET_3;
 			break;
 
 		case CLASS_EL_DRUID:
-			pButton = GetChildByID<CN3UIButton>("btn_cleric0");		ASSET_1;
-			pButton = GetChildByID<CN3UIButton>("btn_cleric1");		ASSET_2;
-			pButton = GetChildByID<CN3UIButton>("btn_cleric2");		ASSET_3;
-			pButton = GetChildByID<CN3UIButton>("btn_master");		ASSET_4;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_cleric0"));		ASSET_1;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_cleric1"));		ASSET_2;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_cleric2"));		ASSET_3;
+			N3_VERIFY_UI_COMPONENT(pButton, GetChildByID<CN3UIButton>("btn_master"));		ASSET_4;
 			break;
 	}
 }

--- a/Client/WarFare/UIStateBar.cpp
+++ b/Client/WarFare/UIStateBar.cpp
@@ -185,13 +185,13 @@ bool CUIStateBar::Load(HANDLE hFile)
 
 	// MiniMap
 	N3_VERIFY_UI_COMPONENT(m_pGroup_MiniMap, GetChildByID("Group_MiniMap"));
-	if(m_pGroup_MiniMap)
+	if (m_pGroup_MiniMap != nullptr)
 	{
 		m_pGroup_MiniMap->SetVisible(false);
 
-		N3_VERIFY_UI_COMPONENT(m_pImage_Map, GetChildByID<CN3UIImage>("Img_MiniMap"));
-		N3_VERIFY_UI_COMPONENT(m_pBtn_ZoomIn, GetChildByID<CN3UIButton>("Btn_ZoomIn"));
-		N3_VERIFY_UI_COMPONENT(m_pBtn_ZoomOut, GetChildByID<CN3UIButton>("Btn_ZoomOut"));
+		N3_VERIFY_UI_COMPONENT(m_pImage_Map,	m_pGroup_MiniMap->GetChildByID<CN3UIImage>("Img_MiniMap"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_ZoomIn,	m_pGroup_MiniMap->GetChildByID<CN3UIButton>("Btn_ZoomIn"));
+		N3_VERIFY_UI_COMPONENT(m_pBtn_ZoomOut,	m_pGroup_MiniMap->GetChildByID<CN3UIButton>("Btn_ZoomOut"));
 	}
 
 	m_pBtn_Quest = GetChildByID<CN3UIButton>("btn_quest");


### PR DESCRIPTION
Restore `_ASSERT()` assertion & debug output behaviour.
Only enable in debug builds.
Update or otherwise disable control loads for UIs/misc. other affected things which were previously throwing assertions.

Resolves #442 