### PR TITLE
N3ME: Fix shutdown behaviour

### DIFF
--- a/N3ME/DTex.cpp
+++ b/N3ME/DTex.cpp
@@ -29,7 +29,8 @@ CDTex::CDTex()
 
 CDTex::~CDTex()
 {
-	Release();
+	delete m_pTex;
+	m_pTex = nullptr;
 }
 
 

--- a/N3ME/DTexGroupMng.cpp
+++ b/N3ME/DTexGroupMng.cpp
@@ -32,7 +32,15 @@ CDTexGroupMng::CDTexGroupMng()
 
 CDTexGroupMng::~CDTexGroupMng()
 {
-	Release();
+	if (m_pGroupView != nullptr)
+	{
+		m_pGroupView->DestroyWindow();
+		delete m_pGroupView;
+		m_pGroupView = nullptr;
+	}
+
+	for (CDTexGroup* pDTG : m_Groups)
+		delete pDTG;
 }
 
 

--- a/N3ME/DTexMng.cpp
+++ b/N3ME/DTexMng.cpp
@@ -32,7 +32,9 @@ CDTexMng::CDTexMng()
 
 CDTexMng::~CDTexMng()
 {
-	Release();
+	for (CDTex* pDTex : m_pDTex)
+		delete pDTex;
+	m_pDTex.clear();
 }
 
 
@@ -41,17 +43,8 @@ CDTexMng::~CDTexMng()
 //
 void CDTexMng::Release()
 {
-	it_DTex it = m_pDTex.begin();
-	while(it!=m_pDTex.end())
-	{
-		CDTex* pTmpDTex = (*it);
-		if(pTmpDTex)
-		{
-			pTmpDTex->Release();
-			delete pTmpDTex;
-		}
-		it = m_pDTex.erase(it);
-	}
+	for (CDTex* pDTex : m_pDTex)
+		delete pDTex;
 	m_pDTex.clear();
 }
 

--- a/N3ME/MainFrm.cpp
+++ b/N3ME/MainFrm.cpp
@@ -290,13 +290,21 @@ void CMainFrame::OnDestroy()
 {
 	CFrameWnd::OnDestroy();
 
-	if (m_pDTexGroupMng){ m_pDTexGroupMng->Release(); delete m_pDTexGroupMng; m_pDTexGroupMng = nullptr;}
-	if (m_pDTexMng){ m_pDTexMng->Release(); delete m_pDTexMng; m_pDTexMng = nullptr;}
-	if (m_pMapMng) { m_pMapMng->Release(); delete m_pMapMng; m_pMapMng = nullptr;}
-	if (m_pEng){ m_pEng->Release(); delete m_pEng; m_pEng = nullptr;}	
-	if (m_pDlgSowSeed){ delete m_pDlgSowSeed; m_pDlgSowSeed = nullptr;}
-}
+	delete m_pDTexGroupMng;
+	m_pDTexGroupMng = nullptr;
 
+	delete m_pDTexMng;
+	m_pDTexMng = nullptr;
+
+	delete m_pMapMng;
+	m_pMapMng = nullptr;
+
+	delete m_pDlgSowSeed;
+	m_pDlgSowSeed = nullptr;
+
+	delete m_pEng;
+	m_pEng = nullptr;
+}
 
 void CMainFrame::OnFileExport() 
 {

--- a/N3ME/MapMng.cpp
+++ b/N3ME/MapMng.cpp
@@ -123,7 +123,6 @@ CMapMng::CMapMng(CMainFrame* pMainFrm)
 // 파괴자
 CMapMng::~CMapMng()
 {
-	Release();
 	if (m_pSceneSource) {delete m_pSceneSource; m_pSceneSource = nullptr;}
 	if (m_pDlgSourceList) {m_pDlgSourceList->DestroyWindow(); delete m_pDlgSourceList; m_pDlgSourceList = nullptr;}
 	if (m_pDlgOutputList) {m_pDlgOutputList->DestroyWindow(); delete m_pDlgOutputList; m_pDlgOutputList = nullptr;}	


### PR DESCRIPTION
Shutdown shouldn't be invoking Release() here, in some cases twice. Release() tends to reset, which can involve UI operations which may not be valid at this point.

We should just explicitly free instead.