### PR TITLE
Add DB_COMPAT_PADDED_NAMES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ x64/
 .int/
 lib/
 warfare_config.h
+server_config.h
 *.idea
 All.sln.DotSettings.user
 *.txt

--- a/Server/AIServer/stdafx.h
+++ b/Server/AIServer/stdafx.h
@@ -35,6 +35,8 @@
 #include "define.h"			// define
 //#include "extern.h"			// 전역 객체
 
+#include <shared/server_config.h>
+
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.
 

--- a/Server/Aujard/StdAfx.h
+++ b/Server/Aujard/StdAfx.h
@@ -24,6 +24,8 @@
 #include <afxdb.h>
 #include <afxtempl.h>
 
+#include <shared/server_config.h>
+
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.
 

--- a/Server/Ebenezer/EbenezerDlg.cpp
+++ b/Server/Ebenezer/EbenezerDlg.cpp
@@ -3099,8 +3099,11 @@ BOOL CEbenezerDlg::LoadServerResourceTable()
 		return FALSE;
 	}
 
+	// NOTE: Not a name, but still falls under the same umbrella - this won't be an issue with DBs not padding these.
+#if defined(DB_COMPAT_PADDED_NAMES)
 	for (auto& [_, serverResource] : tableMap)
 		rtrim(serverResource->Resource);
+#endif
 
 	m_ServerResourceTableMap.Swap(tableMap);
 	return TRUE;
@@ -3137,27 +3140,37 @@ BOOL CEbenezerDlg::LoadAllKnights()
 			pKnights->m_byFlag = row.Flag;
 			pKnights->m_byNation = row.Nation;
 
+#if defined(DB_COMPAT_PADDED_NAMES)
 			rtrim(row.Name);
+#endif
 			strcpy(pKnights->m_strName, row.Name.c_str());
 
+#if defined(DB_COMPAT_PADDED_NAMES)
 			rtrim(row.Chief);
+#endif
 			strcpy(pKnights->m_strChief, row.Chief.c_str());
 
 			if (row.ViceChief1.has_value())
 			{
+#if defined(DB_COMPAT_PADDED_NAMES)
 				rtrim(*row.ViceChief1);
+#endif
 				strcpy(pKnights->m_strViceChief_1, row.ViceChief1->c_str());
 			}
 
 			if (row.ViceChief2.has_value())
 			{
+#if defined(DB_COMPAT_PADDED_NAMES)
 				rtrim(*row.ViceChief2);
+#endif
 				strcpy(pKnights->m_strViceChief_2, row.ViceChief2->c_str());
 			}
 
 			if (row.ViceChief3.has_value())
 			{
+#if defined(DB_COMPAT_PADDED_NAMES)
 				rtrim(*row.ViceChief3);
+#endif
 				strcpy(pKnights->m_strViceChief_3, row.ViceChief3->c_str());
 			}
 
@@ -3208,7 +3221,9 @@ BOOL CEbenezerDlg::LoadAllKnightsUserData()
 			ModelType row = {};
 			recordset.get_ref(row);
 
+#if defined(DB_COMPAT_PADDED_NAMES)
 			rtrim(row.UserId);
+#endif
 			m_KnightsManager.AddKnightsUser(row.KnightsId, row.UserId.c_str());
 		}
 		while (recordset.next());
@@ -3593,11 +3608,12 @@ BOOL CEbenezerDlg::LoadKnightsRankTable()
 			recordset.get_ref(row);
 		
 			CKnights* pKnights = m_KnightsMap.GetData(row.Index);
-
-			rtrim(row.Name);
-
 			if (pKnights == nullptr)
 				continue;
+
+#if defined(DB_COMPAT_PADDED_NAMES)
+			rtrim(row.Name);
+#endif
 
 			if (pKnights->m_byNation == KARUS)
 			{

--- a/Server/Ebenezer/StdAfx.h
+++ b/Server/Ebenezer/StdAfx.h
@@ -28,6 +28,8 @@
 #include <afxtempl.h>
 #include <afxdb.h>
 
+#include <shared/server_config.h>
+
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.
 

--- a/Server/ItemManager/StdAfx.h
+++ b/Server/ItemManager/StdAfx.h
@@ -24,6 +24,8 @@
 #include <afxdb.h>
 #include <afxtempl.h>
 
+#include <shared/server_config.h>
+
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.
 

--- a/Server/VersionManager/stdafx.h
+++ b/Server/VersionManager/stdafx.h
@@ -28,6 +28,8 @@
 #include <afxtempl.h>
 #include <afxdb.h>
 
+#include <shared/server_config.h>
+
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.
 

--- a/Server/shared/server_config.h.default
+++ b/Server/shared/server_config.h.default
@@ -1,0 +1,3 @@
+#pragma once
+
+#define DB_COMPAT_PADDED_NAMES

--- a/Server/shared/shared.vcxproj
+++ b/Server/shared/shared.vcxproj
@@ -73,6 +73,13 @@
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;VC_EXTRALEAN;WIN32;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
+    <PreBuildEvent>
+      <Command>
+        if exist "$(ProjectDir)server_config.h.default" if not exist "$(ProjectDir)server_config.h" (
+          copy /Y "$(ProjectDir)server_config.h.default" "$(ProjectDir)server_config.h"
+        )
+      </Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -159,6 +166,7 @@
     <ClInclude Include="lzf.h" />
     <ClInclude Include="Packet.h" />
     <ClInclude Include="packets.h" />
+    <ClInclude Include="server_config.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="STLMap.h" />
     <ClInclude Include="StringConversion.h" />

--- a/Server/shared/shared.vcxproj.filters
+++ b/Server/shared/shared.vcxproj.filters
@@ -107,5 +107,8 @@
     <ClInclude Include="logger.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="server_config.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This allows for databases where the names are padded (due to being stored in CHAR(N) columns instead of VARCHAR(N)). Our existing database has a few such cases, combined with some data remnants from when a column was padded but is no longer.

This will be entirely replaced in future, but for now we'll just allow for such cases.

For future reference, an exhaustive list of all unnecessarily padded columns and fields in procedures:
BATTLE
COPY_SERIAL_ITEM
FRIEND_LIST
HACKTOOL_USERLOG
HERO_USER
ITEM (data only)
ITEM_UPGRADE
KNIGHTS_RATING
RENTAL_ITEM
RENTAL_ITEM_LIST
TERM_ITEM
USER_EDITOR
USER_EDITOR_TERM
USER_KNIGHTS_RANK
USER_PERSONAL_RANK
USER_RENTAL_ITEM
USER_SAVED_MAGIC
USERDATA_SKILLSHORTCUT
WAREHOUSE
WEB_ITEMMALL
WEB_ITEMMALL_LOG

CHANGE_CASTLE_COMMERCE
CREATE_KNIGHTS
CREATE_KNIGHTS2
DELETE_FRIEND_LIST
DELETE_KNIGHTS
EXEC_KNIGHTS_USER
INSERT_FRIEND_LIST
INSERT_HACKTOOL_USER
KING_CANDIDACY_NOTICE_BOARD_PROC
KING_CANDIDACY_RECOMMEND
KING_IMPEACHMENT_ELECTION
KING_IMPEACHMENT_REQUEST_ELECTION
KING_INSERT_PRIZE_EVENT
KING_UPDATE_IMPEACHMENT_STATUS
LOAD_RENTAL_DATA
LOAD_SAVED_MAGIC
LOAD_WEB_ITEMMALL
NATION_SELECT
RENTAL_ITEM_CANCEL
RENTAL_ITEM_DESTORY
RENTAL_ITEM_DURABILITY_UPDATE
RENTAL_ITEM_LEND
RENTAL_ITEM_REGISTER
UPDATE_BATTLE_HERO
UPDATE_KNIGHTS
UPDATE_KNIGHTS_WAR
UPDATE_PERSONAL_RANK (KPERSONAL_RANK, EPERSONAL_RANK)
UPDATE_SIEGE_CHALLENGER
USER_KNIGHTS_RATING_UPDATE (+ KUSER_RATING, EUSER_RATING)

Closes #479 