### PR TITLE
CUICapeVendor - Stage 1

### DIFF
--- a/Client/WarFare/GameDef.h
+++ b/Client/WarFare/GameDef.h
@@ -635,8 +635,8 @@ struct __TABLE_UI_RESRC
 	std::string szNameCheck;			// 89
 	std::string szCSWAdmin;				// 90
 	std::string szCSWTax;				// 91
-	std::string szCSWCapeList;			// 92
-	std::string szKnightCapeShop;		// 93
+	std::string szKnightCapeVendorList;	// 92
+	std::string szKnightCapeVendorShop;	// 93
 	std::string szCSWTaxCollection;		// 94
 	std::string szCSWTaxRate;			// 95
 	std::string szCSWTaxRateMsg;		// 96

--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -54,6 +54,9 @@
 #include "UIUpgradeSelect.h"
 #include "UILevelGuide.h"
 #include "UIMsgBoxOkCancel.h"
+#include "UICapeVendorList.h"
+#include "UICapeVendorShop.h"
+#include "UICapeVendorSymbol.h"
 
 #include "SubProcPerTrade.h"
 #include "CountableItemEditDlg.h"
@@ -168,6 +171,10 @@ CGameProcMain::CGameProcMain()				// r기본 생성자.. 각 변수의 역활은
 	m_pUIDead = new CUIDead();
 	m_pUIUpgradeSelect = new CUIUpgradeSelect();
 	m_pUILevelGuide = new CUILevelGuide();
+	m_pUICapeVendorList = new CUICapeVendorList();
+	m_pUICapeVendorShop = new CUICapeVendorShop();
+	m_pUICapeVendorSymbol = new CUICapeVendorSymbol();
+	m_pUICapeVendorPreview = new CUICapeVendorPreview();
 
 	m_pSubProcPerTrade = new CSubProcPerTrade();
 	m_pMagicSkillMng = new CMagicSkillMng(this);
@@ -218,6 +225,10 @@ CGameProcMain::~CGameProcMain()
 	delete m_pUIDead;
 	delete m_pUIUpgradeSelect;
 	delete m_pUILevelGuide;
+	delete m_pUICapeVendorList;
+	delete m_pUICapeVendorShop;
+	delete m_pUICapeVendorSymbol;
+	delete m_pUICapeVendorPreview;
 
 	delete m_pSubProcPerTrade;
 	delete m_pMagicSkillMng;
@@ -271,6 +282,10 @@ void CGameProcMain::ReleaseUIs()
 	m_pUICreateClanName->Release();
 	m_pUIUpgradeSelect->Release();
 	m_pUILevelGuide->Release();
+	m_pUICapeVendorList->Release();
+	m_pUICapeVendorShop->Release();
+	m_pUICapeVendorSymbol->Release();
+	m_pUICapeVendorPreview->Release();
 
 	CN3UIBase::DestroyTooltip();
 }
@@ -4134,6 +4149,46 @@ void CGameProcMain::InitUI()
 	m_pUIUpgradeSelect->SetState(UI_STATE_COMMON_NONE);
 	m_pUIUpgradeSelect->SetStyle(m_pUIUpgradeSelect->GetStyle() | UISTYLE_USER_MOVE_HIDE | UISTYLE_SHOW_ME_ALONE);
 
+	// Cape Vendor - List
+	m_pUICapeVendorList->Init(s_pUIMgr);
+	m_pUICapeVendorList->LoadFromFile(pTbl->szKnightCapeVendorList);
+	m_pUICapeVendorList->SetVisibleWithNoSound(false);
+	m_pUICapeVendorList->SetStyle(UISTYLE_USER_MOVE_HIDE);
+	rc = m_pUICapeVendorList->GetRegion();
+	iX = (iW - (rc.right - rc.left)) / 2;
+	iY = (iH - (rc.bottom - rc.top)) / 2;
+	m_pUICapeVendorList->SetPos(iX, iY);
+
+	// Cape Vendor - Shop
+	m_pUICapeVendorShop->Init(s_pUIMgr);
+	m_pUICapeVendorShop->LoadFromFile(pTbl->szKnightCapeVendorShop);
+	m_pUICapeVendorShop->SetVisibleWithNoSound(false);
+	m_pUICapeVendorShop->SetStyle(UISTYLE_USER_MOVE_HIDE);
+	rc = m_pUICapeVendorShop->GetRegion();
+	iX = (iW - (rc.right - rc.left)) / 2;
+	iY = (iH - (rc.bottom - rc.top)) / 2;
+	m_pUICapeVendorShop->SetPos(iX, iY);
+
+	// Cape Vendor - Symbol
+	m_pUICapeVendorSymbol->Init(s_pUIMgr);
+	m_pUICapeVendorSymbol->LoadFromFile(pTbl->szClanLogo);
+	m_pUICapeVendorSymbol->SetVisibleWithNoSound(false);
+	m_pUICapeVendorSymbol->SetStyle(UISTYLE_USER_MOVE_HIDE);
+	rc = m_pUICapeVendorSymbol->GetRegion();
+	iX = (iW - (rc.right - rc.left)) / 2;
+	iY = (iH - (rc.bottom - rc.top)) / 2;
+	m_pUICapeVendorSymbol->SetPos(iX, iY);
+
+	// Cape Vendor - Symbol Preview
+	m_pUICapeVendorPreview->Init(s_pUIMgr);
+	m_pUICapeVendorPreview->LoadFromFile(pTbl->szChrClanLogo);
+	m_pUICapeVendorPreview->SetVisibleWithNoSound(false);
+	m_pUICapeVendorPreview->SetStyle(UISTYLE_USER_MOVE_HIDE);
+	rc = m_pUICapeVendorPreview->GetRegion();
+	iX = (iW - (rc.right - rc.left)) / 2;
+	iY = (iH - (rc.bottom - rc.top)) / 2;
+	m_pUICapeVendorPreview->SetPos(iX, iY);
+
 	//ui level guide
 	m_pUILevelGuide->Init(s_pUIMgr);
 	m_pUILevelGuide->LoadFromFile(pTbl->szLvlGuide);
@@ -6204,6 +6259,9 @@ void CGameProcMain::MsgRecv_Knights(Packet& pkt)
 	case N3_SP_KNIGHTS_JOIN_REQ:
 		MsgRecv_Knigts_Join_Req(pkt);
 		break;
+	case N3_SP_KNIGHTS_CAPE_VENDOR: 
+		MsgRecv_Knights_Cape_Vendor(pkt);
+		break;
 
 /*	case N3_SP_KNIGHTS_APPOINT_CHIEF: //단장 임명 - 가입허가와 같음
 		{
@@ -7217,6 +7275,15 @@ void CGameProcMain::MsgRecv_Knigts_Join_Req(Packet& pkt)
 		}
 		break;
 	}
+}
+
+
+void CGameProcMain::MsgRecv_Knights_Cape_Vendor(Packet& pkt)
+{
+	uint16_t iDK1 = pkt.read<uint16_t>();
+	uint16_t iDK2 = pkt.read<uint16_t>();
+
+	m_pUICapeVendorList->SetVisible(true);
 }
 
 int CGameProcMain::MsgRecv_VersionCheck(Packet& pkt) // virtual

--- a/Client/WarFare/GameProcMain.h
+++ b/Client/WarFare/GameProcMain.h
@@ -59,6 +59,10 @@ public:
 
 	class CUIUpgradeSelect*		m_pUIUpgradeSelect;
 	class CUILevelGuide*		m_pUILevelGuide;
+	class CUICapeVendorList*	m_pUICapeVendorList;			// Cape Vendor List
+	class CUICapeVendorShop*	m_pUICapeVendorShop;			// Cape Vendor Shop
+	class CUICapeVendorSymbol*	m_pUICapeVendorSymbol;			// Cape Vendor Symbol
+	class CUICapeVendorPreview* m_pUICapeVendorPreview;			// Cape Vendor Symbol Preview
 
 	class CN3Shape*				m_pTargetSymbol;				// 플레이어가 타겟으로 잡은 캐릭터의 위치위에 그리면 된다..
 
@@ -202,6 +206,7 @@ protected:
 	void	MsgRecv_Knights_GradeChangeAll(Packet& pkt);
 	void	MsgRecv_Knights_Duty_Change(Packet& pkt);
 	void	MsgRecv_Knigts_Join_Req(Packet& pkt);
+	void	MsgRecv_Knights_Cape_Vendor(Packet& pkt);
 	void	MsgRecv_ItemUpgrade(Packet& pkt);
 
 public:

--- a/Client/WarFare/PacketDef.h
+++ b/Client/WarFare/PacketDef.h
@@ -93,6 +93,7 @@ const int SOCKET_PORT_LOGIN = 15100;
 								N3_SP_KNIGHTS_STASH =				0x0F, // 기사단 창고
 								N3_SP_KNIGHTS_DUTY_CHANGE =			0x10, // 멤버의 직위 변경.. 해당 멤버에게 간다.. Recv - s1(Knights ID) b1(직위);
 								N3_SP_KNIGHTS_JOIN_REQ =			0x11, // 기사단 인덱스
+								N3_SP_KNIGHTS_CAPE_VENDOR =			0x1B, // UI for Cape Vendor
 								N3_SP_KNIGHTS_UNKNOWN };
 
 	enum e_SubPacket_KNights_Create {	N3_SP_KNIGHTS_CREATE_FAIL_DBFAIL =			0x00,

--- a/Client/WarFare/UICapeVendorList.cpp
+++ b/Client/WarFare/UICapeVendorList.cpp
@@ -1,0 +1,73 @@
+﻿// UICapeVendorList.cpp: implementation of the CUICapeVendorList class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#include "stdafx.h"
+#include "GameDef.h"
+#include "GameBase.h"
+#include "GameProcMain.h"
+#include "GameProcedure.h"
+#include "UICapeVendorList.h"
+#include "UICapeVendorShop.h"
+#include "UICapeVendorSymbol.h"
+#include "UIManager.h"
+#include "APISocket.h"
+
+
+//////////////////////////////////////////////////////////////////////
+// Construction/Destruction
+//////////////////////////////////////////////////////////////////////
+
+CUICapeVendorList::CUICapeVendorList()
+{
+}
+
+CUICapeVendorList::~CUICapeVendorList()
+{
+}
+
+bool CUICapeVendorList::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
+{
+	if (pSender == nullptr) return false;
+
+	if (dwMsg == UIMSG_BUTTON_CLICK)
+	{
+		if (pSender->m_szID == "btn_close")
+			SetVisible(false);
+
+		if (pSender->m_szID == "btn_mantle")
+		{
+			SetVisible(false);
+			CGameProcMain::s_pProcMain->m_pUICapeVendorShop->SetVisible(true);
+		}
+
+		if (pSender->m_szID == "btn_application")
+		{
+			SetVisible(false);
+			CGameProcMain::s_pProcMain->m_pUICapeVendorSymbol->SetVisible(true);
+		}
+	}
+	return CN3UIBase::ReceiveMessage(pSender, dwMsg);
+}
+
+bool CUICapeVendorList::OnKeyPress(int iKey)
+{
+	switch (iKey)
+	{
+		case DIK_ESCAPE:
+			SetVisible(false);
+			return true;
+	}
+
+	return CN3UIBase::OnKeyPress(iKey);
+}
+
+void CUICapeVendorList::SetVisible(bool bVisible)
+{
+	CN3UIBase::SetVisible(bVisible);
+
+	if (bVisible)
+		CGameProcedure::s_pUIMgr->SetVisibleFocusedUI(this);
+	else
+		CGameProcedure::s_pUIMgr->ReFocusUI();
+}

--- a/Client/WarFare/UICapeVendorList.h
+++ b/Client/WarFare/UICapeVendorList.h
@@ -1,0 +1,27 @@
+﻿// UICapeVendorList.h: interface for the CUICapeVendorList class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#ifndef UICAPEVENDORLIST_H_INCLUDED
+#define UICAPEVENDORLIST_H_INCLUDED
+
+#if _MSC_VER > 1000
+#pragma once
+#endif // _MSC_VER > 1000
+
+#include <N3Base/N3UIBase.h>
+#include <N3Base/N3UIButton.h>
+
+class CUICapeVendorList : public CN3UIBase
+{
+protected:
+
+public:
+	CUICapeVendorList();
+	~CUICapeVendorList() override;
+	void SetVisible(bool bVisible) override;
+	bool ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg) override;
+	bool OnKeyPress(int iKey) override;
+};
+
+#endif // UICAPEVENDORLIST_H_INCLUDED

--- a/Client/WarFare/UICapeVendorShop.cpp
+++ b/Client/WarFare/UICapeVendorShop.cpp
@@ -1,0 +1,61 @@
+﻿// UICapeVendorShop.cpp: implementation of the CUICapeVendorShop class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#include "stdafx.h"
+#include "GameDef.h"
+#include "GameBase.h"
+#include "GameProcedure.h"
+#include "UICapeVendorShop.h"
+#include "UIManager.h"
+#include "PlayerOtherMgr.h"
+#include "APISocket.h"
+
+#include <N3Base/N3UIString.h>
+#include <N3Base/N3UIImage.h>
+#include <N3Base/N3UIButton.h>
+#include <N3Base/N3UITooltip.h>
+
+//////////////////////////////////////////////////////////////////////
+// Construction/Destruction
+//////////////////////////////////////////////////////////////////////
+
+CUICapeVendorShop::CUICapeVendorShop()
+{}
+
+CUICapeVendorShop::~CUICapeVendorShop()
+{}
+
+bool CUICapeVendorShop::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
+{
+	if (pSender == nullptr) return false;
+
+	if (dwMsg == UIMSG_BUTTON_CLICK)
+	{
+		if (pSender->m_szID == "btn_cancel")
+			SetVisible(false);
+	}
+	return CN3UIBase::ReceiveMessage(pSender, dwMsg);
+}
+
+bool CUICapeVendorShop::OnKeyPress(int iKey)
+{
+	switch (iKey)
+	{
+		case DIK_ESCAPE:
+			SetVisible(false);
+			return true;
+	}
+
+	return CN3UIBase::OnKeyPress(iKey);
+}
+
+void CUICapeVendorShop::SetVisible(bool bVisible)
+{
+	CN3UIBase::SetVisible(bVisible);
+
+	if (bVisible)
+		CGameProcedure::s_pUIMgr->SetVisibleFocusedUI(this);
+	else
+		CGameProcedure::s_pUIMgr->ReFocusUI();
+}

--- a/Client/WarFare/UICapeVendorShop.h
+++ b/Client/WarFare/UICapeVendorShop.h
@@ -1,0 +1,38 @@
+﻿// UICapeVendorShop.h: interface for the CUICapeVendorShop class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#ifndef UICAPEVENDORSHOP_H_INCLUDED
+#define UICAPEVENDORSHOP_H_INCLUDED
+
+#if _MSC_VER > 1000
+#pragma once
+#endif // _MSC_VER > 1000
+
+#include <N3Base/N3UIBase.h>
+#include <N3Base/N3UIButton.h>
+
+
+class Packet;
+class CUICapeVendorShop : public CN3UIBase
+{
+protected:
+	CN3UIButton* m_pBtnLeft;
+	CN3UIButton* m_pBtnRight;
+	CN3UIButton* m_pBtnColorUp;
+	CN3UIButton* m_pBtnColorDown;
+	CN3UIButton* m_pBtnPatternUp;
+	CN3UIButton* m_pBtnPatternDown;
+	CN3UIButton* m_pBtnCancel;
+	CN3UIButton* m_pBtnPurchase;
+
+public:
+	CUICapeVendorShop();
+	~CUICapeVendorShop() override;
+	void SetVisible(bool bVisible) override;
+	bool ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg) override;
+	bool OnKeyPress(int iKey) override;
+
+};
+
+#endif // UICAPEVENDORSHOP_H_INCLUDED

--- a/Client/WarFare/UICapeVendorSymbol.cpp
+++ b/Client/WarFare/UICapeVendorSymbol.cpp
@@ -1,0 +1,116 @@
+﻿// UICapeVendorSymbol.cpp: implementation of the UICapeVendorSymbol and CUICapeVendorPreview class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#include "stdafx.h"
+#include "GameDef.h"
+#include "GameBase.h"
+#include "GameProcMain.h"
+#include "GameProcedure.h"
+#include "UICapeVendorSymbol.h"
+#include "UIManager.h"
+#include "APISocket.h"
+
+
+//////////////////////////////////////////////////////////////////////
+// Construction/Destruction - Symbol
+//////////////////////////////////////////////////////////////////////
+
+
+CUICapeVendorSymbol::CUICapeVendorSymbol()
+{}
+
+CUICapeVendorSymbol::~CUICapeVendorSymbol()
+{}
+
+bool CUICapeVendorSymbol::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
+{
+	if (pSender == nullptr) return false;
+
+	if (dwMsg == UIMSG_BUTTON_CLICK)
+	{
+		if (pSender->m_szID == "btn_cancel")
+			SetVisible(false);
+
+		if (pSender->m_szID == "btn_ok")
+		{
+			SetVisible(false);
+			CGameProcMain::s_pProcMain->m_pUICapeVendorPreview->SetVisible(true);
+
+		}
+	}
+	return CN3UIBase::ReceiveMessage(pSender, dwMsg);
+}
+
+bool CUICapeVendorSymbol::OnKeyPress(int iKey)
+{
+	switch (iKey)
+	{
+		case DIK_ESCAPE:
+			SetVisible(false);
+			return true;
+	}
+
+	return CN3UIBase::OnKeyPress(iKey);
+}
+
+void CUICapeVendorSymbol::SetVisible(bool bVisible)
+{
+	CN3UIBase::SetVisible(bVisible);
+
+	if (bVisible)
+		CGameProcedure::s_pUIMgr->SetVisibleFocusedUI(this);
+	else
+		CGameProcedure::s_pUIMgr->ReFocusUI();
+}
+
+
+//////////////////////////////////////////////////////////////////////
+// Construction/Destruction - Symbol Preview
+//////////////////////////////////////////////////////////////////////
+
+
+CUICapeVendorPreview::CUICapeVendorPreview()
+{}
+
+CUICapeVendorPreview::~CUICapeVendorPreview()
+{}
+
+bool CUICapeVendorPreview::ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg)
+{
+	if (pSender == nullptr) return false;
+
+	if (dwMsg == UIMSG_BUTTON_CLICK)
+	{
+		if (pSender->m_szID == "btn_cancel")
+			SetVisible(false);
+
+		if (pSender->m_szID == "btn_ok")
+		{
+			// TO DO: Build out
+		}
+	}
+	return CN3UIBase::ReceiveMessage(pSender, dwMsg);
+}
+
+bool CUICapeVendorPreview::OnKeyPress(int iKey)
+{
+	switch (iKey)
+	{
+		case DIK_ESCAPE:
+			SetVisible(false);
+			return true;
+	}
+
+	return CN3UIBase::OnKeyPress(iKey);
+}
+
+void CUICapeVendorPreview::SetVisible(bool bVisible)
+{
+	CN3UIBase::SetVisible(bVisible);
+
+	if (bVisible)
+		CGameProcedure::s_pUIMgr->SetVisibleFocusedUI(this);
+	else
+		CGameProcedure::s_pUIMgr->ReFocusUI();
+}

--- a/Client/WarFare/UICapeVendorSymbol.h
+++ b/Client/WarFare/UICapeVendorSymbol.h
@@ -1,0 +1,42 @@
+﻿// UICapeVendorSymbol.h: interface for the CUICapeVendorSymbol and CUICapeVendorSymbolPreview class.
+//
+//////////////////////////////////////////////////////////////////////
+
+#ifndef UICAPEVENDORSYMBOL_H_INCLUDED
+#define UICAPEVENDORSYMBOL_H_INCLUDED
+
+#if _MSC_VER > 1000
+#pragma once
+#endif // _MSC_VER > 1000
+
+#include <N3Base/N3UIBase.h>
+#include <N3Base/N3UIButton.h>
+
+
+class CUICapeVendorSymbol : public CN3UIBase
+{
+protected:
+
+public:
+	CUICapeVendorSymbol();
+	~CUICapeVendorSymbol() override;
+	void SetVisible(bool bVisible) override;
+	bool ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg) override;
+	bool OnKeyPress(int iKey) override;
+
+};
+
+class CUICapeVendorPreview : public CN3UIBase
+{
+protected:
+
+public:
+	CUICapeVendorPreview();
+	~CUICapeVendorPreview() override;
+	void SetVisible(bool bVisible) override;
+	bool ReceiveMessage(CN3UIBase* pSender, uint32_t dwMsg) override;
+	bool OnKeyPress(int iKey) override;
+
+};
+
+#endif // UICAPEVENDORSYMBOL_H_INCLUDED

--- a/Client/WarFare/WarFare.vcxproj
+++ b/Client/WarFare/WarFare.vcxproj
@@ -153,6 +153,9 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="SubProcPerTrade.cpp" />
+    <ClCompile Include="UICapeVendorSymbol.cpp" />
+    <ClCompile Include="UICapeVendorList.cpp" />
+    <ClCompile Include="UICapeVendorShop.cpp" />
     <ClCompile Include="UICharacterCreate.cpp" />
     <ClCompile Include="UICharacterSelect.cpp" />
     <ClCompile Include="UIChat.cpp" />
@@ -238,6 +241,9 @@
     <ClInclude Include="N3River.h" />
     <ClInclude Include="StdAfx.h" />
     <ClInclude Include="text_resources.h" />
+    <ClInclude Include="UICapeVendorSymbol.h" />
+    <ClInclude Include="UICapeVendorList.h" />
+    <ClInclude Include="UICapeVendorShop.h" />
     <ClInclude Include="UICmdEdit.h" />
     <ClInclude Include="UICmdList.h" />
     <ClInclude Include="ItemRepairMgr.h" />

--- a/Client/WarFare/WarFare.vcxproj.filters
+++ b/Client/WarFare/WarFare.vcxproj.filters
@@ -330,6 +330,15 @@
     <ClCompile Include="UIMsgBoxOkCancel.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="UICapeVendorList.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UICapeVendorShop.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UICapeVendorSymbol.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameProcedure.h">
@@ -669,6 +678,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="UIMsgBoxOkCancel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UICapeVendorList.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UICapeVendorShop.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UICapeVendorSymbol.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Feature

## What is the current behaviour?
The cape vendor [mantle] vendor does not currently work in the source client.

## What is the new behaviour?
The UI windows for the cape vendor open and close. This is a first step in implementing the vendor.

## Why and how did I change this?
Linked up the UIF files and created the classes for the various cape vendor UIs. First step in aligning with the official client. It is easier to push this in smaller stages instead of 1 big PR given my available time at the moment.

## Demo

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [x] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
