### PR TITLE
Update sound config to globally disable/enable as per official

### DIFF
--- a/Client/N3Base/N3Base.h
+++ b/Client/N3Base/N3Base.h
@@ -133,8 +133,11 @@ struct __Options
 	int iViewDist;
 	int iEffectSndDist;			// 이펙트 사운드 거리
 
-	bool bSndEnable;		// 0 - High, 1 - Low
+	bool bSndEnable;
+	bool bSndBgmEnable;
+	bool bSndEffectEnable;
 	bool bSndDuplicated;	// 중복된 음원 사용
+
 	bool bWindowCursor;		// 0 - 게임에서 그려주는 커서 1 - 윈도우 커서 사용
 	bool bWindowMode;
 
@@ -152,6 +155,8 @@ struct __Options
 		iViewDist = 512;
 		iEffectSndDist = 48;
 		bSndEnable = false;
+		bSndBgmEnable = false;
+		bSndEffectEnable = false;
 		bSndDuplicated = false;
 		bWindowCursor = true;
 		bWindowMode = false;

--- a/Client/N3Base/N3SndMgr.cpp
+++ b/Client/N3Base/N3SndMgr.cpp
@@ -50,7 +50,19 @@ CN3SndObj* CN3SndMgr::CreateObj(int iID, e_SndType eType)
 
 CN3SndObj* CN3SndMgr::CreateObj(std::string szFN, e_SndType eType)
 {
-	if(!m_bSndEnable) return nullptr;
+	if (!m_bSndEnable)
+		return nullptr;
+
+	if (eType == SNDTYPE_STREAM)
+	{
+		if (!CN3Base::s_Options.bSndBgmEnable)
+			return nullptr;
+	}
+	else
+	{
+		if (!CN3Base::s_Options.bSndEffectEnable)
+			return nullptr;
+	}
 
 	if (!PreprocessFilename(szFN))
 		return nullptr;
@@ -86,6 +98,9 @@ CN3SndObj* CN3SndMgr::CreateObj(std::string szFN, e_SndType eType)
 
 CN3SndObjStream* CN3SndMgr::CreateStreamObj(std::string szFN)
 {
+	if (!CN3Base::s_Options.bSndBgmEnable)
+		return nullptr;
+
 	if (!PreprocessFilename(szFN))
 		return nullptr;
 
@@ -103,10 +118,11 @@ CN3SndObjStream* CN3SndMgr::CreateStreamObj(std::string szFN)
 
 CN3SndObjStream* CN3SndMgr::CreateStreamObj(int iID)
 {
-	TABLE_SOUND* pTbl = m_Tbl_Source.Find(iID);
-	if(pTbl==nullptr) return nullptr;
+	__TABLE_SOUND* pTbl = m_Tbl_Source.Find(iID);
+	if (pTbl == nullptr)
+		return nullptr;
 
-	return this->CreateStreamObj(pTbl->szFN);
+	return CreateStreamObj(pTbl->szFN);
 }
 
 void CN3SndMgr::ReleaseStreamObj(CN3SndObjStream** ppObj)
@@ -314,7 +330,11 @@ void CN3SndMgr::Release()
 // 대신 위치는 처음 한번밖에 지정할 수 없다.
 bool CN3SndMgr::PlayOnceAndRelease(int iSndID, const _D3DVECTOR* pPos)
 {
-	if(!m_bSndEnable) return false;
+	if (!m_bSndEnable)
+		return false;
+
+	if (!CN3Base::s_Options.bSndEffectEnable)
+		return false;
 
 	TABLE_SOUND* pTbl = m_Tbl_Source.Find(iSndID);
 	if(pTbl==nullptr || pTbl->szFN.empty()) return false;

--- a/Client/WarFare/WarFareMain.cpp
+++ b/Client/WarFare/WarFareMain.cpp
@@ -96,7 +96,9 @@ int APIENTRY WinMain(
 	if(CN3Base::s_Options.iEffectSndDist > 48) CN3Base::s_Options.iEffectSndDist = 48;
 
 	// NOTE: is sound enabled?
-	CN3Base::s_Options.bSndEnable = ini.GetBool("Sound", "Enable", true);
+	CN3Base::s_Options.bSndBgmEnable = ini.GetBool("Sound", "Bgm", true);
+	CN3Base::s_Options.bSndEffectEnable = ini.GetBool("Sound", "Effect", true);
+	CN3Base::s_Options.bSndEnable = (CN3Base::s_Options.bSndBgmEnable || CN3Base::s_Options.bSndEffectEnable);
 
 	// NOTE: is sound duplicated?
 	CN3Base::s_Options.bSndDuplicated = ini.GetBool("Sound", "Duplicate", false);


### PR DESCRIPTION
It's not technically implemented like official, but it's close enough based on our current implementation.

Officially (in 1.298) it's implemented so the setting applies on-demand, technically allowing for it to be changed live. You can't actually change it live though, so effectively it doesn't really matter that we're just preemptively blocking it from loading sounds.

Resolves #490