### PR TITLE
CUIKnights: Display member counts

### DIFF
--- a/Client/WarFare/UIVarious.cpp
+++ b/Client/WarFare/UIVarious.cpp
@@ -637,17 +637,17 @@ bool CUIKnights::Load(HANDLE hFile)
 	return true;
 }
 
-void CUIKnights::UpdatePageNumber(int nNewPageNr) // @Demircivi: default value for nNewPageNr is -1.
+void CUIKnights::UpdatePageNumber(int iNewPageNo /*= -1*/)
 {
-	if (nNewPageNr != -1)
-		m_iPageCur = nNewPageNr;
+	if (iNewPageNo != -1)
+		m_iPageCur = iNewPageNo;
 
 	m_pText_Page->SetStringAsInt(m_iPageCur);
 }
 
-void CUIKnights::UpdateMemberCount(int nMemberCountOnline, int nMemberCount)
+void CUIKnights::UpdateMemberCount(int iMemberCountOnline, int iMemberCountTotal)
 {
-	std::string memberCount = fmt::format("{} / {}", nMemberCountOnline, nMemberCount);
+	std::string memberCount = fmt::format("{} / {}", iMemberCountOnline, iMemberCountTotal);
 	m_pText_MemberCount->SetString(memberCount);
 }
 
@@ -909,11 +909,11 @@ bool CUIKnights::MsgRecv_MemberInfo(Packet& pkt)
 {
 	pkt.read<int16_t>(); // @Demircivi: packet sizes, which are unused.
 	int iMemberCountOnline = pkt.read<int16_t>();
-	int iMemberCount = pkt.read<int16_t>(); // @Demircivi: packet sizes, which are unused.
+	int iMemberCountTotal = pkt.read<int16_t>();
 
 	int iMemberCountList = pkt.read<int16_t>();
 
-	UpdateMemberCount(iMemberCountOnline, iMemberCount);
+	UpdateMemberCount(iMemberCountOnline, iMemberCountTotal);
 
 	for (int i = 0; i < iMemberCountList; i++)
 	{

--- a/Client/WarFare/UIVarious.cpp
+++ b/Client/WarFare/UIVarious.cpp
@@ -573,7 +573,7 @@ void CUIKnights::Clear()
 
 	ClearLists();
 	UpdatePageNumber(1);
-	UpdateMemberCount(0);
+	UpdateMemberCount(0, 0);
 
 	m_pText_Name->SetString("");
 	m_pText_Duty->SetString("");
@@ -645,9 +645,9 @@ void CUIKnights::UpdatePageNumber(int nNewPageNr) // @Demircivi: default value f
 	m_pText_Page->SetStringAsInt(m_iPageCur);
 }
 
-void CUIKnights::UpdateMemberCount(int nMemberCount)
+void CUIKnights::UpdateMemberCount(int nMemberCountOnline, int nMemberCount)
 {
-	std::string memberCount = std::to_string(nMemberCount); // TODO: @Demircivi: it should be %d/%d, second %d is clan max member count.
+	std::string memberCount = fmt::format("{} / {}", nMemberCountOnline, nMemberCount);
 	m_pText_MemberCount->SetString(memberCount);
 }
 
@@ -908,14 +908,14 @@ void CUIKnights::MsgSend_MemberInfoAll()
 bool CUIKnights::MsgRecv_MemberInfo(Packet& pkt)
 {
 	pkt.read<int16_t>(); // @Demircivi: packet sizes, which are unused.
-	pkt.read<int16_t>(); // @Demircivi: packet sizes, which are unused.
-	pkt.read<int16_t>(); // @Demircivi: packet sizes, which are unused.
+	int iMemberCountOnline = pkt.read<int16_t>();
+	int iMemberCount = pkt.read<int16_t>(); // @Demircivi: packet sizes, which are unused.
 
-	int iMemberCount = pkt.read<int16_t>();
+	int iMemberCountList = pkt.read<int16_t>();
 
-	UpdateMemberCount(iMemberCount);
+	UpdateMemberCount(iMemberCountOnline, iMemberCount);
 
-	for (int i = 0; i < iMemberCount; i++)
+	for (int i = 0; i < iMemberCountList; i++)
 	{
 		int iNameLength = pkt.read<int16_t>();
 		__ASSERT(iNameLength > 0, "iNameLength was below 0!");

--- a/Client/WarFare/UIVarious.h
+++ b/Client/WarFare/UIVarious.h
@@ -163,7 +163,7 @@ public:
 	void ClearLists();
 
 	void UpdatePageNumber(int nNewPageNr = -1);
-	void UpdateMemberCount(int nMemberCount);
+	void UpdateMemberCount(int nMemberCountOnline, int nMemberCount);
 
 	void PreviousPageButtonHandler();
 	void NextPageButtonHandler();

--- a/Client/WarFare/UIVarious.h
+++ b/Client/WarFare/UIVarious.h
@@ -162,8 +162,8 @@ public:
 
 	void ClearLists();
 
-	void UpdatePageNumber(int nNewPageNr = -1);
-	void UpdateMemberCount(int nMemberCountOnline, int nMemberCount);
+	void UpdatePageNumber(int iNewPageNo = -1);
+	void UpdateMemberCount(int iMemberCountOnline, int iMemberCountTotal);
 
 	void PreviousPageButtonHandler();
 	void NextPageButtonHandler();


### PR DESCRIPTION
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?
The clan UI currently displays the number of users who will be rendered in the list of members. This is different between a clan leader (who gets a full list) and members (who gets an online list).

## What is the new behaviour?
The new behaviour displays the number of members online and the number of total clan members.

## Why and how did I change this?
To align with the official client behaviour. Checked the packet and the parts that were identified as unused contained the missing data needed to correctly populate the UI.

## Demo
<img width="277" height="429" alt="online" src="https://github.com/user-attachments/assets/9af4c194-9114-499d-bf9f-a7ccc35fdc4d" />

## Checklist
- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
