### PR TITLE
Implement GM 'R' damage overrides

### DIFF
--- a/Server/AIServer/Define.h
+++ b/Server/AIServer/Define.h
@@ -8,6 +8,10 @@
 	1. #define AI_SOCKET_PORT	10020 -> 11020으로 수정됨..
 */
 
+constexpr int USER_DAMAGE_OVERRIDE_GM			= 30'000;
+constexpr int USER_DAMAGE_OVERRIDE_LIMITED_GM	= 0;
+constexpr int USER_DAMAGE_OVERRIDE_TEST_MODE	= 10'000;
+
 //
 //	MAX VALUE DEFINE
 //

--- a/Server/AIServer/User.cpp
+++ b/Server/AIServer/User.cpp
@@ -144,8 +144,12 @@ void CUser::Attack(int sid, int tid)
 	// 명중이면 //Damage 처리 ----------------------------------------------------------------//
 	nFinalDamage = GetDamage(tid);
 
-	if (m_pMain->m_byTestMode)
-		nFinalDamage = 3000;	// sungyong test
+	if (m_byIsOP == AUTHORITY_MANAGER)
+		nFinalDamage = USER_DAMAGE_OVERRIDE_GM;
+	else if (m_byIsOP == AUTHORITY_LIMITED_MANAGER)
+		nFinalDamage = USER_DAMAGE_OVERRIDE_LIMITED_GM;
+	else if (m_pMain->m_byTestMode)
+		nFinalDamage = USER_DAMAGE_OVERRIDE_TEST_MODE;	// sungyong test
 
 	// Calculate Target HP	 -------------------------------------------------------//
 	short sOldNpcHP = pNpc->m_iHP;


### PR DESCRIPTION
GMs - 30,000
Limited GMs - 0 (can't attack)
Test mode (existing) - 10,000

Resolves #492