### PR TITLE
Fix “buffer is too small error” in DBAGENT::GetAllCharID

### DIFF
--- a/Server/Aujard/DBAgent.cpp
+++ b/Server/Aujard/DBAgent.cpp
@@ -724,6 +724,8 @@ bool CDBAgent::GetAllCharID(const char* accountId, char* charId1_, char* charId2
 		return false;
 	}
 
+	if(charId1.length() > MAX_ID_SIZE)
+		charId1.resize(MAX_ID_SIZE);
 	if (strcpy_s(charId1_, MAX_ID_SIZE + 1, charId1.c_str()))
 	{
 		spdlog::error("DBAgent::GetAllCharID: failed to write charId1(len: {}, val: {}) to charId1_",
@@ -731,6 +733,8 @@ bool CDBAgent::GetAllCharID(const char* accountId, char* charId1_, char* charId2
 		return false;
 	}
 
+	if (charId2.length() > MAX_ID_SIZE)
+		charId2.resize(MAX_ID_SIZE);
 	if (strcpy_s(charId2_, MAX_ID_SIZE + 1, charId2.c_str()))
 	{
 		spdlog::error("DBAgent::GetAllCharID: failed to write charId2(len: {}, val: {}) to charId2_",
@@ -738,6 +742,8 @@ bool CDBAgent::GetAllCharID(const char* accountId, char* charId1_, char* charId2
 		return false;
 	}
 
+	if (charId3.length() > MAX_ID_SIZE)
+		charId3.resize(MAX_ID_SIZE);
 	if (strcpy_s(charId3_, MAX_ID_SIZE + 1, charId3.c_str()))
 	{
 		spdlog::error("DBAgent::GetAllCharID: failed to write charId3(len: {}, val: {}) to charId3_",


### PR DESCRIPTION
The test  DB  which shared in the README  causes "buffer  is too small error" on the character selection screen.

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## What is the current behaviour?
It throws "buffer too small error" on the character selection screen and characters don’t appear.

<img width="1029" height="793" alt="Ekran görüntüsü 2025-09-04 013432" src="https://github.com/user-attachments/assets/91fd8b98-5d3c-454a-b511-b5fa9f10ce4d" />


## What is the new behaviour?
The characters are visible and selectable.

## Why and how did I change this?
Added a length check and enforced the max limit.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code.
- [ ] Where applicable, I have checked to make sure that this doesn't introduce incompatible behaviour with the official 1.298 server (e.g. unofficial opcodes or behavioural differences).
- [x] I have checked to make sure that this change does not already exist in the codebase in some fashion (e.g. UI already implemented under a different name).
