### PR TITLE
Implement more EVT opcodes

### DIFF
--- a/Server/Ebenezer/EbenezerDlg.h
+++ b/Server/Ebenezer/EbenezerDlg.h
@@ -17,6 +17,7 @@
 #include "SharedMem.h"
 #include "Knights.h"
 #include "KnightsManager.h"
+#include "KnightsSiegeWar.h"
 #include "EVENT.h"
 #include "UdpSocket.h"
 
@@ -110,6 +111,7 @@ public:
 	void MarketBBSBuyDelete(short index);
 	void MarketBBSTimeCheck();
 	int  GetKnightsAllMembers(int knightsindex, char* temp_buff, int& buff_index, int type = 0);
+	bool LoadKnightsSiegeWarfareTable();
 	bool LoadAllKnightsUserData();
 	bool LoadAllKnights();
 	bool LoadStartPositionTable();
@@ -225,18 +227,19 @@ public:
 	EventTriggerMap			m_EventTriggerMap;
 
 	CKnightsManager			m_KnightsManager;
+	CKnightsSiegeWar		m_KnightsSiegeWar;
 
-	short	m_sPartyIndex;
-	short	m_sZoneCount;							// AI Server 재접속시 사용
-	short	m_sSocketCount;							// AI Server 재접속시 사용
+	int16_t	m_sPartyIndex;
+	int16_t	m_sZoneCount;							// AI Server 재접속시 사용
+	int16_t	m_sSocketCount;							// AI Server 재접속시 사용
 	// sungyong 2002.05.23
-	short   m_sSendSocket;
+	int16_t	m_sSendSocket;
 	bool 	m_bFirstServerFlag;		// 서버가 처음시작한 후 게임서버가 붙은 경우에는 1, 붙지 않은 경우 0
 	bool 	m_bServerCheckFlag;
 	bool 	m_bPointCheckFlag;		// AI서버와 재접전에 NPC포인터 참조막기 (true:포인터 참조, false:포인터 참조 못함)
-	short   m_sReSocketCount;		// GameServer와 재접시 필요
+	int16_t	m_sReSocketCount;		// GameServer와 재접시 필요
 	float   m_fReConnectStart;	// 처음 소켓이 도착한 시간
-	short   m_sErrorSocketCount;  // 이상소켓 감시용
+	int16_t	m_sErrorSocketCount;  // 이상소켓 감시용
 	// ~sungyong 2002.05.23
 
 	int m_iPacketCount;		// packet check
@@ -247,27 +250,31 @@ public:
 	int m_nCastleCapture;
 
 	// ~Yookozuna 2002.06.12
-	BYTE    m_byBattleOpen, m_byOldBattleOpen;					// 0:전쟁중이 아님, 1:전쟁중(국가간전쟁), 2:눈싸움전쟁
-	BYTE	m_bVictory, m_byOldVictory;
-	BYTE	m_bKarusFlag, m_bElmoradFlag;
-	BYTE    m_byKarusOpenFlag, m_byElmoradOpenFlag, m_byBanishFlag, m_byBattleSave;
-	short   m_sDiscount;	// 능력치와 포인트 초기화 할인 (0:할인없음, 1:할인(50%) )
-	short	m_sKarusDead, m_sElmoradDead, m_sBanishDelay, m_sKarusCount, m_sElmoradCount;
+	uint8_t	m_byBattleOpen, m_byOldBattleOpen;					// 0:전쟁중이 아님, 1:전쟁중(국가간전쟁), 2:눈싸움전쟁
+	uint8_t	m_bVictory, m_byOldVictory;
+	uint8_t	m_bKarusFlag, m_bElmoradFlag;
+	uint8_t	m_byKarusOpenFlag, m_byElmoradOpenFlag, m_byBanishFlag, m_byBattleSave;
+	int16_t	m_sDiscount;	// 능력치와 포인트 초기화 할인 (0:할인없음, 1:할인(50%) )
+	int16_t	m_sKarusDead, m_sElmoradDead, m_sBanishDelay, m_sKarusCount, m_sElmoradCount;
+
+	uint8_t _karusInvasionMonumentLastCapturedNation[INVASION_MONUMENT_COUNT];
+	uint8_t _elmoradInvasionMonumentLastCapturedNation[INVASION_MONUMENT_COUNT];
+
 	int		m_nBattleZoneOpenWeek, m_nBattleZoneOpenHourStart, m_nBattleZoneOpenHourEnd;
 	char	m_strKarusCaptain[MAX_ID_SIZE + 1];
 	char	m_strElmoradCaptain[MAX_ID_SIZE + 1];
 
 	// ~Yookozuna 2002.07.17
-	BYTE	m_bMaxRegenePoint;
+	uint8_t	m_bMaxRegenePoint;
 
 	// ~Yookozuna 2002.09.21 - Today is Chusok :( 
-	short	m_sBuyID[MAX_BBS_POST];
+	int16_t	m_sBuyID[MAX_BBS_POST];
 	char	m_strBuyTitle[MAX_BBS_POST][MAX_BBS_TITLE];
 	char	m_strBuyMessage[MAX_BBS_POST][MAX_BBS_MESSAGE];
 	int		m_iBuyPrice[MAX_BBS_POST];
 	float	m_fBuyStartTime[MAX_BBS_POST];
 
-	short	m_sSellID[MAX_BBS_POST];
+	int16_t	m_sSellID[MAX_BBS_POST];
 	char	m_strSellTitle[MAX_BBS_POST][MAX_BBS_TITLE];
 	char	m_strSellMessage[MAX_BBS_POST][MAX_BBS_MESSAGE];
 	int		m_iSellPrice[MAX_BBS_POST];
@@ -280,6 +287,12 @@ public:
 
 	// ~Yookozuna 2002.12.11 - 갓댐 산타 클로스 --;
 	uint8_t	m_bySanta;
+
+	e_BeefRoastVictory	_beefRoastVictoryType;
+
+	uint8_t				_monsterChallengeActiveType;
+	uint8_t				_monsterChallengeState; // TODO: enum this
+	int16_t				_monsterChallengePlayerCount;
 
 	// 패킷 압축에 필요 변수   -------------only from ai server
 	int					m_CompCount;

--- a/Server/Ebenezer/GameDefine.h
+++ b/Server/Ebenezer/GameDefine.h
@@ -150,6 +150,25 @@ constexpr int ITEM_NO_TRADE		= 900000001;	// 거래 불가 아이템들.... 비�
 
 ////////////////////////////////////////////////////////////
 
+enum e_BeefRoastVictory : uint8_t
+{
+	BEEF_ROAST_VICTORY_START = 0,						// Stage for Bifrost to be be captured by a nation - 30 minutes.
+	BEEF_ROAST_VICTORY_KARUS,							// Karus captured the Bifrost monument and can now solely enter Bifrost - 60 minutes.
+	BEEF_ROAST_VICTORY_ELMORAD,							// El Morad captured the Bifrost monument and can now solely enter Bifrost - 60 minutes.
+	BEEF_ROAST_VICTORY_ALL,								// Both nations are allowed to enter Bifrost - 2 hours.
+	BEEF_ROAST_VICTORY_PENDING_RESTART_AFTER_VICTORY,	// Bifrost is not active - 4 hours
+	BEEF_ROAST_VICTORY_PENDING_RESTART_AFTER_DRAW,		// Bifrost is not active - 2 hours
+};
+
+enum e_InvasionMonumentType
+{
+	INVASION_MONUMENT_BASE	= 0, // Luferson/El Morad
+	INVASION_MONUMENT_ASGA	= 1, // Asga/Bellua
+	INVASION_MONUMENT_RAIBA	= 2, // Raiba/Linate
+	INVASION_MONUMENT_DODA	= 3, // Doda/Laon
+	INVASION_MONUMENT_COUNT
+};
+
 ////////////////////////////////////////////////////////////
 // USER POINT DEFINE
 enum e_StatType

--- a/Server/Ebenezer/KnightsSiegeWar.cpp
+++ b/Server/Ebenezer/KnightsSiegeWar.cpp
@@ -1,0 +1,8 @@
+﻿#include "StdAfx.h"
+#include "KnightsSiegeWar.h"
+
+CKnightsSiegeWar::CKnightsSiegeWar()
+{
+	_castleIndex	= 0;
+	_masterKnights	= 0;
+}

--- a/Server/Ebenezer/KnightsSiegeWar.h
+++ b/Server/Ebenezer/KnightsSiegeWar.h
@@ -1,0 +1,8 @@
+﻿#pragma once
+
+class CKnightsSiegeWar
+{
+public:
+	int16_t			_castleIndex;
+	int16_t			_masterKnights;
+};

--- a/Server/Ebenezer/LOGIC_ELSE.cpp
+++ b/Server/Ebenezer/LOGIC_ELSE.cpp
@@ -146,6 +146,7 @@ void LOGIC_ELSE::Parse_and(const char* line, const std::wstring& filename, int l
 			m_LogicElse = LOGIC_CHECK_PROMOTION_ELIGIBLE;
 			argsToParse = 1; // officially it always parses 1 even though it doesn't use it
 			break;
+#endif
 
 		// A CHECK_MONSTER_CHALLENGE_TIME {Forgotten Temple type}
 		case "CHECK_MONSTER_CHALLENGE_TIME"_djb2:
@@ -153,6 +154,7 @@ void LOGIC_ELSE::Parse_and(const char* line, const std::wstring& filename, int l
 			argsToParse = 1;
 			break;
 
+#if 0 // TODO
 		// A CHECK_PPCARD_SERIAL
 		case "CHECK_PPCARD_SERIAL"_djb2:
 			m_LogicElse = LOGIC_CHECK_PPCARD_SERIAL;
@@ -172,13 +174,11 @@ void LOGIC_ELSE::Parse_and(const char* line, const std::wstring& filename, int l
 			argsToParse = 2;
 			break;
 
-#if 0 // TODO
 		// A CHECK_ITEMCHANGE_NUM {last slot rewarded by exchange - 1..5 [nExchangeItemNum1..5]}
 		case "CHECK_ITEMCHANGE_NUM"_djb2:
 			m_LogicElse = LOGIC_CHECK_ITEMCHANGE_NUM;
 			argsToParse = 1;
 			break;
-#endif
 
 		// A CHECK_NOCLASS {class 1} {class 2} {class 3} {class 4} {class 5} {class 6}
 		case "CHECK_NOCLASS"_djb2:
@@ -216,7 +216,6 @@ void LOGIC_ELSE::Parse_and(const char* line, const std::wstring& filename, int l
 			argsToParse = 1; // officially it always parses 1 even though it doesn't use it
 			break;
 
-#if 0 // TODO
 		// A CHECK_MIDDLE_STATUE_NOCAPTURE
 		case "CHECK_MIDDLE_STATUE_NOCAPTURE"_djb2:
 			m_LogicElse = LOGIC_CHECK_MIDDLE_STATUE_NOCAPTURE;
@@ -228,7 +227,6 @@ void LOGIC_ELSE::Parse_and(const char* line, const std::wstring& filename, int l
 			m_LogicElse = LOGIC_CHECK_MIDDLE_STATUE_CAPTURE;
 			argsToParse = 1; // officially it always parses 1 even though it doesn't use it
 			break;
-#endif
 
 		// A CHECK_EMPTY_SLOT {required number of empty slots}
 		case "CHECK_EMPTY_SLOT"_djb2:
@@ -236,7 +234,6 @@ void LOGIC_ELSE::Parse_and(const char* line, const std::wstring& filename, int l
 			argsToParse = 1;
 			break;
 
-#if 0 // TODO
 		// A CHECK_NO_CASTLE
 		case "CHECK_NO_CASTLE"_djb2:
 			m_LogicElse = LOGIC_CHECK_NO_CASTLE;
@@ -255,6 +252,7 @@ void LOGIC_ELSE::Parse_and(const char* line, const std::wstring& filename, int l
 			argsToParse = 1;
 			break;
 
+#if 0 // TODO
 		// A CHECK_STAT_TOTAL {minimum} {maximum}
 		case "CHECK_STAT_TOTAL"_djb2:
 			m_LogicElse = LOGIC_CHECK_STAT_TOTAL;
@@ -267,6 +265,21 @@ void LOGIC_ELSE::Parse_and(const char* line, const std::wstring& filename, int l
 			argsToParse = 2;
 			break;
 #endif // 0
+
+		// A CHECK_BEEF_ROAST_KARUS_VICTORY
+		case "CHECK_BEEF_ROAST_KARUS_VICTORY"_djb2:
+			argsToParse = 1; // officially it always parses 1 even though it doesn't use it
+			break;
+
+		// A CHECK_BEEF_ROAST_ELMORAD_VICTORY
+		case "CHECK_BEEF_ROAST_ELMORAD_VICTORY"_djb2:
+			argsToParse = 1; // officially it always parses 1 even though it doesn't use it
+			break;
+
+		// A CHECK_BEEF_ROAST_NO_VICTORY
+		case "CHECK_BEEF_ROAST_NO_VICTORY"_djb2:
+			argsToParse = 1; // officially it always parses 1 even though it doesn't use it
+			break;
 
 		default:
 			spdlog::warn("LOGIC_ELSE::Parse_and: unhandled opcode '{}' ({}:{})", temp, WideToUtf8(filename), lineNumber);

--- a/Server/Ebenezer/User.h
+++ b/Server/Ebenezer/User.h
@@ -33,147 +33,147 @@ public:
 
 	char	m_strAccountID[MAX_ID_SIZE + 1];	// Login -> Select Char 까지 한시적으로만 쓰는변수. 이외에는 _USER_DATA 안에있는 변수를 쓴다...agent 와의 데이터 동기화를 위해...
 
-	short	m_RegionX;						// 현재 영역 X 좌표
-	short	m_RegionZ;						// 현재 영역 Z 좌표
+	int16_t	m_RegionX;						// 현재 영역 X 좌표
+	int16_t	m_RegionZ;						// 현재 영역 Z 좌표
 
 	int		m_iMaxExp;						// 다음 레벨이 되기 위해 필요한 Exp량
 	int		m_iMaxWeight;					// 들 수 있는 최대 무게
-	BYTE    m_sSpeed;						// 스피드
+	uint8_t	m_sSpeed;						// 스피드
 
-	short	m_sBodyAc;						// 맨몸 방어력
+	int16_t	m_sBodyAc;						// 맨몸 방어력
 
-	short	m_sTotalHit;					// 총 타격공격력	
-	short	m_sTotalAc;						// 총 방어력
+	int16_t	m_sTotalHit;					// 총 타격공격력	
+	int16_t	m_sTotalAc;						// 총 방어력
 	float	m_fTotalHitRate;				// 총 공격성공 민첩성
 	float	m_fTotalEvasionRate;			// 총 방어 민첩성
 
-	short   m_sItemMaxHp;                   // 아이템 총 최대 HP Bonus
-	short   m_sItemMaxMp;                   // 아이템 총 최대 MP Bonus
+	int16_t   m_sItemMaxHp;                   // 아이템 총 최대 HP Bonus
+	int16_t   m_sItemMaxMp;                   // 아이템 총 최대 MP Bonus
 	int		m_iItemWeight;					// 아이템 총무게
-	short	m_sItemHit;						// 아이템 총타격치
-	short	m_sItemAc;						// 아이템 총방어력
-	short	m_sItemStr;						// 아이템 총힘 보너스
-	short	m_sItemSta;						// 아이템 총체력 보너스
-	short	m_sItemDex;						// 아이템 총민첩성 보너스
-	short	m_sItemIntel;					// 아이템 총지능 보너스
-	short	m_sItemCham;					// 아이템 총매력보너스
-	short	m_sItemHitrate;					// 아이템 총타격율
-	short	m_sItemEvasionrate;				// 아이템 총회피율
+	int16_t	m_sItemHit;						// 아이템 총타격치
+	int16_t	m_sItemAc;						// 아이템 총방어력
+	int16_t	m_sItemStr;						// 아이템 총힘 보너스
+	int16_t	m_sItemSta;						// 아이템 총체력 보너스
+	int16_t	m_sItemDex;						// 아이템 총민첩성 보너스
+	int16_t	m_sItemIntel;					// 아이템 총지능 보너스
+	int16_t	m_sItemCham;					// 아이템 총매력보너스
+	int16_t	m_sItemHitrate;					// 아이템 총타격율
+	int16_t	m_sItemEvasionrate;				// 아이템 총회피율
 
-	BYTE	m_bFireR;						// 불 마법 저항력
-	BYTE	m_bColdR;						// 얼음 마법 저항력
-	BYTE	m_bLightningR;					// 전기 마법 저항력
-	BYTE	m_bMagicR;						// 기타 마법 저항력
-	BYTE	m_bDiseaseR;					// 저주 마법 저항력
-	BYTE	m_bPoisonR;						// 독 마법 저항력
+	uint8_t	m_bFireR;						// 불 마법 저항력
+	uint8_t	m_bColdR;						// 얼음 마법 저항력
+	uint8_t	m_bLightningR;					// 전기 마법 저항력
+	uint8_t	m_bMagicR;						// 기타 마법 저항력
+	uint8_t	m_bDiseaseR;					// 저주 마법 저항력
+	uint8_t	m_bPoisonR;						// 독 마법 저항력
 
-	BYTE    m_bMagicTypeLeftHand;			// The type of magic item in user's left hand  
-	BYTE    m_bMagicTypeRightHand;			// The type of magic item in user's right hand
-	short   m_sMagicAmountLeftHand;         // The amount of magic item in user's left hand
-	short	m_sMagicAmountRightHand;        // The amount of magic item in user's left hand
+	uint8_t	m_bMagicTypeLeftHand;			// The type of magic item in user's left hand  
+	uint8_t	m_bMagicTypeRightHand;			// The type of magic item in user's right hand
+	int16_t	m_sMagicAmountLeftHand;         // The amount of magic item in user's left hand
+	int16_t	m_sMagicAmountRightHand;        // The amount of magic item in user's left hand
 
-	short   m_sDaggerR;						// Resistance to Dagger
-	short   m_sSwordR;						// Resistance to Sword
-	short	m_sAxeR;						// Resistance to Axe
-	short	m_sMaceR;						// Resistance to Mace
-	short	m_sSpearR;						// Resistance to Spear
-	short	m_sBowR;						// Resistance to Bow		
+	int16_t	m_sDaggerR;						// Resistance to Dagger
+	int16_t	m_sSwordR;						// Resistance to Sword
+	int16_t	m_sAxeR;						// Resistance to Axe
+	int16_t	m_sMaceR;						// Resistance to Mace
+	int16_t	m_sSpearR;						// Resistance to Spear
+	int16_t	m_sBowR;						// Resistance to Bow		
 
-	short	m_iMaxHp;
-	short	m_iMaxMp;
+	int16_t	m_iMaxHp;
+	int16_t	m_iMaxMp;
 
-	short	m_iZoneIndex;
+	int16_t	m_iZoneIndex;
 
 	float	m_fWill_x;
 	float	m_fWill_z;
 	float	m_fWill_y;
 
-	BYTE	m_bResHpType;					// HP 회복타입
-	BYTE	m_bWarp;						// 존이동중...
-	BYTE	m_bNeedParty;					// 파티....구해요
+	uint8_t	m_bResHpType;					// HP 회복타입
+	uint8_t	m_bWarp;						// 존이동중...
+	uint8_t	m_bNeedParty;					// 파티....구해요
 
-	short	m_sPartyIndex;
-	short	m_sExchangeUser;				// 교환중인 유저
-	BYTE	m_bExchangeOK;
+	int16_t	m_sPartyIndex;
+	int16_t	m_sExchangeUser;				// 교환중인 유저
+	uint8_t	m_bExchangeOK;
 
 	ItemList	m_ExchangeItemList;
 	_ITEM_DATA	m_MirrorItem[HAVE_MAX];			// 교환시 백업 아이템 리스트를 쓴다.
 
-	short	m_sPrivateChatUser;
+	int16_t	m_sPrivateChatUser;
 
 	float	m_fHPLastTimeNormal;					// For Automatic HP recovery. 
 	float	m_fHPStartTimeNormal;
-	short	m_bHPAmountNormal;
-	BYTE	m_bHPDurationNormal;
-	BYTE	m_bHPIntervalNormal;
+	int16_t	m_bHPAmountNormal;
+	uint8_t	m_bHPDurationNormal;
+	uint8_t	m_bHPIntervalNormal;
 
 	float	m_fHPLastTime[MAX_TYPE3_REPEAT];		// For Automatic HP recovery and Type 3 durational HP recovery.
 	float	m_fHPStartTime[MAX_TYPE3_REPEAT];
-	short	m_bHPAmount[MAX_TYPE3_REPEAT];
-	BYTE	m_bHPDuration[MAX_TYPE3_REPEAT];
-	BYTE	m_bHPInterval[MAX_TYPE3_REPEAT];
-	short	m_sSourceID[MAX_TYPE3_REPEAT];
+	int16_t	m_bHPAmount[MAX_TYPE3_REPEAT];
+	uint8_t	m_bHPDuration[MAX_TYPE3_REPEAT];
+	uint8_t	m_bHPInterval[MAX_TYPE3_REPEAT];
+	int16_t	m_sSourceID[MAX_TYPE3_REPEAT];
 	bool	m_bType3Flag;
 
 	float	m_fAreaLastTime;			// For Area Damage spells Type 3.
-	float   m_fAreaStartTime;
-	BYTE    m_bAreaInterval;
-	int     m_iAreaMagicID;
+	float	m_fAreaStartTime;
+	uint8_t	m_bAreaInterval;
+	int		m_iAreaMagicID;
 
-	BYTE	m_bAttackSpeedAmount;		// For Character stats in Type 4 Durational Spells.
-	BYTE    m_bSpeedAmount;
-	short   m_sACAmount;
-	BYTE    m_bAttackAmount;
-	short	m_sMaxHPAmount;
-	BYTE	m_bHitRateAmount;
-	short	m_sAvoidRateAmount;
-	short	m_sStrAmount;
-	short	m_sStaAmount;
-	short	m_sDexAmount;
-	short	m_sIntelAmount;
-	short	m_sChaAmount;
-	BYTE	m_bFireRAmount;
-	BYTE	m_bColdRAmount;
-	BYTE	m_bLightningRAmount;
-	BYTE	m_bMagicRAmount;
-	BYTE	m_bDiseaseRAmount;
-	BYTE	m_bPoisonRAmount;
+	uint8_t	m_bAttackSpeedAmount;		// For Character stats in Type 4 Durational Spells.
+	uint8_t	m_bSpeedAmount;
+	int16_t	m_sACAmount;
+	uint8_t	m_bAttackAmount;
+	int16_t	m_sMaxHPAmount;
+	uint8_t	m_bHitRateAmount;
+	int16_t	m_sAvoidRateAmount;
+	int16_t	m_sStrAmount;
+	int16_t	m_sStaAmount;
+	int16_t	m_sDexAmount;
+	int16_t	m_sIntelAmount;
+	int16_t	m_sChaAmount;
+	uint8_t	m_bFireRAmount;
+	uint8_t	m_bColdRAmount;
+	uint8_t	m_bLightningRAmount;
+	uint8_t	m_bMagicRAmount;
+	uint8_t	m_bDiseaseRAmount;
+	uint8_t	m_bPoisonRAmount;
 
-	short   m_sDuration1;  float   m_fStartTime1;
-	short   m_sDuration2;  float   m_fStartTime2;
-	short   m_sDuration3;  float   m_fStartTime3;
-	short   m_sDuration4;  float   m_fStartTime4;
-	short   m_sDuration5;  float   m_fStartTime5;
-	short   m_sDuration6;  float   m_fStartTime6;
-	short   m_sDuration7;  float   m_fStartTime7;
-	short   m_sDuration8;  float   m_fStartTime8;
-	short   m_sDuration9;  float   m_fStartTime9;
+	int16_t	m_sDuration1;  float   m_fStartTime1;
+	int16_t	m_sDuration2;  float   m_fStartTime2;
+	int16_t	m_sDuration3;  float   m_fStartTime3;
+	int16_t	m_sDuration4;  float   m_fStartTime4;
+	int16_t	m_sDuration5;  float   m_fStartTime5;
+	int16_t	m_sDuration6;  float   m_fStartTime6;
+	int16_t	m_sDuration7;  float   m_fStartTime7;
+	int16_t	m_sDuration8;  float   m_fStartTime8;
+	int16_t	m_sDuration9;  float   m_fStartTime9;
 
-	BYTE	m_bType4Buff[MAX_TYPE4_BUFF];
+	uint8_t	m_bType4Buff[MAX_TYPE4_BUFF];
 	bool	m_bType4Flag;
 
 	CEbenezerDlg* m_pMain;
 	CMagicProcess m_MagicProcess;
 
 	float	m_fSpeedHackClientTime, m_fSpeedHackServerTime;
-	BYTE	m_bSpeedHackCheck;
+	uint8_t	m_bSpeedHackCheck;
 
-	short	m_sFriendUser;				// who are you trying to make friends with?
+	int16_t	m_sFriendUser;				// who are you trying to make friends with?
 
 	float	m_fBlinkStartTime;			// When did you start to blink?
 
-	short	m_sAliveCount;
+	int16_t	m_sAliveCount;
 
-	BYTE	m_bAbnormalType;			// Is the player normal,a giant, or a dwarf?
+	uint8_t	m_bAbnormalType;			// Is the player normal,a giant, or a dwarf?
 
-	short	m_sWhoKilledMe;				// Who killed me???
+	int16_t	m_sWhoKilledMe;				// Who killed me???
 	int		m_iLostExp;					// Experience point that was lost when you died.
 
 	float	m_fLastTrapAreaTime;		// The last moment you were in the trap area.
 
 	bool	m_bZoneChangeFlag;			// 성용씨 미워!!
 
-	BYTE	m_bRegeneType;				// Did you die and go home or did you type '/town'?
+	uint8_t	m_bRegeneType;				// Did you die and go home or did you type '/town'?
 
 	float	m_fLastRegeneTime;			// The last moment you got resurrected.
 
@@ -182,22 +182,27 @@ public:
 	// 이밴트용 관련.... 정애씨 이거 보면 코카스 쏠께요 ^^;
 //	int					m_iSelMsgEvent[5];	// 실행중인 선택 메세지박스 이벤트
 	int					m_iSelMsgEvent[MAX_MESSAGE_EVENT];	// 실행중인 선택 메세지박스 이벤트
-	short				m_sEventNid;		// 마지막으로 선택한 이벤트 NPC 번호
+	int16_t				m_sEventNid;		// 마지막으로 선택한 이벤트 NPC 번호
 	UserEventList		m_arUserEvent;		// 실행한 이벤트 리스트
 
 	char	m_strCouponId[MAX_COUPON_ID_LENGTH];		// What was the number of the coupon?
 	int		m_iEditBoxEvent;
 
-	short	m_sEvent[MAX_CURRENT_EVENT];				// 이미 실행된 이밴트 리스트들 :)
+	int16_t	m_sEvent[MAX_CURRENT_EVENT];				// 이미 실행된 이밴트 리스트들 :)
 
 	bool				m_bIsPartyLeader;
-	BYTE				m_byInvisibilityState;
-	short				m_sDirection;
+	uint8_t				m_byInvisibilityState;
+	int16_t				m_sDirection;
 	bool				m_bIsChicken;
-	BYTE				m_byKnightsRank;
-	BYTE				m_byPersonalRank;
+	uint8_t				m_byKnightsRank;
+	uint8_t				m_byPersonalRank;
+
+	// Selected exchange slot for last exchange (1~5).
+	// Applicable only to exchange type 101.
+	uint8_t				m_byLastExchangeNum;
 
 public:
+	bool CheckMiddleStatueCapture() const;
 	void SetZoneAbilityChange(int zone);
 	int16_t GetMaxWeightForClient() const;
 	int16_t GetCurrentWeightForClient() const;


### PR DESCRIPTION
We implement  (exposing unused server members for them):
 * CHECK_MONSTER_CHALLENGE_TIME
 * CHECK_ITEMCHANGE_NUM
 * CHECK_MIDDLE_STATUE_NOCAPTURE
 * CHECK_MIDDLE_STATUE_CAPTURE
 * CHECK_NO_CASTLE (loading KNIGHTS_SIEGE_WARFARE for this info)
 * CHECK_CASTLE (loading KNIGHTS_SIEGE_WARFARE for this info)
 * CHECK_MONSTER_CHALLENGE_USERCOUNT
 * CHECK_BEEF_ROAST_KARUS_VICTORY
 * CHECK_BEEF_ROAST_ELMORAD_VICTORY
 * CHECK_BEEF_ROAST_NO_VICTORY

Refs #260
