### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,19 +4,21 @@ root = true
 [*.{c,cpp,cxx,h,hpp,hxx,inl}]
 
 charset = utf-8-bom
-indent_style = tab
 insert_final_newline = true
 
 # Visual C++ Code Style settings
 
-cpp_generate_documentation_comments = doxygen_slash_star_exclamation
+cpp_generate_documentation_comments = doxygen_double_slash_exclamation
 
 # Visual C++ Formatting settings
 
+indent_style = tab
+indent_size = 4
+tab_width = 4
 cpp_indent_braces = false
-cpp_indent_multi_line_relative_to = statement_begin
+cpp_indent_multi_line_relative_to = innermost_parenthesis
 cpp_indent_within_parentheses = indent
-cpp_indent_preserve_within_parentheses = true
+cpp_indent_preserve_within_parentheses = false
 cpp_indent_case_contents = true
 cpp_indent_case_labels = true
 cpp_indent_case_contents_when_block = false
@@ -27,13 +29,13 @@ cpp_indent_access_specifiers = false
 cpp_indent_namespace_contents = true
 cpp_indent_preserve_comments = true
 cpp_new_line_before_open_brace_namespace = ignore
-cpp_new_line_before_open_brace_type = ignore
+cpp_new_line_before_open_brace_type = new_line
 cpp_new_line_before_open_brace_function = new_line
 cpp_new_line_before_open_brace_block = new_line
 cpp_new_line_before_open_brace_lambda = new_line
 cpp_new_line_scope_braces_on_separate_lines = true
-cpp_new_line_close_brace_same_line_empty_type = true
-cpp_new_line_close_brace_same_line_empty_function = true
+cpp_new_line_close_brace_same_line_empty_type = false
+cpp_new_line_close_brace_same_line_empty_function = false
 cpp_new_line_before_catch = true
 cpp_new_line_before_else = true
 cpp_new_line_before_while_in_do_while = true
@@ -64,8 +66,8 @@ cpp_space_remove_around_member_operators = true
 cpp_space_before_inheritance_colon = true
 cpp_space_before_constructor_colon = true
 cpp_space_remove_before_semicolon = true
-cpp_space_after_semicolon = false
-cpp_space_remove_around_unary_operator = false
+cpp_space_after_semicolon = true
+cpp_space_remove_around_unary_operator = true
 cpp_space_around_binary_operator = insert
 cpp_space_around_assignment_operator = insert
 cpp_space_pointer_reference_alignment = left


### PR DESCRIPTION
This fixes a couple of issues with it unintentionally collapsing methods to:
```cpp
methodName
{}
```

And preventing it from properly spacing cases like:
```cpp
for(int i=0;i<10;i++)
{
}
```

Previously it would simply update like:
```cpp
for (int i=0;i<10;i++)
{
}
```

But now it'll fully tidy it up like:
```cpp
for (int i = 0; i < 10; i++)
{
}
```
