### PR TITLE
Reset lighting entering the CGameProcMain scene

### DIFF
--- a/Client/WarFare/GameProcMain.cpp
+++ b/Client/WarFare/GameProcMain.cpp
@@ -281,6 +281,11 @@ void CGameProcMain::Init()
 	m_pLightMgr->Release();
 	s_pEng->SetDefaultLight(m_pLightMgr->Light(0), m_pLightMgr->Light(1), m_pLightMgr->Light(2));
 
+	// Reset lighting from previous scenes.
+	// Our scene will setup lighting as needed.
+	for (int i = 0; i < 8; i++)
+		s_lpD3DDev->LightEnable(i, FALSE);
+
 	int i = 0;
 	for (uint32_t resource = IDS_CMD_WHISPER; resource <= IDS_CMD_LOCATION; resource++)
 		s_szCmdMsg[i++] = fmt::format_text_resource(resource);


### PR DESCRIPTION
We should reset these so old states from, for example, CGameProcCharacterSelect, don't contaminate.
CGameProcMain will setup its own light states.

This fixes a bug on some drivers (VMWare's, at least) where these previously enabled light states somehow completely break lighting where they don't on typical drivers:
<img width="1021" height="772" alt="image" src="https://github.com/user-attachments/assets/080d0bf2-c828-4983-8930-c4a036423746" />