### PR TITLE
More informative server connection behaviour

### DIFF
--- a/Server/AIServer/ServerDlg.cpp
+++ b/Server/AIServer/ServerDlg.cpp
@@ -391,27 +391,43 @@ BOOL CServerDlg::OnInitDialog()
 /// \returns true when successful, otherwise false
 bool CServerDlg::ListenByZone()
 {
-	int port = 0;
-	if (m_byZone == KARUS_ZONE
-		|| m_byZone == UNIFY_ZONE)
+	int port = GetListenPortByZone();
+	if (port < 0)
 	{
-		port = AI_KARUS_SOCKET_PORT;
-	}
-	else if (m_byZone == ELMORAD_ZONE)
-	{
-		port = AI_ELMO_SOCKET_PORT;
-	}
-	else if (m_byZone == BATTLE_ZONE)
-	{
-		port = AI_BATTLE_SOCKET_PORT;
+		spdlog::error("ServerDlg::ListenByZone: failed to associate listen port for zone {}", m_byZone);
+		return false;
 	}
 
-	if (!m_Iocport.Listen(port)) {
+	if (!m_Iocport.Listen(port))
+	{
 		spdlog::error("ServerDlg::ListenByZone: failed to listen on port {}", port);
 		return false;
 	}
-	
+
+	AddOutputMessage(fmt::format("Listening on 0.0.0.0:{}", port));
 	return true;
+}
+
+/// \brief fetches the listen port associated with m_byZone
+/// \see m_byZone
+/// \returns the associated listen port or -1 if invalid
+int CServerDlg::GetListenPortByZone() const
+{
+	switch (m_byZone)
+	{
+		case KARUS_ZONE:
+		case UNIFY_ZONE:
+			return AI_KARUS_SOCKET_PORT;
+
+		case ELMORAD_ZONE:
+			return AI_ELMO_SOCKET_PORT;
+
+		case BATTLE_ZONE:
+			return AI_BATTLE_SOCKET_PORT;
+
+		default:
+			return -1;
+	}
 }
 
 void CServerDlg::OnSysCommand(UINT nID, LPARAM lParam)

--- a/Server/AIServer/ServerDlg.h
+++ b/Server/AIServer/ServerDlg.h
@@ -198,6 +198,11 @@ protected:
 	/// \see m_byZone
 	/// \returns true when successful, otherwise false
 	bool ListenByZone();
+
+	/// \brief fetches the listen port associated with m_byZone
+	/// \see m_byZone
+	/// \returns the associated listen port or -1 if invalid
+	int GetListenPortByZone() const;
 	
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	afx_msg void OnPaint();

--- a/Server/Ebenezer/EbenezerDlg.h
+++ b/Server/Ebenezer/EbenezerDlg.h
@@ -127,7 +127,8 @@ public:
 	void KillUser(const char* strbuff);
 	void Send_PartyMember(int party, char* pBuf, int len);
 	void Send_KnightsMember(int index, char* pBuf, int len, int zone = 100);
-	BOOL AISocketConnect(int zone, int flag = 0);
+	BOOL AISocketConnect(int zone, bool flag, std::string* errorReason = nullptr);
+	int GetAIServerPort() const;
 	int GetRegionNpcIn(C3DMap* pMap, int region_x, int region_z, char* buff, int& t_count);
 	BOOL LoadNoticeData();
 	int GetZoneIndex(int zonenumber);

--- a/Server/VersionManager/VersionManagerDlg.h
+++ b/Server/VersionManager/VersionManagerDlg.h
@@ -80,11 +80,7 @@ protected:
 public:
 	void ReportTableLoadError(const recordset_loader::Error& err, const char* source);
 
-	/// \brief clears the OutputList text area and regenerates default output
-	/// \see _outputList
-	void ResetOutputList();
-
-	// \brief updates the last/latest version and resets the output list
+	// \brief updates the last/latest version
 	void SetLastVersion(int lastVersion);
 
 protected:


### PR DESCRIPTION
The servers will now report the main port they're listening on and when it allows connections (it can listen, but block until connections are allowed).

Additionally, regarding AI, we report and log the IP:port we're connecting to.

Removed the awkward ResetOutputList() behaviour so we can log appropriately. This will all be changed with a console at some point, so this really doesn't make sense to keep anyway.

Resolves #482