### PR TITLE
CN3Chr::RegenerateCollisionMesh(): Remove redundant transformations

### DIFF
--- a/Client/N3Base/N3Chr.cpp
+++ b/Client/N3Base/N3Chr.cpp
@@ -1979,13 +1979,10 @@ void CN3Chr::Init()
 
 void CN3Chr::RegenerateCollisionMesh()
 {
-	__Matrix44 mtxInverse;
-	D3DXMatrixInverse(&mtxInverse, nullptr, &m_Matrix);
-
 	FindMinMax();
 
 	if (m_pMeshCollision != nullptr)
-		m_pMeshCollision->CreateCube(Min() * mtxInverse, Max() * mtxInverse);
+		m_pMeshCollision->CreateCube(m_vMin, m_vMax);
 }
 
 void CN3Chr::JointSet(const std::string& szFN)


### PR DESCRIPTION
CN3Chr::Min() and CN3Chr::Max() apply CN3Chr::m_Matrix, only for us to effectively attempt to remove it via finding its inverse and applying that.
We can just throw those away entirely and use m_vMin and m_vMax directly.

It was probably only like this because it was handled externally and they didn't have access to them directly.