### PR TITLE
Ebenezer: Load server index from config

### DIFF
--- a/Server/Ebenezer/EbenezerDlg.cpp
+++ b/Server/Ebenezer/EbenezerDlg.cpp
@@ -230,6 +230,7 @@ CEbenezerDlg::CEbenezerDlg(CWnd* pParent /*=nullptr*/)
 	m_bFirstServerFlag = FALSE;
 	m_bPointCheckFlag = FALSE;
 
+	m_nServerIndex = 0;
 	m_nServerNo = 0;
 	m_nServerGroupNo = 0;
 	m_nServerGroup = 0;
@@ -1486,6 +1487,9 @@ void CEbenezerDlg::LoadConfig()
 		datasourceName, datasourceUser, datasourcePass);
 
 	m_Ini.GetString("AI_SERVER", "IP", "127.0.0.1", m_AIServerIP, _countof(m_AIServerIP));
+
+	// NOTE: officially this is required to be explicitly set, so it defaults to 0 and fails.
+	m_nServerIndex = m_Ini.GetInt("SG_INFO", "SERVER_INDEX", 1);
 
 	m_nCastleCapture = m_Ini.GetInt("CASTLE", "NATION", 1);
 	m_nServerNo = m_Ini.GetInt("ZONE_INFO", "MY_INFO", 1);

--- a/Server/Ebenezer/EbenezerDlg.h
+++ b/Server/Ebenezer/EbenezerDlg.h
@@ -280,6 +280,7 @@ public:
 	// ~패킷 압축에 필요 변수   -------------
 
 	// zone server info
+	int					m_nServerIndex;
 	int					m_nServerNo, m_nServerGroupNo;
 	int					m_nServerGroup;	// server의 번호(0:서버군이 없다, 1:서버1군, 2:서버2군)
 	ServerMap			m_ServerArray;


### PR DESCRIPTION
We default this to 1 for simplicity, even though officially it's defaulted to 0 and fails when not set (i.e. 0).
This is so that it's easy to just load up the official server after running this server once, as this default will be written back to file.